### PR TITLE
WebVR reality tabs

### DIFF
--- a/examples/fakeDisplay.js
+++ b/examples/fakeDisplay.js
@@ -3,20 +3,35 @@
 window._makeFakeDisplay = () => {
   const fakeDisplay = window.navigator.createVRDisplay();
   fakeDisplay.enter = async ({renderer, animate, layers}) => {
-    const canvas = renderer.domElement;
+    const {domElement: canvas} = renderer;
 
-    fakeDisplay.layers = layers;
-    fakeDisplay.requestPresent();
-    const session = await fakeDisplay.requestSession({
-      exclusive: true,
-    });
+    if (navigator.xr) {
+      const session = await fakeDisplay.requestSession({
+        exclusive: true,
+      });
 
-    renderer.vr.enabled = true;
-    renderer.vr.setDevice(fakeDisplay);
-    renderer.vr.setSession(session, {
-      frameOfReferenceType: 'stage',
-    });
-    renderer.vr.setAnimationLoop(animate);
+      fakeDisplay.layers = layers;
+
+      renderer.vr.enabled = true;
+      renderer.vr.setDevice(fakeDisplay);
+      renderer.vr.setSession(session, {
+        frameOfReferenceType: 'stage',
+      });
+      renderer.vr.setAnimationLoop(animate);
+    } else {
+      await fakeDisplay.requestPresent([
+        {
+          source: canvas,
+        },
+      ]);
+
+      renderer.vr.enabled = true;
+      renderer.vr.setDevice(fakeDisplay);
+      renderer.vr.setSession(session, {
+        frameOfReferenceType: 'stage',
+      });
+      renderer.vr.setAnimationLoop(animate);
+    }
 
     const context = renderer.getContext();
     const [fbo, tex, depthTex, msFbo, msTex, msDepthTex] = window.browser.createRenderTarget(context, canvas.width, canvas.height, 0, 0, 0, 0);

--- a/examples/fakeDisplay.js
+++ b/examples/fakeDisplay.js
@@ -27,8 +27,6 @@ window._makeFakeDisplay = () => {
       tex,
       depthTex,
     };
-
-    return session;
   };
 
   return fakeDisplay;

--- a/examples/fakeDisplay.js
+++ b/examples/fakeDisplay.js
@@ -27,9 +27,6 @@ window._makeFakeDisplay = () => {
 
       renderer.vr.enabled = true;
       renderer.vr.setDevice(fakeDisplay);
-      renderer.vr.setSession(session, {
-        frameOfReferenceType: 'stage',
-      });
       renderer.vr.setAnimationLoop(animate);
     }
 

--- a/examples/fakeDisplay.js
+++ b/examples/fakeDisplay.js
@@ -24,6 +24,8 @@ window._makeFakeDisplay = () => {
           source: canvas,
         },
       ]);
+      
+      fakeDisplay.layers = layers;
 
       renderer.vr.enabled = true;
       renderer.vr.setDevice(fakeDisplay);

