### PR TITLE
Frame reprojection example

### DIFF
--- a/examples/OrbitControls.js
+++ b/examples/OrbitControls.js
@@ -1,0 +1,1070 @@
+/**
+ * @author qiao / https://github.com/qiao
+ * @author mrdoob / http://mrdoob.com
+ * @author alteredq / http://alteredqualia.com/
+ * @author WestLangley / http://github.com/WestLangley
+ * @author erich666 / http://erichaines.com
+ */
+
+// This set of controls performs orbiting, dollying (zooming), and panning.
+// Unlike TrackballControls, it maintains the "up" direction object.up (+Y by default).
+//
+//    Orbit - left mouse / touch: one-finger move
+//    Zoom - middle mouse, or mousewheel / touch: two-finger spread or squish
+//    Pan - right mouse, or left mouse + ctrl/meta/shiftKey, or arrow keys / touch: two-finger move
+
+THREE.OrbitControls = function ( object, domElement ) {
+
+	this.object = object;
+
+	this.domElement = ( domElement !== undefined ) ? domElement : document;
+
+	// Set to false to disable this control
+	this.enabled = true;
+
+	// "target" sets the location of focus, where the object orbits around
+	this.target = new THREE.Vector3();
+
+	// How far you can dolly in and out ( PerspectiveCamera only )
+	this.minDistance = 0;
+	this.maxDistance = Infinity;
+
+	// How far you can zoom in and out ( OrthographicCamera only )
+	this.minZoom = 0;
+	this.maxZoom = Infinity;
+
+	// How far you can orbit vertically, upper and lower limits.
+	// Range is 0 to Math.PI radians.
+	this.minPolarAngle = 0; // radians
+	this.maxPolarAngle = Math.PI; // radians
+
+	// How far you can orbit horizontally, upper and lower limits.
+	// If set, must be a sub-interval of the interval [ - Math.PI, Math.PI ].
+	this.minAzimuthAngle = - Infinity; // radians
+	this.maxAzimuthAngle = Infinity; // radians
+
+	// Set to true to enable damping (inertia)
+	// If damping is enabled, you must call controls.update() in your animation loop
+	this.enableDamping = false;
+	this.dampingFactor = 0.25;
+
+	// This option actually enables dollying in and out; left as "zoom" for backwards compatibility.
+	// Set to false to disable zooming
+	this.enableZoom = true;
+	this.zoomSpeed = 1.0;
+
+	// Set to false to disable rotating
+	this.enableRotate = true;
+	this.rotateSpeed = 1.0;
+
+	// Set to false to disable panning
+	this.enablePan = true;
+	this.panSpeed = 1.0;
+	this.screenSpacePanning = false; // if true, pan in screen-space
+	this.keyPanSpeed = 7.0;	// pixels moved per arrow key push
+
+	// Set to true to automatically rotate around the target
+	// If auto-rotate is enabled, you must call controls.update() in your animation loop
+	this.autoRotate = false;
+	this.autoRotateSpeed = 2.0; // 30 seconds per round when fps is 60
+
+	// Set to false to disable use of the keys
+	this.enableKeys = true;
+
+	// The four arrow keys
+	this.keys = { LEFT: 37, UP: 38, RIGHT: 39, BOTTOM: 40 };
+
+	// Mouse buttons
+	this.mouseButtons = { LEFT: THREE.MOUSE.LEFT, MIDDLE: THREE.MOUSE.MIDDLE, RIGHT: THREE.MOUSE.RIGHT };
+
+	// for reset
+	this.target0 = this.target.clone();
+	this.position0 = this.object.position.clone();
+	this.zoom0 = this.object.zoom;
+
+	//
+	// public methods
+	//
+
+	this.getPolarAngle = function () {
+
+		return spherical.phi;
+
+	};
+
+	this.getAzimuthalAngle = function () {
+
+		return spherical.theta;
+
+	};
+
+	this.saveState = function () {
+
+		scope.target0.copy( scope.target );
+		scope.position0.copy( scope.object.position );
+		scope.zoom0 = scope.object.zoom;
+
+	};
+
+	this.reset = function () {
+
+		scope.target.copy( scope.target0 );
+		scope.object.position.copy( scope.position0 );
+		scope.object.zoom = scope.zoom0;
+
+		scope.object.updateProjectionMatrix();
+		scope.dispatchEvent( changeEvent );
+
+		scope.update();
+
+		state = STATE.NONE;
+
+	};
+
+	// this method is exposed, but perhaps it would be better if we can make it private...
+	this.update = function () {
+
+		var offset = new THREE.Vector3();
+
+		// so camera.up is the orbit axis
+		var quat = new THREE.Quaternion().setFromUnitVectors( object.up, new THREE.Vector3( 0, 1, 0 ) );
+		var quatInverse = quat.clone().inverse();
+
+		var lastPosition = new THREE.Vector3();
+		var lastQuaternion = new THREE.Quaternion();
+
+		return function update() {
+
+			var position = scope.object.position;
+
+			offset.copy( position ).sub( scope.target );
+
+			// rotate offset to "y-axis-is-up" space
+			offset.applyQuaternion( quat );
+
+			// angle from z-axis around y-axis
+			spherical.setFromVector3( offset );
+
+			if ( scope.autoRotate && state === STATE.NONE ) {
+
+				rotateLeft( getAutoRotationAngle() );
+
+			}
+
+			spherical.theta += sphericalDelta.theta;
+			spherical.phi += sphericalDelta.phi;
+
+			// restrict theta to be between desired limits
+			spherical.theta = Math.max( scope.minAzimuthAngle, Math.min( scope.maxAzimuthAngle, spherical.theta ) );
+
+			// restrict phi to be between desired limits
+			spherical.phi = Math.max( scope.minPolarAngle, Math.min( scope.maxPolarAngle, spherical.phi ) );
+
+			spherical.makeSafe();
+
+
+			spherical.radius *= scale;
+
+			// restrict radius to be between desired limits
+			spherical.radius = Math.max( scope.minDistance, Math.min( scope.maxDistance, spherical.radius ) );
+
+			// move target to panned location
+			scope.target.add( panOffset );
+
+			offset.setFromSpherical( spherical );
+
+			// rotate offset back to "camera-up-vector-is-up" space
+			offset.applyQuaternion( quatInverse );
+
+			position.copy( scope.target ).add( offset );
+
+			scope.object.lookAt( scope.target );
+
+			if ( scope.enableDamping === true ) {
+
+				sphericalDelta.theta *= ( 1 - scope.dampingFactor );
+				sphericalDelta.phi *= ( 1 - scope.dampingFactor );
+
+				panOffset.multiplyScalar( 1 - scope.dampingFactor );
+
+			} else {
+
+				sphericalDelta.set( 0, 0, 0 );
+
+				panOffset.set( 0, 0, 0 );
+
+			}
+
+			scale = 1;
+
+			// update condition is:
+			// min(camera displacement, camera rotation in radians)^2 > EPS
+			// using small-angle approximation cos(x/2) = 1 - x^2 / 8
+
+			if ( zoomChanged ||
+				lastPosition.distanceToSquared( scope.object.position ) > EPS ||
+				8 * ( 1 - lastQuaternion.dot( scope.object.quaternion ) ) > EPS ) {
+
+				scope.dispatchEvent( changeEvent );
+
+				lastPosition.copy( scope.object.position );
+				lastQuaternion.copy( scope.object.quaternion );
+				zoomChanged = false;
+
+				return true;
+
+			}
+
+			return false;
+
+		};
+
+	}();
+
+	this.dispose = function () {
+
+		scope.domElement.removeEventListener( 'contextmenu', onContextMenu, false );
+		scope.domElement.removeEventListener( 'mousedown', onMouseDown, false );
+		scope.domElement.removeEventListener( 'wheel', onMouseWheel, false );
+
+		scope.domElement.removeEventListener( 'touchstart', onTouchStart, false );
+		scope.domElement.removeEventListener( 'touchend', onTouchEnd, false );
+		scope.domElement.removeEventListener( 'touchmove', onTouchMove, false );
+
+		document.removeEventListener( 'mousemove', onMouseMove, false );
+		document.removeEventListener( 'mouseup', onMouseUp, false );
+
+		window.removeEventListener( 'keydown', onKeyDown, false );
+
+		//scope.dispatchEvent( { type: 'dispose' } ); // should this be added here?
+
+	};
+
+	//
+	// internals
+	//
+
+	var scope = this;
+
+	var changeEvent = { type: 'change' };
+	var startEvent = { type: 'start' };
+	var endEvent = { type: 'end' };
+
+	var STATE = { NONE: - 1, ROTATE: 0, DOLLY: 1, PAN: 2, TOUCH_ROTATE: 3, TOUCH_DOLLY_PAN: 4 };
+
+	var state = STATE.NONE;
+
+	var EPS = 0.000001;
+
+	// current position in spherical coordinates
+	var spherical = new THREE.Spherical();
+	var sphericalDelta = new THREE.Spherical();
+
+	var scale = 1;
+	var panOffset = new THREE.Vector3();
+	var zoomChanged = false;
+
+	var rotateStart = new THREE.Vector2();
+	var rotateEnd = new THREE.Vector2();
+	var rotateDelta = new THREE.Vector2();
+
+	var panStart = new THREE.Vector2();
+	var panEnd = new THREE.Vector2();
+	var panDelta = new THREE.Vector2();
+
+	var dollyStart = new THREE.Vector2();
+	var dollyEnd = new THREE.Vector2();
+	var dollyDelta = new THREE.Vector2();
+
+	function getAutoRotationAngle() {
+
+		return 2 * Math.PI / 60 / 60 * scope.autoRotateSpeed;
+
+	}
+
+	function getZoomScale() {
+
+		return Math.pow( 0.95, scope.zoomSpeed );
+
+	}
+
+	function rotateLeft( angle ) {
+
+		sphericalDelta.theta -= angle;
+
+	}
+
+	function rotateUp( angle ) {
+
+		sphericalDelta.phi -= angle;
+
+	}
+
+	var panLeft = function () {
+
+		var v = new THREE.Vector3();
+
+		return function panLeft( distance, objectMatrix ) {
+
+			v.setFromMatrixColumn( objectMatrix, 0 ); // get X column of objectMatrix
+			v.multiplyScalar( - distance );
+
+			panOffset.add( v );
+
+		};
+
+	}();
+
+	var panUp = function () {
+
+		var v = new THREE.Vector3();
+
+		return function panUp( distance, objectMatrix ) {
+
+			if ( scope.screenSpacePanning === true ) {
+
+				v.setFromMatrixColumn( objectMatrix, 1 );
+
+			} else {
+
+				v.setFromMatrixColumn( objectMatrix, 0 );
+				v.crossVectors( scope.object.up, v );
+
+			}
+
+			v.multiplyScalar( distance );
+
+			panOffset.add( v );
+
+		};
+
+	}();
+
+	// deltaX and deltaY are in pixels; right and down are positive
+	var pan = function () {
+
+		var offset = new THREE.Vector3();
+
+		return function pan( deltaX, deltaY ) {
+
+			var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+
+			if ( scope.object.isPerspectiveCamera ) {
+
+				// perspective
+				var position = scope.object.position;
+				offset.copy( position ).sub( scope.target );
+				var targetDistance = offset.length();
+
+				// half of the fov is center to top of screen
+				targetDistance *= Math.tan( ( scope.object.fov / 2 ) * Math.PI / 180.0 );
+
+				// we use only clientHeight here so aspect ratio does not distort speed
+				panLeft( 2 * deltaX * targetDistance / element.clientHeight, scope.object.matrix );
+				panUp( 2 * deltaY * targetDistance / element.clientHeight, scope.object.matrix );
+
+			} else if ( scope.object.isOrthographicCamera ) {
+
+				// orthographic
+				panLeft( deltaX * ( scope.object.right - scope.object.left ) / scope.object.zoom / element.clientWidth, scope.object.matrix );
+				panUp( deltaY * ( scope.object.top - scope.object.bottom ) / scope.object.zoom / element.clientHeight, scope.object.matrix );
+
+			} else {
+
+				// camera neither orthographic nor perspective
+				console.warn( 'WARNING: OrbitControls.js encountered an unknown camera type - pan disabled.' );
+				scope.enablePan = false;
+
+			}
+
+		};
+
+	}();
+
+	function dollyIn( dollyScale ) {
+
+		if ( scope.object.isPerspectiveCamera ) {
+
+			scale /= dollyScale;
+
+		} else if ( scope.object.isOrthographicCamera ) {
+
+			scope.object.zoom = Math.max( scope.minZoom, Math.min( scope.maxZoom, scope.object.zoom * dollyScale ) );
+			scope.object.updateProjectionMatrix();
+			zoomChanged = true;
+
+		} else {
+
+			console.warn( 'WARNING: OrbitControls.js encountered an unknown camera type - dolly/zoom disabled.' );
+			scope.enableZoom = false;
+
+		}
+
+	}
+
+	function dollyOut( dollyScale ) {
+
+		if ( scope.object.isPerspectiveCamera ) {
+
+			scale *= dollyScale;
+
+		} else if ( scope.object.isOrthographicCamera ) {
+
+			scope.object.zoom = Math.max( scope.minZoom, Math.min( scope.maxZoom, scope.object.zoom / dollyScale ) );
+			scope.object.updateProjectionMatrix();
+			zoomChanged = true;
+
+		} else {
+
+			console.warn( 'WARNING: OrbitControls.js encountered an unknown camera type - dolly/zoom disabled.' );
+			scope.enableZoom = false;
+
+		}
+
+	}
+
+	//
+	// event callbacks - update the object state
+	//
+
+	function handleMouseDownRotate( event ) {
+
+		//console.log( 'handleMouseDownRotate' );
+
+		rotateStart.set( event.clientX, event.clientY );
+
+	}
+
+	function handleMouseDownDolly( event ) {
+
+		//console.log( 'handleMouseDownDolly' );
+
+		dollyStart.set( event.clientX, event.clientY );
+
+	}
+
+	function handleMouseDownPan( event ) {
+
+		//console.log( 'handleMouseDownPan' );
+
+		panStart.set( event.clientX, event.clientY );
+
+	}
+
+	function handleMouseMoveRotate( event ) {
+
+		//console.log( 'handleMouseMoveRotate' );
+
+		rotateEnd.set( event.clientX, event.clientY );
+
+		rotateDelta.subVectors( rotateEnd, rotateStart ).multiplyScalar( scope.rotateSpeed );
+
+		var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+
+		rotateLeft( 2 * Math.PI * rotateDelta.x / element.clientHeight ); // yes, height
+
+		rotateUp( 2 * Math.PI * rotateDelta.y / element.clientHeight );
+
+		rotateStart.copy( rotateEnd );
+
+		scope.update();
+
+	}
+
+	function handleMouseMoveDolly( event ) {
+
+		//console.log( 'handleMouseMoveDolly' );
+
+		dollyEnd.set( event.clientX, event.clientY );
+
+		dollyDelta.subVectors( dollyEnd, dollyStart );
+
+		if ( dollyDelta.y > 0 ) {
+
+			dollyIn( getZoomScale() );
+
+		} else if ( dollyDelta.y < 0 ) {
+
+			dollyOut( getZoomScale() );
+
+		}
+
+		dollyStart.copy( dollyEnd );
+
+		scope.update();
+
+	}
+
+	function handleMouseMovePan( event ) {
+
+		//console.log( 'handleMouseMovePan' );
+
+		panEnd.set( event.clientX, event.clientY );
+
+		panDelta.subVectors( panEnd, panStart ).multiplyScalar( scope.panSpeed );
+
+		pan( panDelta.x, panDelta.y );
+
+		panStart.copy( panEnd );
+
+		scope.update();
+
+	}
+
+	function handleMouseUp( event ) {
+
+		// console.log( 'handleMouseUp' );
+
+	}
+
+	function handleMouseWheel( event ) {
+
+		// console.log( 'handleMouseWheel' );
+
+		if ( event.deltaY < 0 ) {
+
+			dollyOut( getZoomScale() );
+
+		} else if ( event.deltaY > 0 ) {
+
+			dollyIn( getZoomScale() );
+
+		}
+
+		scope.update();
+
+	}
+
+	function handleKeyDown( event ) {
+
+		// console.log( 'handleKeyDown' );
+
+		var needsUpdate = false;
+
+		switch ( event.keyCode ) {
+
+			case scope.keys.UP:
+				pan( 0, scope.keyPanSpeed );
+				needsUpdate = true;
+				break;
+
+			case scope.keys.BOTTOM:
+				pan( 0, - scope.keyPanSpeed );
+				needsUpdate = true;
+				break;
+
+			case scope.keys.LEFT:
+				pan( scope.keyPanSpeed, 0 );
+				needsUpdate = true;
+				break;
+
+			case scope.keys.RIGHT:
+				pan( - scope.keyPanSpeed, 0 );
+				needsUpdate = true;
+				break;
+
+		}
+
+		if ( needsUpdate ) {
+
+			// prevent the browser from scrolling on cursor keys
+			event.preventDefault();
+
+			scope.update();
+
+		}
+
+
+	}
+
+	function handleTouchStartRotate( event ) {
+
+		//console.log( 'handleTouchStartRotate' );
+
+		rotateStart.set( event.touches[ 0 ].pageX, event.touches[ 0 ].pageY );
+
+	}
+
+	function handleTouchStartDollyPan( event ) {
+
+		//console.log( 'handleTouchStartDollyPan' );
+
+		if ( scope.enableZoom ) {
+
+			var dx = event.touches[ 0 ].pageX - event.touches[ 1 ].pageX;
+			var dy = event.touches[ 0 ].pageY - event.touches[ 1 ].pageY;
+
+			var distance = Math.sqrt( dx * dx + dy * dy );
+
+			dollyStart.set( 0, distance );
+
+		}
+
+		if ( scope.enablePan ) {
+
+			var x = 0.5 * ( event.touches[ 0 ].pageX + event.touches[ 1 ].pageX );
+			var y = 0.5 * ( event.touches[ 0 ].pageY + event.touches[ 1 ].pageY );
+
+			panStart.set( x, y );
+
+		}
+
+	}
+
+	function handleTouchMoveRotate( event ) {
+
+		//console.log( 'handleTouchMoveRotate' );
+
+		rotateEnd.set( event.touches[ 0 ].pageX, event.touches[ 0 ].pageY );
+
+		rotateDelta.subVectors( rotateEnd, rotateStart ).multiplyScalar( scope.rotateSpeed );
+
+		var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+
+		rotateLeft( 2 * Math.PI * rotateDelta.x / element.clientHeight ); // yes, height
+
+		rotateUp( 2 * Math.PI * rotateDelta.y / element.clientHeight );
+
+		rotateStart.copy( rotateEnd );
+
+		scope.update();
+
+	}
+
+	function handleTouchMoveDollyPan( event ) {
+
+		//console.log( 'handleTouchMoveDollyPan' );
+
+		if ( scope.enableZoom ) {
+
+			var dx = event.touches[ 0 ].pageX - event.touches[ 1 ].pageX;
+			var dy = event.touches[ 0 ].pageY - event.touches[ 1 ].pageY;
+
+			var distance = Math.sqrt( dx * dx + dy * dy );
+
+			dollyEnd.set( 0, distance );
+
+			dollyDelta.set( 0, Math.pow( dollyEnd.y / dollyStart.y, scope.zoomSpeed ) );
+
+			dollyIn( dollyDelta.y );
+
+			dollyStart.copy( dollyEnd );
+
+		}
+
+		if ( scope.enablePan ) {
+
+			var x = 0.5 * ( event.touches[ 0 ].pageX + event.touches[ 1 ].pageX );
+			var y = 0.5 * ( event.touches[ 0 ].pageY + event.touches[ 1 ].pageY );
+
+			panEnd.set( x, y );
+
+			panDelta.subVectors( panEnd, panStart ).multiplyScalar( scope.panSpeed );
+
+			pan( panDelta.x, panDelta.y );
+
+			panStart.copy( panEnd );
+
+		}
+
+		scope.update();
+
+	}
+
+	function handleTouchEnd( event ) {
+
+		//console.log( 'handleTouchEnd' );
+
+	}
+
+	//
+	// event handlers - FSM: listen for events and reset state
+	//
+
+	function onMouseDown( event ) {
+
+		if ( scope.enabled === false ) return;
+
+		// Prevent the browser from scrolling.
+
+		event.preventDefault();
+
+		// Manually set the focus since calling preventDefault above
+		// prevents the browser from setting it automatically.
+
+		scope.domElement.focus ? scope.domElement.focus() : window.focus();
+
+		switch ( event.button ) {
+
+			case scope.mouseButtons.LEFT:
+
+				if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+
+					if ( scope.enablePan === false ) return;
+
+					handleMouseDownPan( event );
+
+					state = STATE.PAN;
+
+				} else {
+
+					if ( scope.enableRotate === false ) return;
+
+					handleMouseDownRotate( event );
+
+					state = STATE.ROTATE;
+
+				}
+
+				break;
+
+			case scope.mouseButtons.MIDDLE:
+
+				if ( scope.enableZoom === false ) return;
+
+				handleMouseDownDolly( event );
+
+				state = STATE.DOLLY;
+
+				break;
+
+			case scope.mouseButtons.RIGHT:
+
+				if ( scope.enablePan === false ) return;
+
+				handleMouseDownPan( event );
+
+				state = STATE.PAN;
+
+				break;
+
+		}
+
+		if ( state !== STATE.NONE ) {
+
+			document.addEventListener( 'mousemove', onMouseMove, false );
+			document.addEventListener( 'mouseup', onMouseUp, false );
+
+			scope.dispatchEvent( startEvent );
+
+		}
+
+	}
+
+	function onMouseMove( event ) {
+
+		if ( scope.enabled === false ) return;
+
+		event.preventDefault();
+
+		switch ( state ) {
+
+			case STATE.ROTATE:
+
+				if ( scope.enableRotate === false ) return;
+
+				handleMouseMoveRotate( event );
+
+				break;
+
+			case STATE.DOLLY:
+
+				if ( scope.enableZoom === false ) return;
+
+				handleMouseMoveDolly( event );
+
+				break;
+
+			case STATE.PAN:
+
+				if ( scope.enablePan === false ) return;
+
+				handleMouseMovePan( event );
+
+				break;
+
+		}
+
+	}
+
+	function onMouseUp( event ) {
+
+		if ( scope.enabled === false ) return;
+
+		handleMouseUp( event );
+
+		document.removeEventListener( 'mousemove', onMouseMove, false );
+		document.removeEventListener( 'mouseup', onMouseUp, false );
+
+		scope.dispatchEvent( endEvent );
+
+		state = STATE.NONE;
+
+	}
+
+	function onMouseWheel( event ) {
+
+		if ( scope.enabled === false || scope.enableZoom === false || ( state !== STATE.NONE && state !== STATE.ROTATE ) ) return;
+
+		event.preventDefault();
+		event.stopPropagation();
+
+		scope.dispatchEvent( startEvent );
+
+		handleMouseWheel( event );
+
+		scope.dispatchEvent( endEvent );
+
+	}
+
+	function onKeyDown( event ) {
+
+		if ( scope.enabled === false || scope.enableKeys === false || scope.enablePan === false ) return;
+
+		handleKeyDown( event );
+
+	}
+
+	function onTouchStart( event ) {
+
+		if ( scope.enabled === false ) return;
+
+		event.preventDefault();
+
+		switch ( event.touches.length ) {
+
+			case 1:	// one-fingered touch: rotate
+
+				if ( scope.enableRotate === false ) return;
+
+				handleTouchStartRotate( event );
+
+				state = STATE.TOUCH_ROTATE;
+
+				break;
+
+			case 2:	// two-fingered touch: dolly-pan
+
+				if ( scope.enableZoom === false && scope.enablePan === false ) return;
+
+				handleTouchStartDollyPan( event );
+
+				state = STATE.TOUCH_DOLLY_PAN;
+
+				break;
+
+			default:
+
+				state = STATE.NONE;
+
+		}
+
+		if ( state !== STATE.NONE ) {
+
+			scope.dispatchEvent( startEvent );
+
+		}
+
+	}
+
+	function onTouchMove( event ) {
+
+		if ( scope.enabled === false ) return;
+
+		event.preventDefault();
+		event.stopPropagation();
+
+		switch ( event.touches.length ) {
+
+			case 1: // one-fingered touch: rotate
+
+				if ( scope.enableRotate === false ) return;
+				if ( state !== STATE.TOUCH_ROTATE ) return; // is this needed?
+
+				handleTouchMoveRotate( event );
+
+				break;
+
+			case 2: // two-fingered touch: dolly-pan
+
+				if ( scope.enableZoom === false && scope.enablePan === false ) return;
+				if ( state !== STATE.TOUCH_DOLLY_PAN ) return; // is this needed?
+
+				handleTouchMoveDollyPan( event );
+
+				break;
+
+			default:
+
+				state = STATE.NONE;
+
+		}
+
+	}
+
+	function onTouchEnd( event ) {
+
+		if ( scope.enabled === false ) return;
+
+		handleTouchEnd( event );
+
+		scope.dispatchEvent( endEvent );
+
+		state = STATE.NONE;
+
+	}
+
+	function onContextMenu( event ) {
+
+		if ( scope.enabled === false ) return;
+
+		event.preventDefault();
+
+	}
+
+	//
+
+	scope.domElement.addEventListener( 'contextmenu', onContextMenu, false );
+
+	scope.domElement.addEventListener( 'mousedown', onMouseDown, false );
+	scope.domElement.addEventListener( 'wheel', onMouseWheel, false );
+
+	scope.domElement.addEventListener( 'touchstart', onTouchStart, false );
+	scope.domElement.addEventListener( 'touchend', onTouchEnd, false );
+	scope.domElement.addEventListener( 'touchmove', onTouchMove, false );
+
+	window.addEventListener( 'keydown', onKeyDown, false );
+
+	// force an update at start
+
+	this.update();
+
+};
+
+THREE.OrbitControls.prototype = Object.create( THREE.EventDispatcher.prototype );
+THREE.OrbitControls.prototype.constructor = THREE.OrbitControls;
+
+Object.defineProperties( THREE.OrbitControls.prototype, {
+
+	center: {
+
+		get: function () {
+
+			console.warn( 'THREE.OrbitControls: .center has been renamed to .target' );
+			return this.target;
+
+		}
+
+	},
+
+	// backward compatibility
+
+	noZoom: {
+
+		get: function () {
+
+			console.warn( 'THREE.OrbitControls: .noZoom has been deprecated. Use .enableZoom instead.' );
+			return ! this.enableZoom;
+
+		},
+
+		set: function ( value ) {
+
+			console.warn( 'THREE.OrbitControls: .noZoom has been deprecated. Use .enableZoom instead.' );
+			this.enableZoom = ! value;
+
+		}
+
+	},
+
+	noRotate: {
+
+		get: function () {
+
+			console.warn( 'THREE.OrbitControls: .noRotate has been deprecated. Use .enableRotate instead.' );
+			return ! this.enableRotate;
+
+		},
+
+		set: function ( value ) {
+
+			console.warn( 'THREE.OrbitControls: .noRotate has been deprecated. Use .enableRotate instead.' );
+			this.enableRotate = ! value;
+
+		}
+
+	},
+
+	noPan: {
+
+		get: function () {
+
+			console.warn( 'THREE.OrbitControls: .noPan has been deprecated. Use .enablePan instead.' );
+			return ! this.enablePan;
+
+		},
+
+		set: function ( value ) {
+
+			console.warn( 'THREE.OrbitControls: .noPan has been deprecated. Use .enablePan instead.' );
+			this.enablePan = ! value;
+
+		}
+
+	},
+
+	noKeys: {
+
+		get: function () {
+
+			console.warn( 'THREE.OrbitControls: .noKeys has been deprecated. Use .enableKeys instead.' );
+			return ! this.enableKeys;
+
+		},
+
+		set: function ( value ) {
+
+			console.warn( 'THREE.OrbitControls: .noKeys has been deprecated. Use .enableKeys instead.' );
+			this.enableKeys = ! value;
+
+		}
+
+	},
+
+	staticMoving: {
+
+		get: function () {
+
+			console.warn( 'THREE.OrbitControls: .staticMoving has been deprecated. Use .enableDamping instead.' );
+			return ! this.enableDamping;
+
+		},
+
+		set: function ( value ) {
+
+			console.warn( 'THREE.OrbitControls: .staticMoving has been deprecated. Use .enableDamping instead.' );
+			this.enableDamping = ! value;
+
+		}
+
+	},
+
+	dynamicDampingFactor: {
+
+		get: function () {
+
+			console.warn( 'THREE.OrbitControls: .dynamicDampingFactor has been renamed. Use .dampingFactor instead.' );
+			return this.dampingFactor;
+
+		},
+
+		set: function ( value ) {
+
+			console.warn( 'THREE.OrbitControls: .dynamicDampingFactor has been renamed. Use .dampingFactor instead.' );
+			this.dampingFactor = value;
+
+		}
+
+	}
+
+} );

