### PR TITLE
Update exokit.iss publisher name and copyright

### DIFF
--- a/metadata/exokit.iss
+++ b/metadata/exokit.iss
@@ -1,7 +1,7 @@
 #define MyAppName "Exokit"
 #define MyAppShortName "Exokit"
 #define MyAppLCShortName "exokit"
-#define MyAppPublisher "WebMR"
+#define MyAppPublisher "exokitXR"
 #define MyAppURL "https://github.com/exokitxr/exokit"
 #define MyAppExeName "exokit.cmd"
 #define MyIcon "exokit.ico"
@@ -36,7 +36,7 @@ ChangesEnvironment=yes
 DisableProgramGroupPage=yes
 ArchitecturesInstallIn64BitMode=x64 ia64
 UninstallDisplayIcon={app}\metadata\{#MyIcon}
-AppCopyright=Copyright (c) 2018 WebMR
+AppCopyright=Copyright (c) 2019 Exokit
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"


### PR DESCRIPTION
Noticed the windows installer publisher is "Zeo Incorporated", can't find any reference to zeo in the repo though, maybe it is something in the CI..

Looking in the installer config, the publisher in the config is WebMR, which has since been updated to exokitXR and the copyright was outdated.

![zeoincwindows](https://user-images.githubusercontent.com/29695350/56073503-e9f30080-5d59-11e9-8f3a-aab1a961995d.PNG)
