### PR TITLE
Node 12 jitless build

### DIFF
--- a/metadata/program-device.mabu
+++ b/metadata/program-device.mabu
@@ -19,7 +19,7 @@ SRCS = ../main.cpp
 
 # Include paths for any language are specified here.
 #
-INCS = ../.node-gyp/11.6.0/include/node \
+INCS = ../../node-magicleap/package/include/node \
   ../node_modules/nan \
   ../deps/exokit-bindings/util/include
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "hterm-repl": "0.0.10",
     "isolator": "0.0.9",
     "leapmotion": "0.0.4",
-    "libnode.a": "0.0.9",
+    "libnode.a": "0.0.10",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "nan": "^2.13.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "event-loop-native": "0.0.8",
     "events": "^3.0.0",
     "fake-indexeddb": "^2.0.4",
-    "fault-zone": "0.0.20",
     "he": "^1.1.1",
     "history": "^4.9.0",
     "hterm-repl": "0.0.10",

--- a/scripts/build-ml.sh
+++ b/scripts/build-ml.sh
@@ -36,7 +36,7 @@ fi
 
 pushd ..
 export TARGET_ARCH="arm64" # for wrtc install prebuilt
-npm install --verbose --devdir="$(pwd)/.node-gyp" --arch=arm64 --target_arch=arm64 --no-optional
+npm install --verbose --devdir="$(pwd)/.node-gyp" --nodedir="$(pwd)/../node-magicleap" --arch=arm64 --target_arch=arm64 --no-optional
 find -name '\.bin' | xargs rm -Rf
 popd
 

--- a/src/index.js
+++ b/src/index.js
@@ -2084,16 +2084,6 @@ const _start = () => {
 if (require.main === module) {
   if (nativeBindings.nativeAnalytics) {
     require(path.join(__dirname, 'bugsnag'));
-    require('fault-zone').registerHandler((stack, stackLen) => {
-      const message = new Buffer(stack, 0, stackLen).toString('utf8');
-      console.warn(message);
-      child_process.execFileSync(process.argv[0], [
-        path.join(__dirname, 'bugsnag.js'),
-      ], {
-        input: message,
-      });
-      process.exit(1);
-    });
   }
   if (args.log) {
     const RedirectOutput = require('redirect-output').default;


### PR DESCRIPTION
This bumps the build process to node 12 (compatibility was added in https://github.com/webmixedreality/exokit/pull/873).

- `libnode.a` is updated to node 12 `-pre` with V8 `7.4` via https://github.com/nodejs/node/pull/26685.
- build process uses local node 12 checkout for now to ensure proper sourcing of header files; this will not be needed at all when node 12 is released in Apr 2019

This allows running without executable memory on platforms that do not allow it, including iOS.