--- a/examples/reprojection.html
+++ b/examples/reprojection.html
@@ -17,6 +17,7 @@
 
       var defaultVertexShader = [
 
+        "varying vec3 viewPosition;",
         "varying vec2 vUv;",
         "varying float vZDiff;",
         "uniform sampler2D dTexture;",
@@ -25,6 +26,7 @@
         "uniform mat4 initialProjectionMatrix;",
         "uniform float zNear;",
         "uniform float zFar;",
+        "uniform vec4 plane;",
         `
         void main() {
           vec2 xy = (position.xy + 1.0) / 2.0; //in [0,1] range
@@ -36,7 +38,9 @@
           vec4 worldPosOrig = initialProjectionMatrixInverse * vec4(position.xy, offset.z/offset.w, 1.0);
           float zNew = worldPosOrig.z/worldPosOrig.w;
           vec4 worldPosNew = modelViewMatrix * worldPosOrig;
+
           gl_Position = projectionMatrix * worldPosNew;
+          vViewPosition = worldPosNew.xyz;
           vUv = uv;
           vZDiff = abs(zNew - zOrig);
         }
@@ -47,13 +51,15 @@
       var defaultFragmentShader = [
 
         `
+        varying vec3 viewPosition;
         varying vec2 vUv;
         varying float vZDiff;
         uniform float numTextures;
         uniform sampler2D uTexture;
         uniform sampler2D dTexture;
+        uniform vec4 plane;
         void main() {
-          if (vZDiff < 0.0001) {
+          if (vZDiff < 0.0001 && dot(vViewPosition, plane.xyz) > plane.w) {
             vec4 c = texture2D(uTexture, vUv);
             float dc = (1.0 - texture2D(dTexture, vUv).r) * 20.0;
             gl_FragColor = vec4(vec3(dc) * c.rgb, c.a);
@@ -103,6 +109,10 @@
             zFar: {
               type:'f',
               value: undefined !== params.zFar ? params.zFar : null
+            },
+            plane: {
+              type:'v4',
+              value: undefined !== params.plane ? params.plane : null
             },
           },
 
@@ -180,6 +190,7 @@ function init() {
   hiddenCamera.inverseMatrix = new THREE.Matrix4();
   hiddenCamera.initialProjectionMatrixInverse = new THREE.Matrix4();
   hiddenCamera.initialProjectionMatrix = new THREE.Matrix4();
+  hiddenCamera.plane = new THREE.Vector4(0, 1, 0, 1);
 
   {
     const ambientLight = new THREE.AmbientLight(0x808080);
@@ -245,6 +256,7 @@ function init() {
     depthTexture: renderTarget.depthTexture,
     zNear: hiddenCamera.near,
     zFar: hiddenCamera.far,
+    plane: hiddenCamera.plane,
     inverseMatrix: hiddenCamera.inverseMatrix,
     initialProjectionMatrixInverse: hiddenCamera.initialProjectionMatrixInverse,
     initialProjectionMatrix: hiddenCamera.initialProjectionMatrix,

--- a/examples/reprojection.html
+++ b/examples/reprojection.html
@@ -19,7 +19,6 @@
         varying vec2 vUv;
         varying float vZDiff;
         uniform sampler2D dTexture;
-        uniform mat4 inverseMatrix;
         uniform mat4 initialProjectionMatrixInverse;
         uniform mat4 initialProjectionMatrix;
         uniform float zNear;
@@ -80,10 +79,6 @@
             dTexture: {
               type:'t',
               value: undefined !== params.depthTexture ? params.depthTexture : null
-            },
-            inverseMatrix: {
-              type:'m4',
-              value: undefined !== params.inverseMatrix ? params.inverseMatrix : null
             },
             initialProjectionMatrixInverse: {
               type:'m4',
@@ -178,7 +173,6 @@ function init() {
   hiddenScene.add(hiddenCamera);
   hiddenCamera.updateMatrixWorld();
   hiddenCamera.updateProjectionMatrix();
-  hiddenCamera.inverseMatrix = new THREE.Matrix4();
   hiddenCamera.initialProjectionMatrixInverse = new THREE.Matrix4();
   hiddenCamera.initialProjectionMatrix = new THREE.Matrix4();
   hiddenCamera.plane = new THREE.Vector4(0, 1, 0, 0);
@@ -248,7 +242,6 @@ function init() {
     zNear: hiddenCamera.near,
     zFar: hiddenCamera.far,
     plane: hiddenCamera.plane,
-    inverseMatrix: hiddenCamera.inverseMatrix,
     initialProjectionMatrixInverse: hiddenCamera.initialProjectionMatrixInverse,
     initialProjectionMatrix: hiddenCamera.initialProjectionMatrix,
   });
@@ -269,8 +262,6 @@ const _renderFrame = () => {
   screenQuad.scale.copy(camera.scale);
   screenQuad.updateMatrixWorld();
 
-  hiddenCamera.inverseMatrix.copy(hiddenCamera.matrixWorld).multiply(screenQuad.matrixWorld);
-  hiddenCamera.inverseMatrix.getInverse(hiddenCamera.inverseMatrix);
   hiddenCamera.initialProjectionMatrixInverse.copy(hiddenCamera.projectionMatrixInverse);
   hiddenCamera.initialProjectionMatrix.copy(hiddenCamera.projectionMatrix);
 

--- a/examples/reprojection.html
+++ b/examples/reprojection.html
@@ -52,9 +52,10 @@
         uniform vec4 plane;
         void main() {
           if (vZDiff < 0.0001 && dot(vViewPosition, plane.xyz) <= plane.w) {
-            vec4 c = texture2D(uTexture, vUv);
+            /* vec4 c = texture2D(uTexture, vUv);
             float dc = (1.0 - texture2D(dTexture, vUv).r) * 20.0;
-            gl_FragColor = vec4(vec3(dc) * c.rgb, c.a);
+            gl_FragColor = vec4(vec3(dc) * c.rgb, c.a); */
+            gl_FragColor = texture2D(uTexture, vUv);
           } else {
             discard;
           }

--- a/examples/reprojection.html
+++ b/examples/reprojection.html
@@ -17,7 +17,7 @@
 
       var defaultVertexShader = [
 
-        "varying vec3 viewPosition;",
+        "varying vec3 vViewPosition;",
         "varying vec2 vUv;",
         "varying float vZDiff;",
         "uniform sampler2D dTexture;",
@@ -51,7 +51,7 @@
       var defaultFragmentShader = [
 
         `
-        varying vec3 viewPosition;
+        varying vec3 vViewPosition;
         varying vec2 vUv;
         varying float vZDiff;
         uniform float numTextures;

--- a/examples/reprojection.html
+++ b/examples/reprojection.html
@@ -1,0 +1,159 @@
+<!doctype html>
+<html>
+  <body>
+    <script src="three.js"></script>
+    <script>
+let renderer, scene, hiddenScene, camera, iframe, planeMesh, renderTarget;
+
+const localVector = new THREE.Vector3();
+const localVector2 = new THREE.Vector3();
+const localVector3 = new THREE.Vector3();
+const localCoord = new THREE.Vector2();
+const localPlane = new THREE.Plane();
+const localLine = new THREE.Line3();
+const localLine2 = new THREE.Line3();
+
+const planeWorldWidth = 0.9;
+const planeWorldHeight = 0.9;
+const boxMeshSize = 0.02;
+const planeWidth = 1280;
+const planeHeight = 1024;
+
+function init() {
+  renderer = new THREE.WebGLRenderer({
+    antialias: true,
+    alpha: true,
+  });
+  renderer.setPixelRatio(window.devicePixelRatio);
+  renderer.setSize(window.innerWidth, window.innerHeight);
+
+  // window.browser.magicleap.RequestDepthPopulation(true);
+  // renderer.autoClear = false;
+
+  document.body.appendChild(renderer.domElement);
+
+  scene = new THREE.Scene();
+  scene.matrixAutoUpdate = false;
+
+  hiddenScene = new THREE.Scene();
+  hiddenScene.matrixAutoUpdate = false;
+
+  camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
+  hiddenScene.add(camera);
+
+  const vertexShader = [
+    'attribute vec2 uv;',
+    'varying vec2 vUv;',
+    'void main() {',
+      // 'vec4 worldPosition = modelMatrix * vec4( position, 1.0 );',
+      // 'vWorldPosition = worldPosition.xyz;',
+      'gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );',
+      'vUv = uv;',
+    '}'
+  ].join('\n');
+  const fragmentShader = [
+    'sampler2D t;',
+    'varying vec2 vUv;',
+    'void main() {',
+      'gl_FragColor = texture2D(t, vUv);',
+    '}'
+  ].join('\n');
+
+  planeMesh = (() => {
+    const geometry = new THREE.PlaneBufferGeometry(planeWorldWidth, planeWorldHeight)
+      // .applyMatrix(new THREE.Matrix4().makeScale(-1, -1, 1));
+    const uvs = geometry.attributes.uv.array;
+    const numUvs = uvs.length / 2;
+    for (let i = 0; i < numUvs; i++) {
+      uvs[i*2+1] = 1 - uvs[i*2+1];
+    }
+    /* const material = new THREE.MeshPhongMaterial({
+      color: 0xFFFF00,
+    }); */
+    const texture = new THREE.Texture(
+      null,
+      THREE.UVMapping,
+      THREE.ClampToEdgeWrapping,
+      THREE.ClampToEdgeWrapping,
+      THREE.NearestFilter,
+      THREE.NearestFilter,
+      THREE.RGBAFormat,
+      THREE.UnsignedByteType,
+      16
+    );
+    const properties = renderer.properties.get(texture);
+    properties.__webglTexture = iframe.texture;
+    properties.__webglInit = true;
+    const material = new THREE.MeshBasicMaterial({
+      map: texture,
+    });
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.position.z = -1;
+    mesh.projectMouse = (x, y) => {
+      const leftLine = localLine;
+      const topLine = localLine2;
+      const plane = localPlane;
+
+      leftLine.start
+        .set(-planeWorldWidth/2, planeWorldHeight/2, 0)
+        .applyMatrix4(mesh.matrixWorld);
+      leftLine.end
+        .set(-planeWorldWidth/2, -planeWorldHeight/2, 0)
+        .applyMatrix4(mesh.matrixWorld);
+
+      topLine.start
+        .set(-planeWorldWidth/2, planeWorldHeight/2, 0)
+        .applyMatrix4(mesh.matrixWorld);
+      topLine.end
+        .set(planeWorldWidth/2, planeWorldHeight / 2, 0)
+        .applyMatrix4(mesh.matrixWorld);
+
+      plane.setFromCoplanarPoints(
+        leftLine.start,
+        leftLine.end,
+        topLine.end
+      );
+    };
+
+    return mesh;
+  })();
+  hiddenScene.add(planeMesh);
+
+  const boxMesh = (() => {
+    const geometry = new THREE.BoxBufferGeometry(boxMeshSize, boxMeshSize, boxMeshSize);
+      // .applyMatrix(new THREE.Matrix4().makeTranslation(-planeWorldWidth/2, planeWorldHeight/2, boxMeshSize/2));
+    const material = new THREE.MeshPhongMaterial({
+      color: 0xFF0000,
+    });
+    const mesh = new THREE.Mesh(geometry, material);
+    return mesh;
+  })();
+  hiddenScene.add(boxMesh);
+
+  renderTarget = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight, {
+    format: THREE.RGBAFormat,
+  });
+  // renderTarget.transparent = false;
+
+  const mesh = new THREE.Mesh(
+    new THREE.PlaneBufferGeometry(0.1, 0.1)
+      .applyMatrix(new THREE.Matrix4().makeTranslation(0, 0.1/2, 0.01)),
+    new THREE.MeshBasicMaterial({
+      // color: 0x0000FF,
+      map: renderTarget.texture,
+    })
+  );
+}
+
+init();
+
+function animate(timestamp, frame) {
+  renderer.render(hiddenScene, camera, renderTarget);
+
+  renderer.render(scene, camera);
+}
+
+  renderer.setAnimationLoop(animate);
+    </script>
+  </body>
+</html>

--- a/examples/reprojection.html
+++ b/examples/reprojection.html
@@ -21,13 +21,13 @@
         uniform sampler2D dTexture;
         uniform mat4 initialProjectionMatrixInverse;
         uniform mat4 initialProjectionMatrix;
-        uniform float zNear;
-        uniform float zFar;
         uniform vec4 plane;
         void main() {
           vec2 xy = (position.xy + 1.0) / 2.0; //in [0,1] range
           float z_b = texture2D(dTexture, xy).r;
           float z_n = 2.0 * z_b - 1.0;
+          float zNear = initialProjectionMatrix[3][2] / (initialProjectionMatrix[2][2] - 1.0);
+          float zFar = initialProjectionMatrix[3][2] / (initialProjectionMatrix[2][2] + 1.0);
           float z_e = -(2.0 * zNear * zFar / (zFar + zNear - z_n * (zFar - zNear)));
           float zOrig = z_e;
           vec4 offset = initialProjectionMatrix * vec4(0.0, 0.0, z_e, 1.0);
@@ -87,14 +87,6 @@
             initialProjectionMatrix: {
               type:'m4',
               value: undefined !== params.initialProjectionMatrix ? params.initialProjectionMatrix : null
-            },
-            zNear: {
-              type:'f',
-              value: undefined !== params.zNear ? params.zNear : null
-            },
-            zFar: {
-              type:'f',
-              value: undefined !== params.zFar ? params.zFar : null
             },
             plane: {
               type:'v4',
@@ -239,8 +231,6 @@ function init() {
   screenQuad = new ScreenQuad({
     texture: renderTarget.texture,
     depthTexture: renderTarget.depthTexture,
-    zNear: hiddenCamera.near,
-    zFar: hiddenCamera.far,
     plane: hiddenCamera.plane,
     initialProjectionMatrixInverse: hiddenCamera.initialProjectionMatrixInverse,
     initialProjectionMatrix: hiddenCamera.initialProjectionMatrix,

--- a/examples/reprojection.html
+++ b/examples/reprojection.html
@@ -21,6 +21,9 @@
         "uniform sampler2D dTexture;",
         "uniform mat4 projectionMatrixInverse;",
         "uniform mat4 matrixWorldInverse;",
+        "uniform mat4 inverseMatrix;",
+        "uniform mat4 inverseMatrix2;",
+        "uniform mat4 initialProjectionMatrix;",
         "uniform float zNear;",
         "uniform float zFar;",
         "uniform float aspect;",
@@ -41,41 +44,14 @@
           float z_n = 2.0 * z_b - 1.0;
           float z_e = 2.0 * zNear * zFar / (zFar + zNear - z_n * (zFar - zNear));
           // float z_e = zNear + (z_b)*(zFar - zNear)
-          // vec4 lol = (matrixWorldInverse * projectionMatrixInverse * vec4(screen.xy, 0.0, 1.0));
-          // return vec4(screen.xy, (projectionMatrix * vec4(0.0, 0.0, 1.0-z_e, 1.0)).z, 1.0);
-          vec4 offset = projectionMatrix * vec4(0.0, 0.0, -z_e, 1.0);
-          return vec4(screen.xy, offset.z/offset.w, 1.0);
+          vec4 offset = initialProjectionMatrix * vec4(0.0, 0.0, -z_e, 1.0);
+          float z = offset.z/offset.w;
+          return projectionMatrix * modelViewMatrix * inverseMatrix2 * vec4(screen.xy, z, 1.0);
         }
         `,
         "void main(){",
-          // "gl_Position = vec4(position.xy, 1., 1.);",
           "gl_Position = screen2World(position.xy);",
           "vUv = uv;",
-        "}",
-
-      ].join("\n");
-
-      var defaultVertexShader2 = [
-
-        // "varying vec2 vUv;",
-        "uniform sampler2D dTexture;",
-        "uniform mat4 projectionMatrixInverse;",
-        `
-        /* vec4 screen2World(vec2 screen) {
-          // input: x_coord, y_coord
-          vec2 xy = (screen + 1.0) / 2.0; //in [0,1] range
-          // vec2 xy = screen;
-          vec4 v_screen = vec4(xy, texture2D(dTexture, xy).r, 1.0 );
-          vec4 v_homo = projectionMatrixInverse * 2.0*(v_screen-vec4(0.5));
-          // vec3 v_eye = v_homo.xyz / v_homo.w; //transfer from homogeneous coordinates
-          // return vec4(screen.xy, v_homo.z/v_homo.w, v_homo.w);
-          return modelViewMatrix * vec4(screen.xy, 0.0, 1.0);
-        } */
-        `,
-        "void main(){",
-          // "gl_Position = vec4(position.xy, 1., 1.);",
-          "gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);",
-          // "vUv = uv;",
         "}",
 
       ].join("\n");
@@ -88,17 +64,8 @@
         uniform sampler2D dTexture;
         void main() {
           vec4 c = texture2D(uTexture, vUv);
-          float d = (1.0 - texture2D(dTexture, vUv).r) * 10.0;
+          float d = (1.0 - texture2D(dTexture, vUv).r) * 20.0;
           gl_FragColor = vec4(vec3(d) * c.rgb, c.a);
-          // gl_FragColor.a = 1.0;
-        }`
-
-      ].join("\n");
-
-      var defaultFragmentShader2 = [
-
-        `void main() {
-          gl_FragColor = vec4(0.0, 0.0, 0.5, 0.1);
         }`
 
       ].join("\n");
@@ -130,6 +97,18 @@
               type:'m4',
               value: undefined !== params.matrixWorldInverse ? params.matrixWorldInverse : null
             },
+            inverseMatrix: {
+              type:'m4',
+              value: undefined !== params.inverseMatrix ? params.inverseMatrix : null
+            },
+            inverseMatrix2: {
+              type:'m4',
+              value: undefined !== params.inverseMatrix2 ? params.inverseMatrix2 : null
+            },
+            initialProjectionMatrix: {
+              type:'m4',
+              value: undefined !== params.initialProjectionMatrix ? params.initialProjectionMatrix : null
+            },
             zNear: {
               type:'f',
               value: undefined !== params.zNear ? params.zNear : null
@@ -144,9 +123,9 @@
             },
           },
 
-          vertexShader: params.lol ? defaultVertexShader : defaultVertexShader2,
+          vertexShader: defaultVertexShader,
 
-          fragmentShader: params.lol ? defaultFragmentShader : defaultFragmentShader2,
+          fragmentShader: defaultFragmentShader,
 
           // depthWrite: !params.lol,
 
@@ -219,6 +198,9 @@ function init() {
   hiddenScene.add(hiddenCamera);
   hiddenCamera.updateMatrixWorld();
   hiddenCamera.updateProjectionMatrix();
+  hiddenCamera.inverseMatrix = new THREE.Matrix4();
+  hiddenCamera.inverseMatrix2 = new THREE.Matrix4();
+  hiddenCamera.initialProjectionMatrix = new THREE.Matrix4();
 
   {
     const ambientLight = new THREE.AmbientLight(0x808080);
@@ -241,8 +223,6 @@ function init() {
     'attribute vec2 uv;',
     'varying vec2 vUv;',
     'void main() {',
-      // 'vec4 worldPosition = modelMatrix * vec4( position, 1.0 );',
-      // 'vWorldPosition = worldPosition.xyz;',
       'gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );',
       'vUv = uv;',
     '}'
@@ -250,19 +230,6 @@ function init() {
   const fragmentShader = [
     'sampler2D t;',
     'varying vec2 vUv;',
-    /* `
-    vec3 screen2screen(vec2 screen, mat4 transformMatrix) {
-      return transformMatrix * vec4(screen, 0.0, 1.0).xy;
-    }
-    vec3 screen2World(vec2 screen, mat4 projectionMatrixInverse, sampler2D samplerDepth) {
-      // input: x_coord, y_coord, samplerDepth
-      vec2 xy = vec2(screen.x,screen.y); //in [0,1] range
-      vec4 v_screen = vec4(xy, texture(samplerDepth, xy), 1.0 );
-      vec4 v_homo = projectionMatrixInverse * 2.0*(v_screen-vec4(0.5));
-      vec3 v_eye = v_homo.xyz / v_homo.w; //transfer from homogeneous coordinates
-      return v_eye;
-    }
-    ` */
     'void main() {',
       'gl_FragColor = texture2D(t, vUv);',
     '}'
@@ -270,7 +237,6 @@ function init() {
 
   const _makeBoxMesh = () => {
     const geometry = new THREE.BoxBufferGeometry(boxMeshSize, boxMeshSize, boxMeshSize);
-      // .applyMatrix(new THREE.Matrix4().makeTranslation(-planeWorldWidth/2, planeWorldHeight/2, boxMeshSize/2));
     const material = new THREE.MeshPhongMaterial({
       color: 0xFF0000,
     });
@@ -282,7 +248,6 @@ function init() {
     return mesh;
   };
   boxMesh = _makeBoxMesh();
-  // boxMesh.position.y = 0.1;
   boxMesh.position.z = -2;
   scene.add(boxMesh);
 
@@ -296,8 +261,6 @@ function init() {
   // renderTarget.transparent = false;
   renderTarget.depthTexture = new THREE.DepthTexture(window.innerWidth, window.innerHeight);
 
-  console.log('got render target', hiddenCamera);
-
   screenQuad = new ScreenQuad({
     texture: renderTarget.texture,
     depthTexture: renderTarget.depthTexture,
@@ -306,20 +269,12 @@ function init() {
     zNear: hiddenCamera.near,
     zFar: hiddenCamera.far,
     aspect: hiddenCamera.aspect,
+    inverseMatrix: hiddenCamera.inverseMatrix,
+    inverseMatrix2: hiddenCamera.inverseMatrix2,
+    initialProjectionMatrix: hiddenCamera.initialProjectionMatrix,
     lol: true,
   });
   scene.add(screenQuad);
-
-  /* const screenQuad2 = new ScreenQuad({
-    texture: renderTarget.texture,
-    depthTexture: renderTarget.depthTexture,
-    projectionMatrixInverse: hiddenCamera.projectionMatrixInverse,
-    matrixWorldInverse: hiddenCamera.matrixWorldInverse,
-    zNear: hiddenCamera.near,
-    zFar: hiddenCamera.far,
-    aspect: hiddenCamera.aspect,
-  });
-  scene.add(screenQuad2); */
 }
 
 init();
@@ -332,6 +287,18 @@ window.addEventListener('keydown', e => {
   hiddenCamera.position.copy(camera.position);
   hiddenCamera.quaternion.copy(camera.quaternion);
   hiddenCamera.scale.copy(camera.scale);
+  hiddenCamera.updateMatrixWorld();
+  hiddenCamera.updateProjectionMatrix();
+
+  screenQuad.position.copy(camera.position);
+  screenQuad.quaternion.copy(camera.quaternion);
+  screenQuad.scale.copy(camera.scale);
+  screenQuad.updateMatrixWorld();
+
+  hiddenCamera.inverseMatrix.copy(hiddenCamera.matrixWorld).multiply(screenQuad.matrixWorld);
+  hiddenCamera.inverseMatrix.getInverse(hiddenCamera.inverseMatrix);
+  hiddenCamera.inverseMatrix2.copy(hiddenCamera.projectionMatrixInverse);
+  hiddenCamera.initialProjectionMatrix.copy(hiddenCamera.projectionMatrix);
 
   renderer.render(hiddenScene, hiddenCamera, renderTarget);
   renderer.setRenderTarget(null);
@@ -340,7 +307,7 @@ window.addEventListener('keydown', e => {
 function animate(timestamp, frame) {
   boxMesh.rotation.x += 0.01;
   boxMesh.rotation.y += 0.01;
-  boxMesh.rotation.z += 0.01; 
+  boxMesh.rotation.z += 0.01;
 
   renderer.render(scene, camera);
 }

--- a/examples/reprojection.html
+++ b/examples/reprojection.html
@@ -27,7 +27,6 @@
         "uniform mat4 initialProjectionMatrix;",
         "uniform float zNear;",
         "uniform float zFar;",
-        "uniform vec2 size;",
         "uniform float aspect;",
         `
         void main() {
@@ -116,10 +115,6 @@
               type:'f',
               value: undefined !== params.zFar ? params.zFar : null
             },
-            size: {
-              type:'v2',
-              value: undefined !== params.size ? params.size : null
-            },
             aspect: {
               type:'f',
               value: undefined !== params.aspect ? params.aspect : null
@@ -200,7 +195,6 @@ function init() {
   hiddenCamera.inverseMatrix = new THREE.Matrix4();
   hiddenCamera.initialProjectionMatrixInverse = new THREE.Matrix4();
   hiddenCamera.initialProjectionMatrix = new THREE.Matrix4();
-  hiddenCamera.size = new THREE.Vector2();
 
   {
     const ambientLight = new THREE.AmbientLight(0x808080);
@@ -268,7 +262,6 @@ function init() {
     matrixWorldInverse: hiddenCamera.matrixWorldInverse,
     zNear: hiddenCamera.near,
     zFar: hiddenCamera.far,
-    size: hiddenCamera.size,
     aspect: hiddenCamera.aspect,
     inverseMatrix: hiddenCamera.inverseMatrix,
     initialProjectionMatrixInverse: hiddenCamera.initialProjectionMatrixInverse,
@@ -299,7 +292,6 @@ window.addEventListener('keydown', e => {
   hiddenCamera.inverseMatrix.getInverse(hiddenCamera.inverseMatrix);
   hiddenCamera.initialProjectionMatrixInverse.copy(hiddenCamera.projectionMatrixInverse);
   hiddenCamera.initialProjectionMatrix.copy(hiddenCamera.projectionMatrix);
-  hiddenCamera.size.set(renderTarget.width, renderTarget.height);
 
   renderer.render(hiddenScene, hiddenCamera, renderTarget);
   renderer.setRenderTarget(null);

--- a/examples/reprojection.html
+++ b/examples/reprojection.html
@@ -23,7 +23,7 @@
         "uniform mat4 projectionMatrixInverse;",
         "uniform mat4 matrixWorldInverse;",
         "uniform mat4 inverseMatrix;",
-        "uniform mat4 inverseMatrix2;",
+        "uniform mat4 initialProjectionMatrixInverse;",
         "uniform mat4 initialProjectionMatrix;",
         "uniform float zNear;",
         "uniform float zFar;",
@@ -37,7 +37,7 @@
           float z_e = -(2.0 * zNear * zFar / (zFar + zNear - z_n * (zFar - zNear)));
           float zOrig = z_e;
           vec4 offset = initialProjectionMatrix * vec4(0.0, 0.0, z_e, 1.0);
-          vec4 worldPosOrig = inverseMatrix2 * vec4(position.xy, offset.z/offset.w, 1.0);
+          vec4 worldPosOrig = initialProjectionMatrixInverse * vec4(position.xy, offset.z/offset.w, 1.0);
           float zNew = worldPosOrig.z/worldPosOrig.w;
           vec4 worldPosNew = modelViewMatrix * worldPosOrig;
           gl_Position = projectionMatrix * worldPosNew;
@@ -100,9 +100,9 @@
               type:'m4',
               value: undefined !== params.inverseMatrix ? params.inverseMatrix : null
             },
-            inverseMatrix2: {
+            initialProjectionMatrixInverse: {
               type:'m4',
-              value: undefined !== params.inverseMatrix2 ? params.inverseMatrix2 : null
+              value: undefined !== params.initialProjectionMatrixInverse ? params.initialProjectionMatrixInverse : null
             },
             initialProjectionMatrix: {
               type:'m4',
@@ -198,7 +198,7 @@ function init() {
   hiddenCamera.updateMatrixWorld();
   hiddenCamera.updateProjectionMatrix();
   hiddenCamera.inverseMatrix = new THREE.Matrix4();
-  hiddenCamera.inverseMatrix2 = new THREE.Matrix4();
+  hiddenCamera.initialProjectionMatrixInverse = new THREE.Matrix4();
   hiddenCamera.initialProjectionMatrix = new THREE.Matrix4();
   hiddenCamera.size = new THREE.Vector2();
 
@@ -271,7 +271,7 @@ function init() {
     size: hiddenCamera.size,
     aspect: hiddenCamera.aspect,
     inverseMatrix: hiddenCamera.inverseMatrix,
-    inverseMatrix2: hiddenCamera.inverseMatrix2,
+    initialProjectionMatrixInverse: hiddenCamera.initialProjectionMatrixInverse,
     initialProjectionMatrix: hiddenCamera.initialProjectionMatrix,
   });
   scene.add(screenQuad);
@@ -297,7 +297,7 @@ window.addEventListener('keydown', e => {
 
   hiddenCamera.inverseMatrix.copy(hiddenCamera.matrixWorld).multiply(screenQuad.matrixWorld);
   hiddenCamera.inverseMatrix.getInverse(hiddenCamera.inverseMatrix);
-  hiddenCamera.inverseMatrix2.copy(hiddenCamera.projectionMatrixInverse);
+  hiddenCamera.initialProjectionMatrixInverse.copy(hiddenCamera.projectionMatrixInverse);
   hiddenCamera.initialProjectionMatrix.copy(hiddenCamera.projectionMatrix);
   hiddenCamera.size.set(renderTarget.width, renderTarget.height);
 

--- a/examples/reprojection.html
+++ b/examples/reprojection.html
@@ -27,7 +27,6 @@
         "uniform mat4 initialProjectionMatrix;",
         "uniform float zNear;",
         "uniform float zFar;",
-        "uniform float aspect;",
         `
         void main() {
           vec2 xy = (position.xy + 1.0) / 2.0; //in [0,1] range
@@ -114,10 +113,6 @@
             zFar: {
               type:'f',
               value: undefined !== params.zFar ? params.zFar : null
-            },
-            aspect: {
-              type:'f',
-              value: undefined !== params.aspect ? params.aspect : null
             },
           },
 
@@ -262,7 +257,6 @@ function init() {
     matrixWorldInverse: hiddenCamera.matrixWorldInverse,
     zNear: hiddenCamera.near,
     zFar: hiddenCamera.far,
-    aspect: hiddenCamera.aspect,
     inverseMatrix: hiddenCamera.inverseMatrix,
     initialProjectionMatrixInverse: hiddenCamera.initialProjectionMatrixInverse,
     initialProjectionMatrix: hiddenCamera.initialProjectionMatrix,

--- a/examples/reprojection.html
+++ b/examples/reprojection.html
@@ -266,11 +266,7 @@ function init() {
 
 init();
 
-window.addEventListener('keydown', e => {
-  boxMesh2.position.copy(boxMesh.position);
-  boxMesh2.quaternion.copy(boxMesh.quaternion);
-  boxMesh2.scale.copy(boxMesh.scale);
-
+const _renderFrame = () => {
   hiddenCamera.position.copy(camera.position);
   hiddenCamera.quaternion.copy(camera.quaternion);
   hiddenCamera.scale.copy(camera.scale);
@@ -289,12 +285,19 @@ window.addEventListener('keydown', e => {
 
   renderer.render(hiddenScene, hiddenCamera, renderTarget);
   renderer.setRenderTarget(null);
-});
+
+  setTimeout(_renderFrame, 2000);
+};
+_renderFrame();
 
 function animate(timestamp, frame) {
   boxMesh.rotation.x += 0.01;
   boxMesh.rotation.y += 0.01;
   boxMesh.rotation.z += 0.01;
+
+  boxMesh2.position.copy(boxMesh.position);
+  boxMesh2.quaternion.copy(boxMesh.quaternion);
+  boxMesh2.scale.copy(boxMesh.scale);
 
   renderer.render(scene, camera);
 }

--- a/examples/reprojection.html
+++ b/examples/reprojection.html
@@ -37,10 +37,11 @@
           vec4 offset = initialProjectionMatrix * vec4(0.0, 0.0, z_e, 1.0);
           vec4 worldPosOrig = initialProjectionMatrixInverse * vec4(position.xy, offset.z/offset.w, 1.0);
           float zNew = worldPosOrig.z/worldPosOrig.w;
-          vec4 worldPosNew = modelViewMatrix * worldPosOrig;
+          vec4 worldPosNew = modelMatrix * worldPosOrig;
+          vec4 viewPosNew = viewMatrix * worldPosNew;
 
-          gl_Position = projectionMatrix * worldPosNew;
-          vViewPosition = worldPosNew.xyz;
+          gl_Position = projectionMatrix * viewPosNew;
+          vViewPosition = -worldPosNew.xyz;
           vUv = uv;
           vZDiff = abs(zNew - zOrig);
         }
@@ -59,7 +60,7 @@
         uniform sampler2D dTexture;
         uniform vec4 plane;
         void main() {
-          if (vZDiff < 0.0001 && dot(vViewPosition, plane.xyz) > plane.w) {
+          if (vZDiff < 0.0001 && dot(vViewPosition, plane.xyz) <= plane.w) {
             vec4 c = texture2D(uTexture, vUv);
             float dc = (1.0 - texture2D(dTexture, vUv).r) * 20.0;
             gl_FragColor = vec4(vec3(dc) * c.rgb, c.a);
@@ -190,7 +191,7 @@ function init() {
   hiddenCamera.inverseMatrix = new THREE.Matrix4();
   hiddenCamera.initialProjectionMatrixInverse = new THREE.Matrix4();
   hiddenCamera.initialProjectionMatrix = new THREE.Matrix4();
-  hiddenCamera.plane = new THREE.Vector4(0, 1, 0, 1);
+  hiddenCamera.plane = new THREE.Vector4(0, 1, 0, 0);
 
   {
     const ambientLight = new THREE.AmbientLight(0x808080);

--- a/examples/reprojection.html
+++ b/examples/reprojection.html
@@ -1,9 +1,179 @@
 <!doctype html>
 <html>
+  <head>
+    <style>
+      body {
+        margin: 0;
+      }
+    </style>
+  </head>
   <body>
     <script src="three.js"></script>
+    <script src="OrbitControls.js"></script>
     <script>
-let renderer, scene, hiddenScene, camera, iframe, planeMesh, renderTarget;
+ window.ScreenQuad = (() => {
+
+      var defaultQuad = new THREE.PlaneBufferGeometry(2,2,1000, 1000);
+
+      var defaultVertexShader = [
+
+        "varying vec2 vUv;",
+        "uniform sampler2D dTexture;",
+        "uniform mat4 projectionMatrixInverse;",
+        "uniform mat4 matrixWorldInverse;",
+        "uniform float zNear;",
+        "uniform float zFar;",
+        "uniform float aspect;",
+        `
+        /* vec4 screen2WorldOld(vec2 screen) {
+          // input: x_coord, y_coord
+          vec2 xy = (screen + 1.0) / 2.0; //in [0,1] range
+          // vec2 xy = screen;
+          vec4 v_screen = vec4(xy, texture2D(dTexture, xy).r, 1.0 );
+          vec4 v_homo = projectionMatrixInverse * 2.0*(v_screen-vec4(0.5));
+          // vec3 v_eye = v_homo.xyz / v_homo.w; //transfer from homogeneous coordinates
+          // return vec4(screen.xy, v_homo.z/v_homo.w, v_homo.w);
+          return modelViewMatrix * vec4(screen.xy, v_homo.z/v_homo.w, 1.0);
+        } */
+        vec4 screen2World(vec2 screen) {
+          vec2 xy = (screen + 1.0) / 2.0; //in [0,1] range
+          float z_b = texture2D(dTexture, xy).r;
+          float z_n = 2.0 * z_b - 1.0;
+          float z_e = 2.0 * zNear * zFar / (zFar + zNear - z_n * (zFar - zNear));
+          // float z_e = zNear + (z_b)*(zFar - zNear)
+          // vec4 lol = (matrixWorldInverse * projectionMatrixInverse * vec4(screen.xy, 0.0, 1.0));
+          // return vec4(screen.xy, (projectionMatrix * vec4(0.0, 0.0, 1.0-z_e, 1.0)).z, 1.0);
+          vec4 offset = projectionMatrix * vec4(0.0, 0.0, -z_e, 1.0);
+          return vec4(screen.xy, offset.z/offset.w, 1.0);
+        }
+        `,
+        "void main(){",
+          // "gl_Position = vec4(position.xy, 1., 1.);",
+          "gl_Position = screen2World(position.xy);",
+          "vUv = uv;",
+        "}",
+
+      ].join("\n");
+
+      var defaultVertexShader2 = [
+
+        // "varying vec2 vUv;",
+        "uniform sampler2D dTexture;",
+        "uniform mat4 projectionMatrixInverse;",
+        `
+        /* vec4 screen2World(vec2 screen) {
+          // input: x_coord, y_coord
+          vec2 xy = (screen + 1.0) / 2.0; //in [0,1] range
+          // vec2 xy = screen;
+          vec4 v_screen = vec4(xy, texture2D(dTexture, xy).r, 1.0 );
+          vec4 v_homo = projectionMatrixInverse * 2.0*(v_screen-vec4(0.5));
+          // vec3 v_eye = v_homo.xyz / v_homo.w; //transfer from homogeneous coordinates
+          // return vec4(screen.xy, v_homo.z/v_homo.w, v_homo.w);
+          return modelViewMatrix * vec4(screen.xy, 0.0, 1.0);
+        } */
+        `,
+        "void main(){",
+          // "gl_Position = vec4(position.xy, 1., 1.);",
+          "gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);",
+          // "vUv = uv;",
+        "}",
+
+      ].join("\n");
+
+      var defaultFragmentShader = [
+
+        `varying vec2 vUv;
+        uniform float numTextures;
+        uniform sampler2D uTexture;
+        uniform sampler2D dTexture;
+        void main() {
+          vec4 c = texture2D(uTexture, vUv);
+          float d = (1.0 - texture2D(dTexture, vUv).r) * 10.0;
+          gl_FragColor = vec4(vec3(d) * c.rgb, c.a);
+          // gl_FragColor.a = 1.0;
+        }`
+
+      ].join("\n");
+
+      var defaultFragmentShader2 = [
+
+        `void main() {
+          gl_FragColor = vec4(0.0, 0.0, 0.5, 0.1);
+        }`
+
+      ].join("\n");
+
+      function ScreenQuad( params ){
+
+        params = params || {};
+
+        THREE.Mesh.apply( this, [ defaultQuad , new THREE.ShaderMaterial({
+
+          uniforms:{
+            numTextures: {
+              type: 'f',
+              value: undefined !== params.numTextures ? params.numTextures : 1
+            },
+            uTexture: {
+              type:'t',
+              value: undefined !== params.texture ? params.texture : null
+            },
+            dTexture: {
+              type:'t',
+              value: undefined !== params.depthTexture ? params.depthTexture : null
+            },
+            projectionMatrixInverse: {
+              type:'m4',
+              value: undefined !== params.projectionMatrixInverse ? params.projectionMatrixInverse : null
+            },
+            matrixWorldInverse: {
+              type:'m4',
+              value: undefined !== params.matrixWorldInverse ? params.matrixWorldInverse : null
+            },
+            zNear: {
+              type:'f',
+              value: undefined !== params.zNear ? params.zNear : null
+            },
+            zFar: {
+              type:'f',
+              value: undefined !== params.zFar ? params.zFar : null
+            },
+            aspect: {
+              type:'f',
+              value: undefined !== params.aspect ? params.aspect : null
+            },
+          },
+
+          vertexShader: params.lol ? defaultVertexShader : defaultVertexShader2,
+
+          fragmentShader: params.lol ? defaultFragmentShader : defaultFragmentShader2,
+
+          // depthWrite: !params.lol,
+
+          transparent: true,
+
+        })]);
+
+        this.frustumCulled = false;
+
+        this.renderOrder = -1;
+
+        //end mesh setup
+
+        // console.log( this , this.width , this.height );
+
+      }
+
+      ScreenQuad.prototype = Object.create( THREE.Mesh.prototype );
+
+      ScreenQuad.constructor = ScreenQuad;
+
+      return ScreenQuad
+
+})();
+    </script>
+    <script>
+let renderer, scene, hiddenScene, camera, hiddenCamera, iframe, boxMesh, boxMesh2, renderTarget, screenQuad;
 
 const localVector = new THREE.Vector3();
 const localVector2 = new THREE.Vector3();
@@ -15,7 +185,7 @@ const localLine2 = new THREE.Line3();
 
 const planeWorldWidth = 0.9;
 const planeWorldHeight = 0.9;
-const boxMeshSize = 0.02;
+const boxMeshSize = 1;
 const planeWidth = 1280;
 const planeHeight = 1024;
 
@@ -39,7 +209,33 @@ function init() {
   hiddenScene.matrixAutoUpdate = false;
 
   camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
-  hiddenScene.add(camera);
+  camera.position.z = 1;
+  scene.add(camera);
+
+  new THREE.OrbitControls(camera);
+
+  hiddenCamera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
+  hiddenCamera.position.copy(camera.position);
+  hiddenScene.add(hiddenCamera);
+  hiddenCamera.updateMatrixWorld();
+  hiddenCamera.updateProjectionMatrix();
+
+  {
+    const ambientLight = new THREE.AmbientLight(0x808080);
+    scene.add(ambientLight);
+
+    const directionalLight = new THREE.DirectionalLight(0xFFFFFF, 1);
+    directionalLight.position.set(1, 1, 1);
+    scene.add(directionalLight);
+  }
+  {
+    const ambientLight = new THREE.AmbientLight(0x808080);
+    hiddenScene.add(ambientLight);
+
+    const directionalLight = new THREE.DirectionalLight(0xFFFFFF, 1);
+    directionalLight.position.set(1, 1, 1);
+    hiddenScene.add(directionalLight);
+  }
 
   const vertexShader = [
     'attribute vec2 uv;',
@@ -54,101 +250,97 @@ function init() {
   const fragmentShader = [
     'sampler2D t;',
     'varying vec2 vUv;',
+    /* `
+    vec3 screen2screen(vec2 screen, mat4 transformMatrix) {
+      return transformMatrix * vec4(screen, 0.0, 1.0).xy;
+    }
+    vec3 screen2World(vec2 screen, mat4 projectionMatrixInverse, sampler2D samplerDepth) {
+      // input: x_coord, y_coord, samplerDepth
+      vec2 xy = vec2(screen.x,screen.y); //in [0,1] range
+      vec4 v_screen = vec4(xy, texture(samplerDepth, xy), 1.0 );
+      vec4 v_homo = projectionMatrixInverse * 2.0*(v_screen-vec4(0.5));
+      vec3 v_eye = v_homo.xyz / v_homo.w; //transfer from homogeneous coordinates
+      return v_eye;
+    }
+    ` */
     'void main() {',
       'gl_FragColor = texture2D(t, vUv);',
     '}'
   ].join('\n');
 
-  planeMesh = (() => {
-    const geometry = new THREE.PlaneBufferGeometry(planeWorldWidth, planeWorldHeight)
-      // .applyMatrix(new THREE.Matrix4().makeScale(-1, -1, 1));
-    const uvs = geometry.attributes.uv.array;
-    const numUvs = uvs.length / 2;
-    for (let i = 0; i < numUvs; i++) {
-      uvs[i*2+1] = 1 - uvs[i*2+1];
-    }
-    /* const material = new THREE.MeshPhongMaterial({
-      color: 0xFFFF00,
-    }); */
-    const texture = new THREE.Texture(
-      null,
-      THREE.UVMapping,
-      THREE.ClampToEdgeWrapping,
-      THREE.ClampToEdgeWrapping,
-      THREE.NearestFilter,
-      THREE.NearestFilter,
-      THREE.RGBAFormat,
-      THREE.UnsignedByteType,
-      16
-    );
-    const properties = renderer.properties.get(texture);
-    properties.__webglTexture = iframe.texture;
-    properties.__webglInit = true;
-    const material = new THREE.MeshBasicMaterial({
-      map: texture,
-    });
-    const mesh = new THREE.Mesh(geometry, material);
-    mesh.position.z = -1;
-    mesh.projectMouse = (x, y) => {
-      const leftLine = localLine;
-      const topLine = localLine2;
-      const plane = localPlane;
-
-      leftLine.start
-        .set(-planeWorldWidth/2, planeWorldHeight/2, 0)
-        .applyMatrix4(mesh.matrixWorld);
-      leftLine.end
-        .set(-planeWorldWidth/2, -planeWorldHeight/2, 0)
-        .applyMatrix4(mesh.matrixWorld);
-
-      topLine.start
-        .set(-planeWorldWidth/2, planeWorldHeight/2, 0)
-        .applyMatrix4(mesh.matrixWorld);
-      topLine.end
-        .set(planeWorldWidth/2, planeWorldHeight / 2, 0)
-        .applyMatrix4(mesh.matrixWorld);
-
-      plane.setFromCoplanarPoints(
-        leftLine.start,
-        leftLine.end,
-        topLine.end
-      );
-    };
-
-    return mesh;
-  })();
-  hiddenScene.add(planeMesh);
-
-  const boxMesh = (() => {
+  const _makeBoxMesh = () => {
     const geometry = new THREE.BoxBufferGeometry(boxMeshSize, boxMeshSize, boxMeshSize);
       // .applyMatrix(new THREE.Matrix4().makeTranslation(-planeWorldWidth/2, planeWorldHeight/2, boxMeshSize/2));
     const material = new THREE.MeshPhongMaterial({
       color: 0xFF0000,
     });
     const mesh = new THREE.Mesh(geometry, material);
+    mesh.rotation.x = Math.PI / 4;
+    mesh.rotation.y = Math.PI / 4;
+    mesh.rotation.z = Math.PI / 4;
+    mesh.rotation.order = 'YXZ';
     return mesh;
-  })();
-  hiddenScene.add(boxMesh);
+  };
+  boxMesh = _makeBoxMesh();
+  // boxMesh.position.y = 0.1;
+  boxMesh.position.z = -2;
+  scene.add(boxMesh);
+
+  boxMesh2 = _makeBoxMesh();
+  boxMesh2.position.z = -2;
+  hiddenScene.add(boxMesh2);
 
   renderTarget = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight, {
     format: THREE.RGBAFormat,
   });
   // renderTarget.transparent = false;
+  renderTarget.depthTexture = new THREE.DepthTexture(window.innerWidth, window.innerHeight);
 
-  const mesh = new THREE.Mesh(
-    new THREE.PlaneBufferGeometry(0.1, 0.1)
-      .applyMatrix(new THREE.Matrix4().makeTranslation(0, 0.1/2, 0.01)),
-    new THREE.MeshBasicMaterial({
-      // color: 0x0000FF,
-      map: renderTarget.texture,
-    })
-  );
+  console.log('got render target', hiddenCamera);
+
+  screenQuad = new ScreenQuad({
+    texture: renderTarget.texture,
+    depthTexture: renderTarget.depthTexture,
+    projectionMatrixInverse: hiddenCamera.projectionMatrixInverse,
+    matrixWorldInverse: hiddenCamera.matrixWorldInverse,
+    zNear: hiddenCamera.near,
+    zFar: hiddenCamera.far,
+    aspect: hiddenCamera.aspect,
+    lol: true,
+  });
+  scene.add(screenQuad);
+
+  /* const screenQuad2 = new ScreenQuad({
+    texture: renderTarget.texture,
+    depthTexture: renderTarget.depthTexture,
+    projectionMatrixInverse: hiddenCamera.projectionMatrixInverse,
+    matrixWorldInverse: hiddenCamera.matrixWorldInverse,
+    zNear: hiddenCamera.near,
+    zFar: hiddenCamera.far,
+    aspect: hiddenCamera.aspect,
+  });
+  scene.add(screenQuad2); */
 }
 
 init();
 
+window.addEventListener('keydown', e => {
+  boxMesh2.position.copy(boxMesh.position);
+  boxMesh2.quaternion.copy(boxMesh.quaternion);
+  boxMesh2.scale.copy(boxMesh.scale);
+
+  hiddenCamera.position.copy(camera.position);
+  hiddenCamera.quaternion.copy(camera.quaternion);
+  hiddenCamera.scale.copy(camera.scale);
+
+  renderer.render(hiddenScene, hiddenCamera, renderTarget);
+  renderer.setRenderTarget(null);
+});
+
 function animate(timestamp, frame) {
-  renderer.render(hiddenScene, camera, renderTarget);
+  boxMesh.rotation.x += 0.01;
+  boxMesh.rotation.y += 0.01;
+  boxMesh.rotation.z += 0.01; 
 
   renderer.render(scene, camera);
 }

--- a/examples/reprojection.html
+++ b/examples/reprojection.html
@@ -13,7 +13,7 @@
     <script>
  window.ScreenQuad = (() => {
 
-      const defaultQuad = new THREE.PlaneBufferGeometry(2, 2, 1000, 1000);
+      const defaultQuad = new THREE.PlaneBufferGeometry(2, 2, window.innerWidth, window.innerHeight);
       const vertexShader = `\
         varying vec3 vViewPosition;
         varying vec2 vUv;

--- a/examples/reprojection.html
+++ b/examples/reprojection.html
@@ -20,8 +20,6 @@
         "varying vec2 vUv;",
         "varying float vZDiff;",
         "uniform sampler2D dTexture;",
-        "uniform mat4 projectionMatrixInverse;",
-        "uniform mat4 matrixWorldInverse;",
         "uniform mat4 inverseMatrix;",
         "uniform mat4 initialProjectionMatrixInverse;",
         "uniform mat4 initialProjectionMatrix;",
@@ -85,14 +83,6 @@
             dTexture: {
               type:'t',
               value: undefined !== params.depthTexture ? params.depthTexture : null
-            },
-            projectionMatrixInverse: {
-              type:'m4',
-              value: undefined !== params.projectionMatrixInverse ? params.projectionMatrixInverse : null
-            },
-            matrixWorldInverse: {
-              type:'m4',
-              value: undefined !== params.matrixWorldInverse ? params.matrixWorldInverse : null
             },
             inverseMatrix: {
               type:'m4',
@@ -253,8 +243,6 @@ function init() {
   screenQuad = new ScreenQuad({
     texture: renderTarget.texture,
     depthTexture: renderTarget.depthTexture,
-    projectionMatrixInverse: hiddenCamera.projectionMatrixInverse,
-    matrixWorldInverse: hiddenCamera.matrixWorldInverse,
     zNear: hiddenCamera.near,
     zFar: hiddenCamera.far,
     inverseMatrix: hiddenCamera.inverseMatrix,

--- a/examples/reprojection.html
+++ b/examples/reprojection.html
@@ -30,69 +30,8 @@
         "uniform vec2 size;",
         "uniform float aspect;",
         `
-        float depthLimit = 0.95;
-        float getDepth(vec2 xy) {
-          float dx = 1.0/size.x;
-          float dy = 1.0/size.y;
-
-          float value = 0.0;
-          float count = 0.0;
-
-          float d = texture2D(dTexture, xy + vec2(-dx, -dy)).r;
-          if (d > depthLimit) {
-            value += d;
-            count++;
-          }
-          d = texture2D(dTexture, xy + vec2(0.0, -dy)).r;
-          if (d > depthLimit) {
-            value += d;
-            count++;
-          }
-          d = texture2D(dTexture, xy + vec2(dx, -dy)).r;
-          if (d > depthLimit) {
-            value += d;
-            count++;
-          }
-          d = texture2D(dTexture, xy + vec2(-dx, 0.0)).r;
-          if (d > depthLimit) {
-            value += d;
-            count++;
-          }
-          d = texture2D(dTexture, xy + vec2(dx, 0.0)).r;
-          if (d > depthLimit) {
-            value += d;
-            count++;
-          }
-          d = texture2D(dTexture, xy + vec2(-dx, dy)).r;
-          if (d > depthLimit) {
-            value += d;
-            count++;
-          }
-          d = texture2D(dTexture, xy + vec2(0.0, dy)).r;
-          if (d > depthLimit) {
-            value += d;
-            count++;
-          }
-          d = texture2D(dTexture, xy + vec2(dx, dy)).r;
-          if (d > depthLimit) {
-            value += d;
-            count++;
-          }
-          d = texture2D(dTexture, xy + vec2(0.0, 0.0)).r;
-          if (d > depthLimit) {
-            value += d;
-            count++;
-          }
-
-          if (count > 0.0) {
-            return d;
-          } else {
-            return 100.0;
-          }
-        }
         void main() {
           vec2 xy = (position.xy + 1.0) / 2.0; //in [0,1] range
-          // float z_b = getDepth(xy);
           float z_b = texture2D(dTexture, xy).r;
           float z_n = 2.0 * z_b - 1.0;
           float z_e = -(2.0 * zNear * zFar / (zFar + zNear - z_n * (zFar - zNear)));
@@ -191,8 +130,6 @@
 
           fragmentShader: defaultFragmentShader,
 
-          // depthWrite: !params.lol,
-
           transparent: true,
 
         })]);
@@ -202,8 +139,6 @@
         this.renderOrder = -1;
 
         //end mesh setup
-
-        // console.log( this , this.width , this.height );
 
       }
 
@@ -338,7 +273,6 @@ function init() {
     inverseMatrix: hiddenCamera.inverseMatrix,
     inverseMatrix2: hiddenCamera.inverseMatrix2,
     initialProjectionMatrix: hiddenCamera.initialProjectionMatrix,
-    lol: true,
   });
   scene.add(screenQuad);
 }

--- a/examples/reprojection.html
+++ b/examples/reprojection.html
@@ -13,21 +13,18 @@
     <script>
  window.ScreenQuad = (() => {
 
-      var defaultQuad = new THREE.PlaneBufferGeometry(2,2,1000, 1000);
-
-      var defaultVertexShader = [
-
-        "varying vec3 vViewPosition;",
-        "varying vec2 vUv;",
-        "varying float vZDiff;",
-        "uniform sampler2D dTexture;",
-        "uniform mat4 inverseMatrix;",
-        "uniform mat4 initialProjectionMatrixInverse;",
-        "uniform mat4 initialProjectionMatrix;",
-        "uniform float zNear;",
-        "uniform float zFar;",
-        "uniform vec4 plane;",
-        `
+      const defaultQuad = new THREE.PlaneBufferGeometry(2, 2, 1000, 1000);
+      const vertexShader = `\
+        varying vec3 vViewPosition;
+        varying vec2 vUv;
+        varying float vZDiff;
+        uniform sampler2D dTexture;
+        uniform mat4 inverseMatrix;
+        uniform mat4 initialProjectionMatrixInverse;
+        uniform mat4 initialProjectionMatrix;
+        uniform float zNear;
+        uniform float zFar;
+        uniform vec4 plane;
         void main() {
           vec2 xy = (position.xy + 1.0) / 2.0; //in [0,1] range
           float z_b = texture2D(dTexture, xy).r;
@@ -45,13 +42,8 @@
           vUv = uv;
           vZDiff = abs(zNew - zOrig);
         }
-        `,
-
-      ].join("\n");
-
-      var defaultFragmentShader = [
-
-        `
+      `;
+      const fragmentShader = `\
         varying vec3 vViewPosition;
         varying vec2 vUv;
         varying float vZDiff;
@@ -68,9 +60,7 @@
             discard;
           }
         }
-        `
-
-      ].join("\n");
+      `;
 
       function ScreenQuad( params ){
 
@@ -117,9 +107,9 @@
             },
           },
 
-          vertexShader: defaultVertexShader,
+          vertexShader,
 
-          fragmentShader: defaultFragmentShader,
+          fragmentShader,
 
           transparent: true,
 

--- a/examples/reprojection.html
+++ b/examples/reprojection.html
@@ -18,6 +18,7 @@
       var defaultVertexShader = [
 
         "varying vec2 vUv;",
+        "varying float vZDiff;",
         "uniform sampler2D dTexture;",
         "uniform mat4 projectionMatrixInverse;",
         "uniform mat4 matrixWorldInverse;",
@@ -26,47 +27,106 @@
         "uniform mat4 initialProjectionMatrix;",
         "uniform float zNear;",
         "uniform float zFar;",
+        "uniform vec2 size;",
         "uniform float aspect;",
         `
-        /* vec4 screen2WorldOld(vec2 screen) {
-          // input: x_coord, y_coord
-          vec2 xy = (screen + 1.0) / 2.0; //in [0,1] range
-          // vec2 xy = screen;
-          vec4 v_screen = vec4(xy, texture2D(dTexture, xy).r, 1.0 );
-          vec4 v_homo = projectionMatrixInverse * 2.0*(v_screen-vec4(0.5));
-          // vec3 v_eye = v_homo.xyz / v_homo.w; //transfer from homogeneous coordinates
-          // return vec4(screen.xy, v_homo.z/v_homo.w, v_homo.w);
-          return modelViewMatrix * vec4(screen.xy, v_homo.z/v_homo.w, 1.0);
-        } */
-        vec4 screen2World(vec2 screen) {
-          vec2 xy = (screen + 1.0) / 2.0; //in [0,1] range
+        float depthLimit = 0.95;
+        float getDepth(vec2 xy) {
+          float dx = 1.0/size.x;
+          float dy = 1.0/size.y;
+
+          float value = 0.0;
+          float count = 0.0;
+
+          float d = texture2D(dTexture, xy + vec2(-dx, -dy)).r;
+          if (d > depthLimit) {
+            value += d;
+            count++;
+          }
+          d = texture2D(dTexture, xy + vec2(0.0, -dy)).r;
+          if (d > depthLimit) {
+            value += d;
+            count++;
+          }
+          d = texture2D(dTexture, xy + vec2(dx, -dy)).r;
+          if (d > depthLimit) {
+            value += d;
+            count++;
+          }
+          d = texture2D(dTexture, xy + vec2(-dx, 0.0)).r;
+          if (d > depthLimit) {
+            value += d;
+            count++;
+          }
+          d = texture2D(dTexture, xy + vec2(dx, 0.0)).r;
+          if (d > depthLimit) {
+            value += d;
+            count++;
+          }
+          d = texture2D(dTexture, xy + vec2(-dx, dy)).r;
+          if (d > depthLimit) {
+            value += d;
+            count++;
+          }
+          d = texture2D(dTexture, xy + vec2(0.0, dy)).r;
+          if (d > depthLimit) {
+            value += d;
+            count++;
+          }
+          d = texture2D(dTexture, xy + vec2(dx, dy)).r;
+          if (d > depthLimit) {
+            value += d;
+            count++;
+          }
+          d = texture2D(dTexture, xy + vec2(0.0, 0.0)).r;
+          if (d > depthLimit) {
+            value += d;
+            count++;
+          }
+
+          if (count > 0.0) {
+            return d;
+          } else {
+            return 100.0;
+          }
+        }
+        void main() {
+          vec2 xy = (position.xy + 1.0) / 2.0; //in [0,1] range
+          // float z_b = getDepth(xy);
           float z_b = texture2D(dTexture, xy).r;
           float z_n = 2.0 * z_b - 1.0;
-          float z_e = 2.0 * zNear * zFar / (zFar + zNear - z_n * (zFar - zNear));
-          // float z_e = zNear + (z_b)*(zFar - zNear)
-          vec4 offset = initialProjectionMatrix * vec4(0.0, 0.0, -z_e, 1.0);
-          float z = offset.z/offset.w;
-          return projectionMatrix * modelViewMatrix * inverseMatrix2 * vec4(screen.xy, z, 1.0);
+          float z_e = -(2.0 * zNear * zFar / (zFar + zNear - z_n * (zFar - zNear)));
+          float zOrig = z_e;
+          vec4 offset = initialProjectionMatrix * vec4(0.0, 0.0, z_e, 1.0);
+          vec4 worldPosOrig = inverseMatrix2 * vec4(position.xy, offset.z/offset.w, 1.0);
+          float zNew = worldPosOrig.z/worldPosOrig.w;
+          vec4 worldPosNew = modelViewMatrix * worldPosOrig;
+          gl_Position = projectionMatrix * worldPosNew;
+          vUv = uv;
+          vZDiff = abs(zNew - zOrig);
         }
         `,
-        "void main(){",
-          "gl_Position = screen2World(position.xy);",
-          "vUv = uv;",
-        "}",
 
       ].join("\n");
 
       var defaultFragmentShader = [
 
-        `varying vec2 vUv;
+        `
+        varying vec2 vUv;
+        varying float vZDiff;
         uniform float numTextures;
         uniform sampler2D uTexture;
         uniform sampler2D dTexture;
         void main() {
-          vec4 c = texture2D(uTexture, vUv);
-          float d = (1.0 - texture2D(dTexture, vUv).r) * 20.0;
-          gl_FragColor = vec4(vec3(d) * c.rgb, c.a);
-        }`
+          if (vZDiff < 0.0001) {
+            vec4 c = texture2D(uTexture, vUv);
+            float dc = (1.0 - texture2D(dTexture, vUv).r) * 20.0;
+            gl_FragColor = vec4(vec3(dc) * c.rgb, c.a);
+          } else {
+            discard;
+          }
+        }
+        `
 
       ].join("\n");
 
@@ -116,6 +176,10 @@
             zFar: {
               type:'f',
               value: undefined !== params.zFar ? params.zFar : null
+            },
+            size: {
+              type:'v2',
+              value: undefined !== params.size ? params.size : null
             },
             aspect: {
               type:'f',
@@ -201,6 +265,7 @@ function init() {
   hiddenCamera.inverseMatrix = new THREE.Matrix4();
   hiddenCamera.inverseMatrix2 = new THREE.Matrix4();
   hiddenCamera.initialProjectionMatrix = new THREE.Matrix4();
+  hiddenCamera.size = new THREE.Vector2();
 
   {
     const ambientLight = new THREE.AmbientLight(0x808080);
@@ -268,6 +333,7 @@ function init() {
     matrixWorldInverse: hiddenCamera.matrixWorldInverse,
     zNear: hiddenCamera.near,
     zFar: hiddenCamera.far,
+    size: hiddenCamera.size,
     aspect: hiddenCamera.aspect,
     inverseMatrix: hiddenCamera.inverseMatrix,
     inverseMatrix2: hiddenCamera.inverseMatrix2,
@@ -299,6 +365,7 @@ window.addEventListener('keydown', e => {
   hiddenCamera.inverseMatrix.getInverse(hiddenCamera.inverseMatrix);
   hiddenCamera.inverseMatrix2.copy(hiddenCamera.projectionMatrixInverse);
   hiddenCamera.initialProjectionMatrix.copy(hiddenCamera.projectionMatrix);
+  hiddenCamera.size.set(renderTarget.width, renderTarget.height);
 
   renderer.render(hiddenScene, hiddenCamera, renderTarget);
   renderer.setRenderTarget(null);


### PR DESCRIPTION
Adds a frame reprojection shader example to `examples`. The intent is for this to be a testbed for actual frame reprojection support in exokit code.

The main use case for this is the scenario where many reality tabs are composited and not all can keep up. In those cases, we can reproject older reality tab framebuffers (with depth) so that the fast reality tabs are not held up.

This is a universal feature of VR platforms, but since in this instance we _are_ the VR platform and we wrote out own timing and compositor, we need to also handle the reprojection frame-perfectly.

The style of this reprojection shader is the one used on recent versions of OpenVR, where we re-swim the depthed canvas in front of the eye with a high resolution geometry mesh on the framebuffer.