### PR TITLE
CanvasRenderingContext2D surface creation checks

### DIFF
--- a/deps/exokit-bindings/canvascontext/include/canvas-context.h
+++ b/deps/exokit-bindings/canvascontext/include/canvas-context.h
@@ -75,7 +75,7 @@ public:
   void ClearRect(float x, float y, float w, float h);
   void FillText(const std::string &text, float x, float y);
   void StrokeText(const std::string &text, float x, float y);
-  void Resize(unsigned int w, unsigned int h);
+  bool Resize(unsigned int w, unsigned int h);
   void DrawImage(const SkImage *image, float sx, float sy, float sw, float sh, float dx, float dy, float dw, float dh, bool flipY);
   void Save();
   void Restore();


### PR DESCRIPTION
```
/home/sketchstick/apps/exokit/node_modules/fault-zone/build/Release/segfault-handler.node(+0x2b4a) [0x7f6d1c55bb4a]
/usr/lib/libpthread.so.0(+0x11a80) [0x7f6d21cc5a80]
/home/sketchstick/apps/exokit/build/Release/exokit.node(_ZN24CanvasRenderingContext2D8GetWidthEv+0x4) [0x7f6d0ede5a24]
/home/sketchstick/apps/exokit/build/Release/exokit.node(_ZN24CanvasRenderingContext2D10DataGetterEN2v85LocalINS0_6StringEEERKN3Nan20PropertyCallbackInfoINS0_5ValueEEE+0x108) [0x7f6d0ede5e68]
/home/sketchstick/apps/exokit/build/Release/exokit.node(+0x28704e) [0x7f6d0ede304e]
node(_ZN2v88internal25PropertyCallbackArguments28BasicCallNamedGetterCallbackEPFvNS_5LocalINS_4NameEEERKNS_20PropertyCallbackInfoINS_5ValueEEEENS0_6HandleINS0_4NameEEENSC_INS0_6ObjectEEE+0x90) [0x55b7c41c3310]
node(_ZN2v88internal6Object23GetPropertyWithAccessorEPNS0_14LookupIteratorE+0x25d) [0x55b7c41f505d]
node(+0xac1bf8) [0x55b7c41f0bf8]
node(_ZN2v88internal6LoadIC4LoadENS0_6HandleINS0_6ObjectEEENS2_INS0_4NameEEE+0x28f) [0x55b7c41482ff]
node(_ZN2v88internal19Runtime_LoadIC_MissEiPPNS0_6ObjectEPNS0_7IsolateE+0x228) [0x55b7c41499d8]
[0x133e323841bd]
```

From this stack trace we can see that it seems the canvas 2d context surface might have failed to create. This PR throws in that case to JS, for easier debugging.

This was on loading a-painter on Linux, almost immediately on startup.