### PR TITLE
Bump EGL pixel depth to RGBA8

### DIFF
--- a/deps/exokit-bindings/browser/src/Servo2D.cpp
+++ b/deps/exokit-bindings/browser/src/Servo2D.cpp
@@ -68,14 +68,10 @@ int Servo2D::init(
   this->display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
   EGLConfig eglConfig;
   EGLint eglConfigAttribs[] = {
-    EGL_RED_SIZE, 5,
-    EGL_GREEN_SIZE, 6,
-    EGL_BLUE_SIZE,  5,
-    EGL_ALPHA_SIZE, 0,
-    /* EGL_RED_SIZE, 8,
+    EGL_RED_SIZE, 8,
     EGL_GREEN_SIZE, 8,
     EGL_BLUE_SIZE, 8,
-    EGL_ALPHA_SIZE, 8, */
+    EGL_ALPHA_SIZE, 8,
     EGL_DEPTH_SIZE, 24,
     EGL_STENCIL_SIZE, 8,
     EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,

--- a/deps/exokit-bindings/egl/src/egl.cc
+++ b/deps/exokit-bindings/egl/src/egl.cc
@@ -194,10 +194,10 @@ NATIVEwindow *CreateNativeWindow(unsigned int width, unsigned int height, bool v
   EGLDisplay display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
 
   EGLint config_attribs[] = {
-    EGL_RED_SIZE, 5,
-    EGL_GREEN_SIZE, 6,
-    EGL_BLUE_SIZE, 5,
-    EGL_ALPHA_SIZE, 0,
+    EGL_RED_SIZE, 8,
+    EGL_GREEN_SIZE, 8,
+    EGL_BLUE_SIZE, 8,
+    EGL_ALPHA_SIZE, 8,
     EGL_DEPTH_SIZE, 24,
     EGL_STENCIL_SIZE, 8,
     EGL_NONE


### PR DESCRIPTION
Previously we were creating a 16-bit RGB context in EGL's `CreateNativeWindow`. This changes it into an RGBA8-backed context.

I'm not actually sure if this makes a difference to the final blit of the device (e.g. if it only handles RGB16), but this might be a good change for devices that _do_ use RGBA8 natively (e.g. Android ArCore).

This change continues to work on Magic Leap.