### PR TITLE
Box helper for reality tabs placement

### DIFF
--- a/examples/realitytabs.html
+++ b/examples/realitytabs.html
@@ -191,8 +191,9 @@ const _requestSpriteMesh = url => new Promise((accept, reject) => {
 
 const _makeBoxGeometry = (x = 1, y = 1, z = 1) => {
   const size = 1;
+  const width = 0.01;
 
-  const lineGeometry = new THREE.CylinderBufferGeometry(0.001, 0.001, size, 3, 1);
+  const lineGeometry = new THREE.CylinderBufferGeometry(width, width, size, 3, 1);
   const geometry = new THREE.BufferGeometry();
   const positions = new Float32Array(lineGeometry.attributes.position.array.length * 12);
   geometry.addAttribute('position', new THREE.BufferAttribute(positions, 3));
@@ -373,10 +374,6 @@ const _makeBoxMesh = () => {
   mesh.frustumCulled = false;
   return mesh;
 };
-const boxMeshes = [
-  _makeBoxMesh(),
-  _makeBoxMesh(),
-];
 
 // helpers
 
@@ -1286,6 +1283,16 @@ cacheCanvas.width = 1024;
 cacheCanvas.height = 1024;
 const cacheCanvasCtx = cacheCanvas.getContext('2d');
 
+// box meshes
+
+const boxMeshes = [
+  _makeBoxMesh(),
+  _makeBoxMesh(),
+];
+boxMeshes.forEach(boxMesh => {
+  scene.add(boxMesh);
+});
+
 const moves = [null, null];
 
 window.addEventListener('click', () => {
@@ -1497,6 +1504,7 @@ function animate(time, frame) {
 
       boxMesh.position.copy(localVector);
       boxMesh.quaternion.copy(localQuaternion);
+      // boxMesh.updateMatrixWorld();
       boxMesh.visible = true;
     } else {
       boxMesh.visible = false;


### PR DESCRIPTION
We can move and place WebXR reality tabs in arbitrary space and we'll soon be able to scale them too (via https://github.com/webmixedreality/exokit/pull/714).

This adds a box helper for visualizing the reality tab location and scale when we're in move mode to make it easier to tell what we're doing. In all likelyhood the WebXR site we're loading isn't drawing at the origin so without this helper it's finnicky to see what transform we're applying to the site.