### PR TITLE
Remove non-full builds from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,19 +55,8 @@ matrix:
     - cp -R * /tmp/Exokit.app/Contents/MacOS
     - cp metadata/Info.plist /tmp/Exokit.app/Contents
     - tar -czf exokit-macos-full.tar.gz --exclude=".*" --exclude="*.tar.gz" *
-    - rm -R node
-    - tar -czf exokit-macos.tar.gz --exclude=".*" --exclude="*.tar.gz" *
     - ./scripts/exokit-codesign-macos.sh
     deploy:
-    - provider: releases
-      api_key:
-        secure: OlejFsEjiEBzw44wFRlmQb3stF+PURu52AMogc1t4qu54x6YRxxk0NMlv3nzGlObo9JnOPMhAfISgDr8515jqvGEfFXcDzFOPIx42nyqVZe0I8UCA4cRbsV3EvvXtYfbwaXa9n65kk+RuEJEdtqEAWy9xYjiJGDhtkKv2khVDIVhrS6fbleHGanNcFlYsOzyf7ZWouFq4wIEX+ovNhe2hRZKRjzgKnFcPaKIzlG8qQF3WrdL0L4D2FE6xA4+lc56R2dKrpmvR9r32kRLS620apS0iFKOWwttgNiIf580RElmUGa+mTEi9Bob9pods0pcmLpWhhqRddPyi5G2PVgZG1FCaXdymwmS7FsNNo1sqvAmISuhcQrHNUMqmdYbpl7vvBHHmzXPIQjfxPU9zaPFEctW+wqmZUf+WuWJeZmQInCbUxe/bRS9OFQtRMiyzcdFvYfOtZg/Sv8/YeaihGff+n0k36Im3TPygsDLEaMBpTM4EXUd6TRk+631nUVQy/Z8WSzWwKWM2cCjRtMbKqDVy7M2vYBYQ1F9WlZidGUD5nYu1uNKsV7rfqpNsvagt7dQL8aJRQN0JgAKgRe8sKXUzl299JXTo+TdTUgqmkr4DoAoH6972JcdcT1mRK8B1oMjLFkB8oef9SbfOoBRKT17V65dZHTJEMhgKLQHrCpcbHE=
-      file: exokit-macos.tar.gz
-      body: Exokit git release
-      on:
-        repo: webmixedreality/exokit
-        tags: true
-      skip_cleanup: true
     - provider: releases
       api_key:
         secure: OlejFsEjiEBzw44wFRlmQb3stF+PURu52AMogc1t4qu54x6YRxxk0NMlv3nzGlObo9JnOPMhAfISgDr8515jqvGEfFXcDzFOPIx42nyqVZe0I8UCA4cRbsV3EvvXtYfbwaXa9n65kk+RuEJEdtqEAWy9xYjiJGDhtkKv2khVDIVhrS6fbleHGanNcFlYsOzyf7ZWouFq4wIEX+ovNhe2hRZKRjzgKnFcPaKIzlG8qQF3WrdL0L4D2FE6xA4+lc56R2dKrpmvR9r32kRLS620apS0iFKOWwttgNiIf580RElmUGa+mTEi9Bob9pods0pcmLpWhhqRddPyi5G2PVgZG1FCaXdymwmS7FsNNo1sqvAmISuhcQrHNUMqmdYbpl7vvBHHmzXPIQjfxPU9zaPFEctW+wqmZUf+WuWJeZmQInCbUxe/bRS9OFQtRMiyzcdFvYfOtZg/Sv8/YeaihGff+n0k36Im3TPygsDLEaMBpTM4EXUd6TRk+631nUVQy/Z8WSzWwKWM2cCjRtMbKqDVy7M2vYBYQ1F9WlZidGUD5nYu1uNKsV7rfqpNsvagt7dQL8aJRQN0JgAKgRe8sKXUzl299JXTo+TdTUgqmkr4DoAoH6972JcdcT1mRK8B1oMjLFkB8oef9SbfOoBRKT17V65dZHTJEMhgKLQHrCpcbHE=

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,17 +16,7 @@ matrix:
     - docker build -t exokit .
     - docker run exokit cat exokit-linux-bin.tar.gz >exokit-linux-bin.tar.gz
     - docker run exokit cat exokit-linux-full.tar.gz >exokit-linux-full.tar.gz
-    - docker run exokit cat exokit-linux.tar.gz >exokit-linux.tar.gz
     deploy:
