### PR TITLE
Do not auto-pull magic leap toolchain build hacks in build-ml.sh

### DIFF
--- a/scripts/build-ml.sh
+++ b/scripts/build-ml.sh
@@ -27,10 +27,10 @@ export npm_config_arch=arm64
 
 if [ ! -d magicleap-js ]; then
   git clone https://github.com/webmixedreality/magicleap-js
-else
-  pushd magicleap-js
-  git pull --rebase
-  popd
+# else
+#   pushd magicleap-js
+#   git pull --rebase
+#   popd
 fi
 
 ./magicleap-js/hack-toolchain.js


### PR DESCRIPTION
There is really no reason to do this -- it just adds another network dependency to the build process.