### PR TITLE
Magic leap direct blit to headset

### DIFF
--- a/deps/exokit-bindings/egl/src/egl.cc
+++ b/deps/exokit-bindings/egl/src/egl.cc
@@ -70,21 +70,21 @@ NAN_METHOD(BlitFrameBuffer) {
 
 NAN_METHOD(BlitFrameBufferArray) {
   Local<Object> glObj = Local<Object>::Cast(info[0]);
-  GLuint fbo1 = info[1]->Uint32Value();
-  GLuint tex = info[2]->Uint32Value();
+  GLuint srcFbo = info[1]->Uint32Value();
+  GLuint dstTex = info[2]->Uint32Value();
   int width = info[3]->Int32Value();
   int height = info[4]->Int32Value();
   bool color = info[5]->BooleanValue();
   bool depth = info[6]->BooleanValue();
   bool stencil = info[7]->BooleanValue();
 
-  GLuint fbo2;
-  glGenFramebuffers(1, &fbo2);
+  GLuint dstFbo;
+  glGenFramebuffers(1, &dstFbo);
 
-  glBindFramebuffer(GL_READ_FRAMEBUFFER, fbo1);
-  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fbo2);
+  glBindFramebuffer(GL_READ_FRAMEBUFFER, srcFbo);
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, dstFbo);
   for (int i = 0; i < 2; i++) {
-    glFramebufferTextureLayer(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, tex, 0, i);
+    glFramebufferTextureLayer(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, dstTex, 0, i);
     // glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, depth, 0, i);
 
     glBlitFramebuffer(
@@ -99,7 +99,7 @@ NAN_METHOD(BlitFrameBufferArray) {
     );
   }
   
-  glDeleteFramebuffers(1, &fbo2);
+  glDeleteFramebuffers(1, &dstFbo);
 
   WebGLRenderingContext *gl = ObjectWrap::Unwrap<WebGLRenderingContext>(glObj);
   if (gl->HasFramebufferBinding(GL_READ_FRAMEBUFFER)) {

--- a/deps/exokit-bindings/egl/src/egl.cc
+++ b/deps/exokit-bindings/egl/src/egl.cc
@@ -35,10 +35,10 @@ NAN_METHOD(BlitFrameBuffer) {
   Local<Object> glObj = Local<Object>::Cast(info[0]);
   GLuint fbo1 = info[1]->Uint32Value();
   GLuint fbo2 = info[2]->Uint32Value();
-  int sw = info[3]->Uint32Value();
-  int sh = info[4]->Uint32Value();
-  int dw = info[5]->Uint32Value();
-  int dh = info[6]->Uint32Value();
+  int sw = info[3]->Int32Value();
+  int sh = info[4]->Int32Value();
+  int dw = info[5]->Int32Value();
+  int dh = info[6]->Int32Value();
   bool color = info[7]->BooleanValue();
   bool depth = info[8]->BooleanValue();
   bool stencil = info[9]->BooleanValue();

--- a/deps/exokit-bindings/glfw/src/glfw.cc
+++ b/deps/exokit-bindings/glfw/src/glfw.cc
@@ -843,10 +843,10 @@ NAN_METHOD(BlitFrameBuffer) {
   Local<Object> glObj = Local<Object>::Cast(info[0]);
   GLuint fbo1 = info[1]->Uint32Value();
   GLuint fbo2 = info[2]->Uint32Value();
-  int sw = info[3]->Uint32Value();
-  int sh = info[4]->Uint32Value();
-  int dw = info[5]->Uint32Value();
-  int dh = info[6]->Uint32Value();
+  int sw = info[3]->Int32Value();
+  int sh = info[4]->Int32Value();
+  int dw = info[5]->Int32Value();
+  int dh = info[6]->Int32Value();
   bool color = info[7]->BooleanValue();
   bool depth = info[8]->BooleanValue();
   bool stencil = info[9]->BooleanValue();

--- a/deps/exokit-bindings/magicleap/include/magicleap.h
+++ b/deps/exokit-bindings/magicleap/include/magicleap.h
@@ -229,6 +229,7 @@ public:
   static NAN_METHOD(RequestDepthPopulation);
   static NAN_METHOD(RequestCamera);
   static NAN_METHOD(CancelCamera);
+  static NAN_METHOD(IsCameraRunning);
   static NAN_METHOD(PrePollEvents);
   static NAN_METHOD(PostPollEvents);
 

--- a/deps/exokit-bindings/magicleap/include/magicleap.h
+++ b/deps/exokit-bindings/magicleap/include/magicleap.h
@@ -239,7 +239,6 @@ public:
 
   // tracking
   MLHandle graphics_client;
-  GLuint framebuffer_id;
   MLHandle frame_handle;
   MLHandle head_tracker;
   MLHeadTrackingStaticData head_static_data;

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -2003,7 +2003,7 @@ NAN_METHOD(MLContext::Exit) {
 }
 
 NAN_METHOD(MLContext::WaitGetPoses) {
-  if (info[0]->IsObject() && info[1]->IsNumber() && info[2]->IsNumber() && info[3]->IsNumber() && info[4]->IsFloat32Array() && info[5]->IsFloat32Array() && info[6]->IsFloat32Array()) {
+  if (info[0]->IsObject() && info[1]->IsNumber() && info[2]->IsNumber() && info[3]->IsNumber() && info[4]->IsFloat32Array() && info[5]->IsFloat32Array() && info[6]->IsFloat32Array() && info[7]->IsUint32Array()) {
     if (application_context.dummy_value == DummyValue::RUNNING) {
       MLContext *mlContext = ObjectWrap::Unwrap<MLContext>(info.This());
       WebGLRenderingContext *gl = ObjectWrap::Unwrap<WebGLRenderingContext>(Local<Object>::Cast(info[0]));
@@ -2014,6 +2014,7 @@ NAN_METHOD(MLContext::WaitGetPoses) {
       Local<Float32Array> transformArray = Local<Float32Array>::Cast(info[4]);
       Local<Float32Array> projectionArray = Local<Float32Array>::Cast(info[5]);
       Local<Float32Array> controllersArray = Local<Float32Array>::Cast(info[6]);
+      Local<Uint32Array> graphicsBuffersArray = Local<Uint32Array>::Cast(info[7]);
 
       MLGraphicsFrameParams frame_params;
       MLResult result = MLGraphicsInitFrameParams(&frame_params);
@@ -2086,7 +2087,12 @@ NAN_METHOD(MLContext::WaitGetPoses) {
         } else {
           ML_LOG(Error, "MLInputGetControllerState failed: %s", application_name);
         }
+        
+        // graphics
+        graphicsBuffersArray->Set(0, JS_INT((unsigned int)mlContext->virtual_camera_array.color_id));
+        graphicsBuffersArray->Set(1, JS_INT((unsigned int)mlContext->virtual_camera_array.depth_id));
 
+        // draw helpers
         if (depthEnabled) {
           glBindFramebuffer(GL_DRAW_FRAMEBUFFER, framebuffer);
 

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -2179,18 +2179,18 @@ NAN_METHOD(MLContext::WaitGetPoses) {
 NAN_METHOD(MLContext::SubmitFrame) {
   MLContext *mlContext = ObjectWrap::Unwrap<MLContext>(info.This());
 
-  if (info[0]->IsObject() && info[1]->IsNumber() && info[2]->IsNumber() && info[3]->IsNumber()) {
-    WebGLRenderingContext *gl = ObjectWrap::Unwrap<WebGLRenderingContext>(Local<Object>::Cast(info[0]));
+  // if (info[0]->IsObject() && info[1]->IsNumber() && info[2]->IsNumber() && info[3]->IsNumber()) {
+    /* WebGLRenderingContext *gl = ObjectWrap::Unwrap<WebGLRenderingContext>(Local<Object>::Cast(info[0]));
     GLuint src_framebuffer_id = info[1]->Uint32Value();
     unsigned int width = info[2]->Uint32Value();
     unsigned int height = info[3]->Uint32Value();
 
-    const MLRectf &viewport = mlContext->virtual_camera_array.viewport;
+    const MLRectf &viewport = mlContext->virtual_camera_array.viewport; */
 
     for (int i = 0; i < 2; i++) {
       MLGraphicsVirtualCameraInfo &camera = mlContext->virtual_camera_array.virtual_cameras[i];
       
-      glBindFramebuffer(GL_READ_FRAMEBUFFER, src_framebuffer_id);
+      /* glBindFramebuffer(GL_READ_FRAMEBUFFER, src_framebuffer_id);
 
       glBindFramebuffer(GL_DRAW_FRAMEBUFFER, mlContext->framebuffer_id);
       glFramebufferTextureLayer(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, mlContext->virtual_camera_array.color_id, 0, i);
@@ -2201,7 +2201,7 @@ NAN_METHOD(MLContext::SubmitFrame) {
         viewport.x, viewport.y,
         viewport.w, viewport.h,
         GL_COLOR_BUFFER_BIT,
-        GL_LINEAR);
+        GL_LINEAR); */
 
       MLResult result = MLGraphicsSignalSyncObjectGL(mlContext->graphics_client, camera.sync_object);
       if (result != MLResult_Ok) {
@@ -2214,7 +2214,7 @@ NAN_METHOD(MLContext::SubmitFrame) {
       ML_LOG(Error, "MLGraphicsEndFrame complained: %d", result);
     }
     
-    if (gl->HasFramebufferBinding(GL_READ_FRAMEBUFFER)) {
+    /* if (gl->HasFramebufferBinding(GL_READ_FRAMEBUFFER)) {
       glBindFramebuffer(GL_READ_FRAMEBUFFER, gl->GetFramebufferBinding(GL_READ_FRAMEBUFFER));
     } else {
       glBindFramebuffer(GL_READ_FRAMEBUFFER, gl->defaultFramebuffer);
@@ -2223,10 +2223,10 @@ NAN_METHOD(MLContext::SubmitFrame) {
       glBindFramebuffer(GL_DRAW_FRAMEBUFFER, gl->GetFramebufferBinding(GL_DRAW_FRAMEBUFFER));
     } else {
       glBindFramebuffer(GL_DRAW_FRAMEBUFFER, gl->defaultFramebuffer);
-    }
-  } else {
+    } */
+  /* } else {
     Nan::ThrowError("MLContext::SubmitFrame: invalid arguments");
-  }
+  } */
 }
 
 NAN_METHOD(MLContext::IsPresent) {

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -1934,9 +1934,7 @@ NAN_METHOD(MLContext::Present) {
   application_context.dummy_value = DummyValue::RUNNING;
 
   ML_LOG(Info, "%s: Start loop.", application_name);
-
-  glGenFramebuffers(1, &mlContext->framebuffer_id);
-
+  
   Local<Object> result = Nan::New<Object>();
   result->Set(JS_STR("width"), JS_INT(halfWidth));
   result->Set(JS_STR("height"), JS_INT(height));
@@ -2002,8 +2000,6 @@ NAN_METHOD(MLContext::Exit) {
 
   // HACK: force the app to be "stopped"
   application_context.dummy_value = DummyValue::STOPPED;
-
-  glDeleteFramebuffers(1, &mlContext->framebuffer_id);
 }
 
 NAN_METHOD(MLContext::WaitGetPoses) {

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -2278,14 +2278,14 @@ NAN_METHOD(MLContext::RequestDepthPopulation) {
   }
 }
 
-bool cameraConnected = false;
+bool cameraRunning = false;
 NAN_METHOD(MLContext::RequestCamera) {
   if (info[0]->IsFunction()) {
-    if (!cameraConnected) {
+    if (!cameraRunning) {
       MLResult result = MLCameraConnect();
 
       if (result == MLResult_Ok) {
-        cameraConnected = true;
+        cameraRunning = true;
 
         std::thread([]() -> void {
           for (;;) {

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -1185,6 +1185,7 @@ Handle<Object> MLContext::Initialize(Isolate *isolate) {
   Nan::SetMethod(ctorFn, "RequestEyeTracking", RequestEyeTracking);
   Nan::SetMethod(ctorFn, "RequestCamera", RequestCamera);
   Nan::SetMethod(ctorFn, "CancelCamera", CancelCamera);
+  Nan::SetMethod(ctorFn, "IsCameraRunning", IsCameraRunning);
   Nan::SetMethod(ctorFn, "PrePollEvents", PrePollEvents);
   Nan::SetMethod(ctorFn, "PostPollEvents", PostPollEvents);
 
@@ -2336,6 +2337,10 @@ NAN_METHOD(MLContext::CancelCamera) {
   } else {
     Nan::ThrowError("invalid arguments");
   }
+}
+
+NAN_METHOD(MLContext::IsCameraRunning) {
+  info.GetReturnValue().Set(JS_BOOL(cameraRunning));
 }
 
 void setFingerValue(const MLWristState &wristState, MLSnapshot *snapshot, float data[4][1 + 3]);

--- a/deps/exokit-bindings/windowsystem/include/windowsystem.h
+++ b/deps/exokit-bindings/windowsystem/include/windowsystem.h
@@ -50,7 +50,6 @@ bool CreateRenderTarget(WebGLRenderingContext *gl, int width, int height, GLuint
 NAN_METHOD(CreateRenderTarget);
 NAN_METHOD(ResizeRenderTarget);
 NAN_METHOD(DestroyRenderTarget);
-void ComposeLayers(WebGLRenderingContext *gl, const std::vector<LayerSpec> &layers);
 NAN_METHOD(ComposeLayers);
 void Decorate(Local<Object> target);
 

--- a/deps/exokit-bindings/windowsystem/src/windowsystem.cc
+++ b/deps/exokit-bindings/windowsystem/src/windowsystem.cc
@@ -483,7 +483,7 @@ void ComposeLayersArray(WebGLRenderingContext *gl, GLuint tex, const std::vector
 
       glUniform4f(
         composeSpec->texSizeLocation,
-        i == 0 ? 0 : layer.width/2, 0,
+        j == 0 ? 0 : layer.width/2, 0,
         layer.width/2, layer.height
       );
 

--- a/src/index.js
+++ b/src/index.js
@@ -1073,6 +1073,13 @@ const _bindWindow = (window, newWindowCb) => {
             } else {
               nativeWindow.blitFrameBufferArray(context, mlPresentState.mlMsFbo, mlPresentState.mlHwColorTex, mlPresentState.mlGlContext.canvas.width, mlPresentState.mlGlContext.canvas.height, true, false, false);
             }
+            // if camera is running, compose to camera content composition framebuffer
+            if (nativeMl.IsCameraRunning()) {
+              if (mlPresentState.layers.length > 0) {
+                nativeWindow.composeLayers(context, mlPresentState.mlFbo, mlPresentState.layers);
+              } else {
+                nativeWindow.blitFrameBuffer(context, mlPresentState.mlMsFbo, mlPresentState.mlFbo, mlPresentState.mlGlContext.canvas.width, mlPresentState.mlGlContext.canvas.height, mlPresentState.mlGlContext.canvas.width, mlPresentState.mlGlContext.canvas.height, true, false, false);
+              }
             }
 
             mlPresentState.mlContext.SubmitFrame();

--- a/src/index.js
+++ b/src/index.js
@@ -1067,10 +1067,12 @@ const _bindWindow = (window, newWindowCb) => {
 
             nativeWindow.blitFrameBuffer(context, vrPresentState.fbo, 0, vrPresentState.glContext.canvas.width * (args.blit ? 0.5 : 1), vrPresentState.glContext.canvas.height, window.innerWidth, window.innerHeight, true, false, false);
           } else if (mlPresentState.mlGlContext === context && mlPresentState.mlHasPose) {
-            if (mlPresentState.layers.length > 0) { // TODO: composition can be directly to the output texture array
-              nativeWindow.composeLayersArray(context, mlPresentState.mlTex, mlPresentState.layers);
+            // compose to hardware framebuffer
+            if (mlPresentState.layers.length > 0) {
+              nativeWindow.composeLayersArray(context, mlPresentState.mlHwColorTex, mlPresentState.layers);
             } else {
-              nativeWindow.blitFrameBufferArray(context, mlPresentState.mlMsFbo, mlPresentState.mlTex, mlPresentState.mlGlContext.canvas.width, mlPresentState.mlGlContext.canvas.height, true, false, false);
+              nativeWindow.blitFrameBufferArray(context, mlPresentState.mlMsFbo, mlPresentState.mlHwColorTex, mlPresentState.mlGlContext.canvas.width, mlPresentState.mlGlContext.canvas.height, true, false, false);
+            }
             }
 
             mlPresentState.mlContext.SubmitFrame();

--- a/src/index.js
+++ b/src/index.js
@@ -1075,8 +1075,6 @@ const _bindWindow = (window, newWindowCb) => {
 
             mlPresentState.mlContext.SubmitFrame();
             mlPresentState.mlHasPose = false;
-
-            // nativeWindow.blitFrameBuffer(context, mlPresentState.mlFbo, 0, mlPresentState.mlGlContext.canvas.width, mlPresentState.mlGlContext.canvas.height, window.innerWidth, window.innerHeight, true, false, false);
           } else if (fakePresentState.layers.length > 0) {
             nativeWindow.composeLayers(context, 0, fakePresentState.layers);
           }

--- a/src/index.js
+++ b/src/index.js
@@ -1055,9 +1055,9 @@ const _bindWindow = (window, newWindowCb) => {
             nativeWindow.blitFrameBuffer(context, vrPresentState.fbo, 0, vrPresentState.glContext.canvas.width * (args.blit ? 0.5 : 1), vrPresentState.glContext.canvas.height, window.innerWidth, window.innerHeight, true, false, false);
           } else if (mlPresentState.mlGlContext === context && mlPresentState.mlHasPose) {
             if (mlPresentState.layers.length > 0) { // TODO: composition can be directly to the output texture array
-              nativeWindow.composeLayers(context, mlPresentState.mlFbo, mlPresentState.layers);
+              nativeWindow.composeLayersArray(context, mlPresentState.mlFbo, mlPresentState.layers);
             } else {
-              nativeWindow.blitFrameBuffer(context, mlPresentState.mlMsFbo, mlPresentState.mlFbo, mlPresentState.mlGlContext.canvas.width, mlPresentState.mlGlContext.canvas.height, mlPresentState.mlGlContext.canvas.width, mlPresentState.mlGlContext.canvas.height, true, false, false);
+              nativeWindow.blitFrameBufferArray(context, mlPresentState.mlMsFbo, mlPresentState.mlFbo, mlPresentState.mlGlContext.canvas.width, mlPresentState.mlGlContext.canvas.height, mlPresentState.mlGlContext.canvas.width, mlPresentState.mlGlContext.canvas.height, true, false, false);
             }
 
             mlPresentState.mlContext.SubmitFrame(context, mlPresentState.mlFbo, mlPresentState.mlGlContext.canvas.width, mlPresentState.mlGlContext.canvas.height);

--- a/src/index.js
+++ b/src/index.js
@@ -1060,7 +1060,7 @@ const _bindWindow = (window, newWindowCb) => {
               nativeWindow.blitFrameBufferArray(context, mlPresentState.mlMsFbo, mlPresentState.mlFbo, mlPresentState.mlGlContext.canvas.width, mlPresentState.mlGlContext.canvas.height, mlPresentState.mlGlContext.canvas.width, mlPresentState.mlGlContext.canvas.height, true, false, false);
             }
 
-            mlPresentState.mlContext.SubmitFrame(context, mlPresentState.mlFbo, mlPresentState.mlGlContext.canvas.width, mlPresentState.mlGlContext.canvas.height);
+            mlPresentState.mlContext.SubmitFrame();
             mlPresentState.mlHasPose = false;
 
             // nativeWindow.blitFrameBuffer(context, mlPresentState.mlFbo, 0, mlPresentState.mlGlContext.canvas.width, mlPresentState.mlGlContext.canvas.height, window.innerWidth, window.innerHeight, true, false, false);

--- a/src/index.js
+++ b/src/index.js
@@ -329,6 +329,7 @@ const handsArray = [
   new Float32Array(handEntrySize),
 ];
 const controllersArray = new Float32Array((3 + 4 + 6) * 2);
+const graphicsBuffersArray = new Uint32Array(2);
 
 const localVector = new THREE.Vector3();
 const localVector2 = new THREE.Vector3();

--- a/src/index.js
+++ b/src/index.js
@@ -1055,9 +1055,9 @@ const _bindWindow = (window, newWindowCb) => {
             nativeWindow.blitFrameBuffer(context, vrPresentState.fbo, 0, vrPresentState.glContext.canvas.width * (args.blit ? 0.5 : 1), vrPresentState.glContext.canvas.height, window.innerWidth, window.innerHeight, true, false, false);
           } else if (mlPresentState.mlGlContext === context && mlPresentState.mlHasPose) {
             if (mlPresentState.layers.length > 0) { // TODO: composition can be directly to the output texture array
-              nativeWindow.composeLayersArray(context, mlPresentState.mlFbo, mlPresentState.layers);
+              nativeWindow.composeLayersArray(context, mlPresentState.mlTex, mlPresentState.layers);
             } else {
-              nativeWindow.blitFrameBufferArray(context, mlPresentState.mlMsFbo, mlPresentState.mlFbo, mlPresentState.mlGlContext.canvas.width, mlPresentState.mlGlContext.canvas.height, mlPresentState.mlGlContext.canvas.width, mlPresentState.mlGlContext.canvas.height, true, false, false);
+              nativeWindow.blitFrameBufferArray(context, mlPresentState.mlMsFbo, mlPresentState.mlTex, mlPresentState.mlGlContext.canvas.width, mlPresentState.mlGlContext.canvas.height, true, false, false);
             }
 
             mlPresentState.mlContext.SubmitFrame();


### PR DESCRIPTION
We use multisampled textures for all default framebuffers, and this requires a blit to a single-sampled texture before presenting to the headset APIs.

For presenting frames to the Magic Leap API, we were previously using an indirect texture blit to a local single-sampled texture, before blitting a second time to the device-provided textures. This does nothing except waste GPU time, and it's made slightly worse with Reality Tab blending since the draw calls are stacked up at the end of the frame and the final blit must wait for all draws to finish before adding its own overhead.

This PR shortcuts this intermediate blit for Magic Leap and composes the final framebuffer to the hardware-provided textures.