### PR TITLE
[MACOS] Lock Travis to node 11.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,8 @@ matrix:
       skip_cleanup: true
   - os: osx
     osx_image: xcode10.1
+    node_js:
+    - "11.6.0"
     install:
     - npm install -g appdmg
     - curl "https://nodejs.org/dist/v11.6.0/node-v11.6.0-darwin-x64.tar.gz" >node.tar.gz


### PR DESCRIPTION
No changes to Exokit or Node dependency -- just updating MacOS Travis to use `11.6.0` so tests pass.

Going forward, when we move to `user-parallel` and don't use our own VM solution (`vm-one`), this shouldn't be an issue.

Fixes https://github.com/exokitxr/exokit/issues/910.