--- a/examples/realitytabs.html
+++ b/examples/realitytabs.html
@@ -2702,13 +2702,11 @@ function animate(time, frame) {
 const _bootFakeDisplay = async () => {
   fakeDisplay = _makeFakeDisplay();
   fakeDisplay.position.set(0, 1.6, 0);
-  // const canvas = renderer.domElement;
-  const session = await fakeDisplay.enter({
+  await fakeDisplay.enter({
     renderer,
     animate,
     layers,
   });
-  fakeDisplay.session = session;
 
   display = fakeDisplay;
 

--- a/examples/realitytabs.html
+++ b/examples/realitytabs.html
@@ -2805,6 +2805,7 @@ const _bootFakeDisplay = async () => {
         renderer.vr.setAnimationLoop(animate);
       } else {
         console.log('no vr displays');
+        await _bootFakeDisplay();
       }
     }
   } else {

--- a/examples/realitytabs.html
+++ b/examples/realitytabs.html
@@ -2729,58 +2729,83 @@ const _bootFakeDisplay = async () => {
   console.log('loaded root in 2D');
 };
 (async () => {
-  if (navigator.xr && !query.fake) {
-    display = await navigator.xr.requestDevice();
+  if (!query.fake) {
+    if (navigator.xr) { // WebXR
+      display = await navigator.xr.requestDevice();
 
-    if (display) {
-      const session = await display.requestSession({
-        exclusive: true,
-      });
-      display.session = session;
-
-      session.layers = layers;
-
-      /* session.onselect = e => {
-        console.log('select'); // XXX
-      }; */
-
-      // console.log('request first frame');
-      session.requestAnimationFrame((timestamp, frame) => {
-        renderer.vr.setSession(session, {
-          frameOfReferenceType: 'stage',
+      if (display) {
+        const session = await display.requestSession({
+          exclusive: true,
         });
+        display.session = session;
 
-        const viewport = session.baseLayer.getViewport(frame.views[0]);
-        // const width = viewport.width;
-        const height = viewport.height;
-        const fullWidth = (() => {
-          let result = 0;
-          for (let i = 0; i < frame.views.length; i++) {
-            result += session.baseLayer.getViewport(frame.views[i]).width;
+        session.layers = layers;
+
+        // console.log('request first frame');
+        session.requestAnimationFrame((timestamp, frame) => {
+          renderer.vr.setSession(session, {
+            frameOfReferenceType: 'stage',
+          });
+
+          const viewport = session.baseLayer.getViewport(frame.views[0]);
+          // const width = viewport.width;
+          const height = viewport.height;
+          const fullWidth = (() => {
+            let result = 0;
+            for (let i = 0; i < frame.views.length; i++) {
+              result += session.baseLayer.getViewport(frame.views[i]).width;
+            }
+            return result;
+          })();
+
+          renderer.setSize(fullWidth, height);
+
+          renderer.setAnimationLoop(null);
+
+          renderer.vr.enabled = true;
+          renderer.vr.setDevice(display);
+          renderer.vr.setAnimationLoop(animate);
+
+          if (window.browser && window.browser.magicleap) {
+            window.browser.magicleap.RequestDepthPopulation(true);
+            renderer.autoClearDepth = false;
           }
-          return result;
-        })();
 
-        renderer.setSize(fullWidth, height);
+          _openUrl('tutorial.html');
+          _updateRigLists();
+
+          console.log('loaded root in XR');
+        });
+      } else {
+        console.log('no xr displays');
+        await _bootFakeDisplay();
+      }
+    } else { // WebVR
+      console.log('request device');
+      const displays = await navigator.getVRDisplays();
+      display = displays[0];
+
+      if (display) {
+        console.log('request present');
+        await display.requestPresent([
+          {
+            source: renderer.domElement,
+          }
+        ]);
+        console.log('entered vr');
+
+        display.layers = layers;
+
+        const {renderWidth: width, renderHeight: height} = display.getEyeParameters('left');
+        renderer.setSize(width * 2, height);
 
         renderer.setAnimationLoop(null);
-
         renderer.vr.enabled = true;
         renderer.vr.setDevice(display);
         renderer.vr.setAnimationLoop(animate);
-
-        if (window.browser && window.browser.magicleap) {
-          window.browser.magicleap.RequestDepthPopulation(true);
-          renderer.autoClearDepth = false;
-        }
-
-        _openUrl('tutorial.html');
-        _updateRigLists();
-
-        console.log('loaded root in XR');
-      });
-    } else {
-      await _bootFakeDisplay();
+      } else {
+        console.log('no vr displays');
+      }
     }
   } else {
     await _bootFakeDisplay();

--- a/examples/realitytabs.html
+++ b/examples/realitytabs.html
@@ -900,7 +900,7 @@ for (let i = 0; i < controllerMeshes.length; i++) {
   scene.add(controllerMesh);
   controllerMeshes[i] = controllerMesh;
 }
-const _getControllerIndex = inputSource => inputSource.handedness === 'left' ? 0 : 1;
+const _getControllerIndex = gamepad => gamepad.hand === 'left' ? 0 : 1;
 
 // rig
 
@@ -1870,24 +1870,20 @@ function animate(time, frame) {
   const timeDiff = now - lastTime;
   const startTimeDiff = now - startTime;
 
-  const inputSources = display.session.getInputSources();
-  for (let i = 0; i < inputSources.length; i++) {
+  const gamepads = navigator.getGamepads();
+  for (let i = 0; i < gamepads.length; i++) {
+    const gamepad = gamepads[i];
     const moveTab = moves[i];
     const boxMesh = boxMeshes[i];
 
     if (moveTab) {
-      const inputSource = inputSources[i];
-      const pose = frame.getInputPose(inputSource);
       const {iframe} = moveTab;
 
-      const gamepads = navigator.getGamepads();
-      const gamepad = gamepads[i];
       const scrollFactor = scrollFactors[i];
       const scaleFactor = scaleFactors[i];
 
-      localMatrix
-        .fromArray(pose.targetRay.transformMatrix)
-        .decompose(localVector, localQuaternion, localVector2);
+      localVector.fromArray(gamepad.pose.position);
+      localQuaternion.fromArray(gamepad.pose.orientation);
       localVector
         .add(
           localVector2.set(0, 0, -scrollFactor)
@@ -1924,14 +1920,13 @@ function animate(time, frame) {
         controllerMeshes[i].visible = false;
       }
 
-      for (let i = 0; i < inputSources.length; i++) {
-        const inputSource = inputSources[i];
-        const pose = frame.getInputPose(inputSource);
+      for (let i = 0; i < gamepads.length; i++) {
+        const gamepad = gamepads[i];
 
-        const controllerIndex = _getControllerIndex(inputSource);
+        const controllerIndex = _getControllerIndex(gamepad);
         const controllerMesh = controllerMeshes[controllerIndex];
-        controllerMesh.matrix.fromArray(pose.targetRay.transformMatrix);
-        controllerMesh.matrix.decompose(controllerMesh.position, controllerMesh.quaternion, controllerMesh.scale);
+        controllerMesh.position.fromArray(gamepad.pose.position);
+        controllerMesh.quaternion.fromArray(gamepad.pose.orientation);
         controllerMesh.updateMatrixWorld(true);
         controllerMesh.visible = true;
       }
@@ -2301,12 +2296,8 @@ function animate(time, frame) {
                           const tab = tabs[menuMesh.listMesh.scrollIndex + j];
                           moves[i] = tab;
 
-                          const inputSources = display.session.getInputSources();
-                          const inputSource = inputSources[i];
-                          const pose = frame.getInputPose(inputSource);
-                          localMatrix
-                            .fromArray(pose.targetRay.transformMatrix)
-                            .decompose(localVector, localQuaternion, localVector2);
+                          localVector.fromArray(gamepad.pose.position);
+                          localQuaternion.fromArray(gamepad.pose.orientation);
                           const distance = localVector
                             .distanceTo(
                               localVector2
@@ -2521,11 +2512,7 @@ function animate(time, frame) {
 
   const _updateButtons = () => {
     if (display) {
-      const inputSources = display.session.getInputSources();
-      const gamepads = navigator.getGamepads();
-
-      for (let i = 0; i < inputSources.length; i++) {
-        const inputSource = inputSources[i];
+      for (let i = 0; i < gamepads.length; i++) {
         const gamepad = gamepads[i];
 
         {

--- a/examples/tutorial.html
+++ b/examples/tutorial.html
@@ -393,8 +393,6 @@
           ]);
           console.log('entered vr');
 
-          display.layers = layers;
-
           const {renderWidth: width, renderHeight: height} = display.getEyeParameters('left');
           renderer.setSize(width * 2, height);
 
@@ -404,6 +402,7 @@
           renderer.vr.setAnimationLoop(animate);
         } else {
           console.log('no vr displays');
+          renderer.setAnimationLoop(animate);
         }
       }
     })()

--- a/examples/tutorial.html
+++ b/examples/tutorial.html
@@ -344,37 +344,68 @@
 
     (async () => {
       console.log('request device');
-      display = await navigator.xr.requestDevice();
+
+      if (navigator.xr) {
+        display = await navigator.xr.requestDevice();
+
+        if (display) {
+          console.log('request session');
+          const session = await display.requestSession({
+            exclusive: true,
+          });
+          display.session = session;
+
+          // console.log('request first frame');
+          session.requestAnimationFrame((timestamp, frame) => {
+            renderer.vr.setSession(session, {
+              frameOfReferenceType: 'stage',
+            });
+
+            const viewport = session.baseLayer.getViewport(frame.views[0]);
+            const width = viewport.width;
+            const height = viewport.height;
+
+            renderer.setSize(width * 2, height);
+
+            renderer.setAnimationLoop(null);
+
+            renderer.vr.enabled = true;
+            renderer.vr.setDevice(display);
+            renderer.vr.setAnimationLoop(animate);
+
+            console.log('running!');
+          });
+        } else {
+          renderer.setAnimationLoop(animate);
+        }
+      } else {
+        console.log('no xr displays');
+      }
+    } else { // WebVR
+      console.log('request device');
+      const displays = await navigator.getVRDisplays();
+      display = displays[0];
 
       if (display) {
-        console.log('request session');
-        const session = await display.requestSession({
-          exclusive: true,
-        });
-        display.session = session;
+        console.log('request present');
+        await display.requestPresent([
+          {
+            source: renderer.domElement,
+          }
+        ]);
+        console.log('entered vr');
 
-        // console.log('request first frame');
-        session.requestAnimationFrame((timestamp, frame) => {
-          renderer.vr.setSession(session, {
-            frameOfReferenceType: 'stage',
-          });
+        display.layers = layers;
 
-          const viewport = session.baseLayer.getViewport(frame.views[0]);
-          const width = viewport.width;
-          const height = viewport.height;
+        const {renderWidth: width, renderHeight: height} = display.getEyeParameters('left');
+        renderer.setSize(width * 2, height);
 
-          renderer.setSize(width * 2, height);
-
-          renderer.setAnimationLoop(null);
-
-          renderer.vr.enabled = true;
-          renderer.vr.setDevice(display);
-          renderer.vr.setAnimationLoop(animate);
-
-          console.log('running!');
-        });
+        renderer.setAnimationLoop(null);
+        renderer.vr.enabled = true;
+        renderer.vr.setDevice(display);
+        renderer.vr.setAnimationLoop(animate);
       } else {
-        renderer.setAnimationLoop(animate);
+        console.log('no vr displays');
       }
     })()
       .catch(err => {

--- a/examples/tutorial.html
+++ b/examples/tutorial.html
@@ -376,36 +376,35 @@
             console.log('running!');
           });
         } else {
+          console.log('no xr displays');
           renderer.setAnimationLoop(animate);
         }
-      } else {
-        console.log('no xr displays');
-      }
-    } else { // WebVR
-      console.log('request device');
-      const displays = await navigator.getVRDisplays();
-      display = displays[0];
+      } else { // WebVR
+        console.log('request device');
+        const displays = await navigator.getVRDisplays();
+        display = displays[0];
 
-      if (display) {
-        console.log('request present');
-        await display.requestPresent([
-          {
-            source: renderer.domElement,
-          }
-        ]);
-        console.log('entered vr');
+        if (display) {
+          console.log('request present');
+          await display.requestPresent([
+            {
+              source: renderer.domElement,
+            }
+          ]);
+          console.log('entered vr');
 
-        display.layers = layers;
+          display.layers = layers;
 
-        const {renderWidth: width, renderHeight: height} = display.getEyeParameters('left');
-        renderer.setSize(width * 2, height);
+          const {renderWidth: width, renderHeight: height} = display.getEyeParameters('left');
+          renderer.setSize(width * 2, height);
 
-        renderer.setAnimationLoop(null);
-        renderer.vr.enabled = true;
-        renderer.vr.setDevice(display);
-        renderer.vr.setAnimationLoop(animate);
-      } else {
-        console.log('no vr displays');
+          renderer.setAnimationLoop(null);
+          renderer.vr.enabled = true;
+          renderer.vr.setDevice(display);
+          renderer.vr.setAnimationLoop(animate);
+        } else {
+          console.log('no vr displays');
+        }
       }
     })()
       .catch(err => {

--- a/src/Document.js
+++ b/src/Document.js
@@ -208,22 +208,11 @@ function initDocument (document, window) {
     const displays = window.navigator.getVRDisplaysSync();
     if (displays.length > 0 && (!window[symbols.optionsSymbol].args || ['all', 'webvr'].includes(window[symbols.optionsSymbol].args.xr))) {
       const _initDisplays = () => {
-        if (!_tryEmitDisplay()) {
-          _delayFrames(() => {
-            _tryEmitDisplay();
-          }, 1);
-        }
-      };
-      const _tryEmitDisplay = () => {
         const presentingDisplay = displays.find(display => display.isPresenting);
-        if (presentingDisplay) {
-          if (presentingDisplay.constructor.name === 'FakeVRDisplay') {
-            _emitOneDisplay(presentingDisplay);
-          }
-          return true;
+        if (presentingDisplay && presentingDisplay.constructor.name === 'FakeVRDisplay') {
+          _emitOneDisplay(presentingDisplay);
         } else {
           _emitOneDisplay(displays[0]);
-          return false;
         }
       };
       const _emitOneDisplay = display => {
@@ -235,17 +224,15 @@ function initDocument (document, window) {
         if (n === 0) {
           fn();
         } else {
-          try {
-            window.requestAnimationFrame(() => {
-              _delayFrames(fn, n - 1);
-            });
-          } catch(err) {
-            console.log(err.stack);
-          }
+          window.requestAnimationFrame(() => {
+            _delayFrames(fn, n - 1);
+          });
         }
       };
       if (document.resources.resources.length === 0) {
-        _initDisplays();
+        _delayFrames(() => {
+          _initDisplays();
+        }, 2); // arbitary delay to give site time to bind events
       } else {
         const _update = () => {
           if (document.resources.resources.length === 0) {

--- a/src/VR.js
+++ b/src/VR.js
@@ -392,6 +392,9 @@ class FakeVRDisplay extends VRDisplay {
   requestSession({exclusive = true} = {}) {
     const self = this;
 
+    GlobalContext.xrState.renderWidth[0] = this.window.innerWidth * this.window.devicePixelRatio / 2;
+    GlobalContext.xrState.renderHeight[0] = this.window.innerHeight * this.window.devicePixelRatio;
+
     const session = {
       addEventListener(e, fn) {
         if (e === 'end') {

--- a/src/VR.js
+++ b/src/VR.js
@@ -379,7 +379,6 @@ class FakeVRDisplay extends VRDisplay {
   }
 
   exitPresent() {
-
     if (this.onvrdisplaypresentchange && this.isPresenting) {
       this.isPresenting = false;
       this.onvrdisplaypresentchange();

--- a/src/VR.js
+++ b/src/VR.js
@@ -202,6 +202,7 @@ class VRDisplay extends EventEmitter {
 
     this._frameData = new VRFrameData();
     this._rafs = [];
+    this._layers = [];
   }
 
   getFrameData(frameData) {
@@ -294,6 +295,17 @@ class VRDisplay extends EventEmitter {
   }
 
   submitFrame() {}
+  
+  get layers() {
+    return this._layers;
+  }
+  set layers(layers) {
+    this._layers = layers;
+
+    if (this.onlayers) {
+      this.onlayers(layers);
+    }
+  }
 
   destroy() {
     for (let i = 0; i < this._rafs.length; i++) {
@@ -334,7 +346,6 @@ class FakeVRDisplay extends VRDisplay {
       });
     };
 
-    this._layers = [];
     this._onends = [];
     this._lastPresseds = [false, false];
 
@@ -506,17 +517,6 @@ class FakeVRDisplay extends VRDisplay {
 
   supportsSession() {
     return Promise.resolve(null);
-  }
-
-  get layers() {
-    return this._layers;
-  }
-  set layers(layers) {
-    this._layers = layers;
-
-    if (this.onlayers) {
-      this.onlayers(layers);
-    }
   }
 
   /* getFrameData(frameData) {

--- a/src/VR.js
+++ b/src/VR.js
@@ -364,9 +364,13 @@ class FakeVRDisplay extends VRDisplay {
     GlobalContext.xrState.rightProjectionMatrix.set(projectionMatrix);
   } */
 
-  requestPresent() {
+  requestPresent(layers) {
     GlobalContext.xrState.renderWidth[0] = this.window.innerWidth * this.window.devicePixelRatio / 2;
     GlobalContext.xrState.renderHeight[0] = this.window.innerHeight * this.window.devicePixelRatio;
+
+    if (this.onrequestpresent) {
+      this.onrequestpresent(layers);
+    }
 
     if (this.onvrdisplaypresentchange && !this.isPresenting) {
       this.isPresenting = true;

--- a/src/Window.js
+++ b/src/Window.js
@@ -886,7 +886,10 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
       })(wsProxy.Server);
       return wsProxy;
     })(),
-    createRenderTarget: nativeWindow.createRenderTarget, // XXX needed for reality tabs fakeDisplay
+    createRenderTarget(context) { // XXX needed for reality tabs fakeDisplay
+      nativeWindow.setCurrentWindowContext(context.getWindowHandle());
+      return nativeWindow.createRenderTarget.apply(nativeWindow, arguments);
+    },
     magicleap: nativeMl ? {
       RequestMeshing() {
         const mesher = nativeMl.RequestMeshing(window);


### PR DESCRIPTION
We've had WebXR support for multi-app compositing ("reality tabs") for a long time now, but that support was never extended to WebVR hosts.

Although we always supported WebVR children for reality tabs, this precluded having something like A-Frame UI at the host level (since A-Frame will only auto-enter on `vrdisplayactivate` and WebXR has no such thing).

This PR fixes that by refactoring the `realitytabs.html` example to support WebVR (`-x webvr`), and makes the changes necessary in the  engine core to make that work.

Fixes https://github.com/exokitxr/exokit/issues/904.