### PR TITLE
Add ML launcher icon

### DIFF
--- a/metadata/manifest-device.xml
+++ b/metadata/manifest-device.xml
@@ -1,11 +1,11 @@
 <manifest
-	xmlns:ml="magicleap"
-	ml:package="com.webmr.exokit"
-	ml:version_code="1"
-	ml:version_name="1.0">
-	<application
-		ml:visible_name="Exokit"
-		ml:sdk_version="1.0">
+  xmlns:ml="magicleap"
+  ml:package="com.webmr.exokit"
+  ml:version_code="1"
+  ml:version_name="1.0">
+  <application
+    ml:visible_name="Exokit"
+    ml:sdk_version="1.0">
       <uses-privilege ml:name="LowLatencyLightwear" />
       <uses-privilege ml:name="Internet" />
       <uses-privilege ml:name="LocalAreaNetwork" />
@@ -23,14 +23,14 @@
       <uses-privilege ml:name="AudioRecognizer" />
       <uses-privilege ml:name="PwFoundObjRead" />
       <uses-privilege ml:name="NormalNotificationsUsage" />
-		<component
-			ml:name=".fullscreen"
-			ml:visible_name="Exokit"
-			ml:binary_name="bin/program-device"
+    <component
+      ml:name=".fullscreen"
+      ml:visible_name="Exokit"
+      ml:binary_name="bin/program-device"
       ml:type="Fullscreen">
       <icon
         ml:model_folder="assets/magicleap/model/"
         ml:portal_folder="assets/magicleap/portal/" />
-		</component>
-	</application>
+    </component>
+  </application>
 </manifest>


### PR DESCRIPTION
This adds the ML icon placeholder to `manifest-device.xml`, making Exokit launchable from the app menu instead of just `mldb`.