### PR TITLE
Add --no-bugsnag

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -19,7 +19,7 @@ const bugsnagApiKey = (() => {
     return null;
   }
 })();
-if (bugsnagApiKey) {
+if (bugsnagApiKey && !GlobalContext.args.noBugsnag) {
   bugsnag.register(bugsnagApiKey, {
     metaData: {
       argv: process.argv,

--- a/src/index.js
+++ b/src/index.js
@@ -71,6 +71,7 @@ const args = (() => {
         'blit',
         'require',
         'headless',
+        'no-bugsnag',
       ],
       string: [
         'webgl',
@@ -94,6 +95,7 @@ const args = (() => {
         r: 'require',
         n: 'headless',
         d: 'download',
+        nobs: 'no-bugsnag',
       },
     });
     return {
@@ -112,6 +114,7 @@ const args = (() => {
       require: minimistArgs.require,
       headless: minimistArgs.headless,
       download: minimistArgs.download !== undefined ? (minimistArgs.download || path.join(process.cwd(), 'downloads')) : undefined,
+      noBugsnag: minimistArgs['no-bugsnag'] !== undefined ? true : undefined,
     };
   } else {
     return {};


### PR DESCRIPTION
Bugsnag was prematurely terminating exokit when loading from localhost:8000/tests/test_celeste.html (presumably because my test has errors, which is expected behavior) so I added `--no-bugsnag` to prevent exokit from quitting.