-    - provider: releases
-      api_key:
-        secure: OlejFsEjiEBzw44wFRlmQb3stF+PURu52AMogc1t4qu54x6YRxxk0NMlv3nzGlObo9JnOPMhAfISgDr8515jqvGEfFXcDzFOPIx42nyqVZe0I8UCA4cRbsV3EvvXtYfbwaXa9n65kk+RuEJEdtqEAWy9xYjiJGDhtkKv2khVDIVhrS6fbleHGanNcFlYsOzyf7ZWouFq4wIEX+ovNhe2hRZKRjzgKnFcPaKIzlG8qQF3WrdL0L4D2FE6xA4+lc56R2dKrpmvR9r32kRLS620apS0iFKOWwttgNiIf580RElmUGa+mTEi9Bob9pods0pcmLpWhhqRddPyi5G2PVgZG1FCaXdymwmS7FsNNo1sqvAmISuhcQrHNUMqmdYbpl7vvBHHmzXPIQjfxPU9zaPFEctW+wqmZUf+WuWJeZmQInCbUxe/bRS9OFQtRMiyzcdFvYfOtZg/Sv8/YeaihGff+n0k36Im3TPygsDLEaMBpTM4EXUd6TRk+631nUVQy/Z8WSzWwKWM2cCjRtMbKqDVy7M2vYBYQ1F9WlZidGUD5nYu1uNKsV7rfqpNsvagt7dQL8aJRQN0JgAKgRe8sKXUzl299JXTo+TdTUgqmkr4DoAoH6972JcdcT1mRK8B1oMjLFkB8oef9SbfOoBRKT17V65dZHTJEMhgKLQHrCpcbHE=
-      file: exokit-linux.tar.gz
-      body: Exokit git release
-      on:
-        repo: webmixedreality/exokit
-        tags: true
-      skip_cleanup: true
     - provider: releases
       api_key:
         secure: OlejFsEjiEBzw44wFRlmQb3stF+PURu52AMogc1t4qu54x6YRxxk0NMlv3nzGlObo9JnOPMhAfISgDr8515jqvGEfFXcDzFOPIx42nyqVZe0I8UCA4cRbsV3EvvXtYfbwaXa9n65kk+RuEJEdtqEAWy9xYjiJGDhtkKv2khVDIVhrS6fbleHGanNcFlYsOzyf7ZWouFq4wIEX+ovNhe2hRZKRjzgKnFcPaKIzlG8qQF3WrdL0L4D2FE6xA4+lc56R2dKrpmvR9r32kRLS620apS0iFKOWwttgNiIf580RElmUGa+mTEi9Bob9pods0pcmLpWhhqRddPyi5G2PVgZG1FCaXdymwmS7FsNNo1sqvAmISuhcQrHNUMqmdYbpl7vvBHHmzXPIQjfxPU9zaPFEctW+wqmZUf+WuWJeZmQInCbUxe/bRS9OFQtRMiyzcdFvYfOtZg/Sv8/YeaihGff+n0k36Im3TPygsDLEaMBpTM4EXUd6TRk+631nUVQy/Z8WSzWwKWM2cCjRtMbKqDVy7M2vYBYQ1F9WlZidGUD5nYu1uNKsV7rfqpNsvagt7dQL8aJRQN0JgAKgRe8sKXUzl299JXTo+TdTUgqmkr4DoAoH6972JcdcT1mRK8B1oMjLFkB8oef9SbfOoBRKT17V65dZHTJEMhgKLQHrCpcbHE=

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,5 @@ RUN \
   cd /tmp/exokit-bin && \
   tar -czf /app/exokit-linux-bin.tar.gz --exclude=".*" --exclude="*.tar.gz" * && \
   cd /app && \
-  tar -czf exokit-linux-full.tar.gz --exclude=".*" --exclude="*.tar.gz" * && \
-  rm -R node && \
-  tar -czf exokit-linux.tar.gz --exclude=".*" --exclude="*.tar.gz" *
+  tar -czf exokit-linux-full.tar.gz --exclude=".*" --exclude="*.tar.gz" *
 


### PR DESCRIPTION
Currently we have full and non-full builds being built on CI. Non-full contains just the results on `npm install`. Full contains a copy of `node` to run as well.

This PR removes the non-full version since they're not that useful -- you still need `node` and if you have node you might as well be building yourself.