### PR TITLE
Fix chdir error in webworkers

### DIFF
--- a/src/native-bindings.js
+++ b/src/native-bindings.js
@@ -1,11 +1,20 @@
 const path = require('path');
 
+const _chdir = (dir) => {
+  try {
+    process.chdir(dir);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
 const exokitNode = (() => {
   const oldCwd = process.cwd();
   const nodeModulesDir = path.resolve(path.dirname(require.resolve('native-graphics-deps')), '..');
-  process.chdir(nodeModulesDir);
+  if (!_chdir(nodeModulesDir)) return {};
   const exokitNode = require(path.join(__dirname, '..', 'build', 'Release', 'exokit.node'));
-  process.chdir(oldCwd);
+  if (!_chdir(oldCwd)) return {};
   return exokitNode;
 })();
 const WindowWorker = require('window-worker');


### PR DESCRIPTION
Possibly a dumb fix, since the following `require` statement also fails with "Module failed to self-register" error. But I'll tackle that next.