### PR TITLE
Remove erroring CreateRenderTarget texture setup

### DIFF
--- a/deps/exokit-bindings/windowsystem/src/windowsystem.cc
+++ b/deps/exokit-bindings/windowsystem/src/windowsystem.cc
@@ -189,7 +189,6 @@ bool CreateRenderTarget(WebGLRenderingContext *gl, int width, int height, GLuint
       msDepthStencilTex = sharedMsDepthStencilTex;
     }
     glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, msDepthStencilTex);
-    glTexParameteri(GL_TEXTURE_2D_MULTISAMPLE, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D_MULTISAMPLE, GL_TEXTURE_MAX_LEVEL, 0);
 #ifndef LUMIN
     glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, samples, GL_DEPTH24_STENCIL8, GL_MAX_TEXTURE_SIZE, GL_MAX_TEXTURE_SIZE/2, true);
@@ -205,7 +204,6 @@ bool CreateRenderTarget(WebGLRenderingContext *gl, int width, int height, GLuint
       msColorTex = sharedMsColorTex;
     }
     glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, msColorTex);
-    glTexParameteri(GL_TEXTURE_2D_MULTISAMPLE, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D_MULTISAMPLE, GL_TEXTURE_MAX_LEVEL, 0);
 #ifndef LUMIN
     glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, samples, GL_RGBA8, GL_MAX_TEXTURE_SIZE, GL_MAX_TEXTURE_SIZE/2, true);


### PR DESCRIPTION
`CreateRenderTarget` in the `windowsystem` (EGL/GLFW) setup code was calling:

```glTexParameteri(GL_TEXTURE_2D_MULTISAMPLE, GL_TEXTURE_MIN_FILTER, GL_LINEAR);```

This is both illegal and not necessary -- it was generating GL errors which would be seen in the user code, making the user think they had caused an error.

- Remove the erroring calls