### PR TITLE
WebXR gamepads post-oculus desktop

### DIFF
--- a/examples/realitytabs.html
+++ b/examples/realitytabs.html
@@ -2070,7 +2070,7 @@ function animate(time, frame) {
 
                   const gamepads = navigator.getGamepads();
                   const gamepad = gamepads[i];
-                  if (gamepad.buttons[1].pressed) {
+                  if (gamepad && gamepad.buttons[1].pressed) {
                     const textX = x - cursorWidth;
                     let closestIndex = -1;
                     let closestDistance = Infinity;
@@ -2106,7 +2106,7 @@ function animate(time, frame) {
 
                   const gamepads = navigator.getGamepads();
                   const gamepad = gamepads[i];
-                  if (gamepad.buttons[1].pressed) {
+                  if (gamepad && gamepad.buttons[1].pressed) {
                     _closeRig();
                   }
 
@@ -2146,7 +2146,7 @@ function animate(time, frame) {
 
                 const gamepads = navigator.getGamepads();
                 const gamepad = gamepads[i];
-                if (gamepad.buttons[1].pressed) {
+                if (gamepad && gamepad.buttons[1].pressed) {
                   const optionX = Math.floor(x/(menuWidth*0.2));
                   if (optionX === 0) {
                     menuMesh.optionsMesh.d = 3;
@@ -2230,18 +2230,20 @@ function animate(time, frame) {
 
                         const gamepads = navigator.getGamepads();
                         const gamepad = gamepads[i];
-                        const pressed = gamepad.buttons[1].pressed;
-                        const lastPressed = lastPresseds[i];
-                        if (pressed && !lastPressed) {
-                          const tab = tabs[menuMesh.listMesh.scrollIndex + j];
-                          _closeTab(tab);
+                        if (gamepad) {
+                          const pressed = gamepad.buttons[1].pressed;
+                          const lastPressed = lastPresseds[i];
+                          if (pressed && !lastPressed) {
+                            const tab = tabs[menuMesh.listMesh.scrollIndex + j];
+                            _closeTab(tab);
 
-                          if (focusedTab === tab) {
-                            focusedTab = rig.menuMesh.urlMesh;
+                            if (focusedTab === tab) {
+                              focusedTab = rig.menuMesh.urlMesh;
+                            }
+
+                            rig.menuMesh.urlMesh.updateText();
+                            _updateRigLists();
                           }
-
-                          rig.menuMesh.urlMesh.updateText();
-                          _updateRigLists();
                         }
 
                         intersectionSpecs[i] = null;
@@ -2258,21 +2260,23 @@ function animate(time, frame) {
 
                         const gamepads = navigator.getGamepads();
                         const gamepad = gamepads[i];
-                        const pressed = gamepad.buttons[1].pressed;
-                        const lastPressed = lastPresseds[i];
-                        if (pressed && !lastPressed) {
-                          const tab = tabs[menuMesh.listMesh.scrollIndex + j];
-                          const {iframe} = tab;
-                          if (iframe.d === 3) {
-                            window.browser.devTools.requestDevTools(iframe.contentWindow, document)
-                              .then(devTools => {
-                                const {position, quaternion} = _getFrontOfCamera();
-                                // position.add(localVector.set(0, -0.3, 0).applyQuaternion(quaternion));
-                                _addTab(devTools.getIframe(), position, quaternion, undefined, 2);
-                              })
-                              .catch(err => {
-                                console.warn(err.stack);
-                              });
+                        if (gamepad) {
+                          const pressed = gamepad.buttons[1].pressed;
+                          const lastPressed = lastPresseds[i];
+                          if (pressed && !lastPressed) {
+                            const tab = tabs[menuMesh.listMesh.scrollIndex + j];
+                            const {iframe} = tab;
+                            if (iframe.d === 3) {
+                              window.browser.devTools.requestDevTools(iframe.contentWindow, document)
+                                .then(devTools => {
+                                  const {position, quaternion} = _getFrontOfCamera();
+                                  // position.add(localVector.set(0, -0.3, 0).applyQuaternion(quaternion));
+                                  _addTab(devTools.getIframe(), position, quaternion, undefined, 2);
+                                })
+                                .catch(err => {
+                                  console.warn(err.stack);
+                                });
+                            }
                           }
                         }
 
@@ -2290,23 +2294,25 @@ function animate(time, frame) {
 
                         const gamepads = navigator.getGamepads();
                         const gamepad = gamepads[i];
-                        const pressed = gamepad.buttons[1].pressed;
-                        const lastPressed = lastPresseds[i];
-                        if (pressed && !lastPressed) {
-                          const tab = tabs[menuMesh.listMesh.scrollIndex + j];
-                          moves[i] = tab;
+                        if (gamepad) {
+                          const pressed = gamepad.buttons[1].pressed;
+                          const lastPressed = lastPresseds[i];
+                          if (pressed && !lastPressed) {
+                            const tab = tabs[menuMesh.listMesh.scrollIndex + j];
+                            moves[i] = tab;
 
-                          localVector.fromArray(gamepad.pose.position);
-                          localQuaternion.fromArray(gamepad.pose.orientation);
-                          const distance = localVector
-                            .distanceTo(
-                              localVector2
-                                .fromArray(tab.iframe.xrOffset.position)
-                            );
-                          scrollFactors[i] = distance;
+                            localVector.fromArray(gamepad.pose.position);
+                            localQuaternion.fromArray(gamepad.pose.orientation);
+                            const distance = localVector
+                              .distanceTo(
+                                localVector2
+                                  .fromArray(tab.iframe.xrOffset.position)
+                              );
+                            scrollFactors[i] = distance;
 
-                          const scale = tab.iframe.xrOffset.scale[0];
-                          scaleFactors[i] = scale;
+                            const scale = tab.iframe.xrOffset.scale[0];
+                            scaleFactors[i] = scale;
+                          }
                         }
 
                         intersectionSpecs[i] = null;
@@ -2323,13 +2329,15 @@ function animate(time, frame) {
 
                         const gamepads = navigator.getGamepads();
                         const gamepad = gamepads[i];
-                        const pressed = gamepad.buttons[1].pressed;
-                        const lastPressed = lastPresseds[i];
-                        if (pressed && !lastPressed) {
-                          focusedTab = tabs[menuMesh.listMesh.scrollIndex + j];
+                        if (gamepad) {
+                          const pressed = gamepad.buttons[1].pressed;
+                          const lastPressed = lastPresseds[i];
+                          if (pressed && !lastPressed) {
+                            focusedTab = tabs[menuMesh.listMesh.scrollIndex + j];
 
-                          menuMesh.urlMesh.updateText();
-                          menuMesh.listMesh.updateList();
+                            menuMesh.urlMesh.updateText();
+                            menuMesh.listMesh.updateList();
+                          }
                         }
 
                         intersectionSpecs[i] = null;
@@ -2354,20 +2362,22 @@ function animate(time, frame) {
 
                       const gamepads = navigator.getGamepads();
                       const gamepad = gamepads[i];
-                      const pressed = gamepad.buttons[1].pressed;
-                      const lastPressed = lastPresseds[i];
-                      if (pressed && !lastPressed) {
-                        const link = localLinks[j];
-                        const {url} = link;
+                      if (gamepad) {
+                        const pressed = gamepad.buttons[1].pressed;
+                        const lastPressed = lastPresseds[i];
+                        if (pressed && !lastPressed) {
+                          const link = localLinks[j];
+                          const {url} = link;
 
-                        const {position, quaternion} = _getFrontOfCamera();
-                        _openUrl(url, position, quaternion, undefined, menuMesh.optionsMesh.d);
+                          const {position, quaternion} = _getFrontOfCamera();
+                          _openUrl(url, position, quaternion, undefined, menuMesh.optionsMesh.d);
 
-                        menuMesh.optionsMesh.list = 'tabs';
-                        menuMesh.optionsMesh.updateOptions();
-                        menuMesh.listMesh.scrollIndex = 0;
+                          menuMesh.optionsMesh.list = 'tabs';
+                          menuMesh.optionsMesh.updateOptions();
+                          menuMesh.listMesh.scrollIndex = 0;
 
-                        _updateRigLists();
+                          _updateRigLists();
+                        }
                       }
 
                       intersectionSpecs[i] = null;
@@ -2392,13 +2402,15 @@ function animate(time, frame) {
 
                         const gamepads = navigator.getGamepads();
                         const gamepad = gamepads[i];
-                        const pressed = gamepad.buttons[1].pressed;
-                        const lastPressed = lastPresseds[i];
-                        if (pressed && !lastPressed) {
-                          const server = localServers[j];
-                          const {name} = server;
+                        if (gamepad) {
+                          const pressed = gamepad.buttons[1].pressed;
+                          const lastPressed = lastPresseds[i];
+                          if (pressed && !lastPressed) {
+                            const server = localServers[j];
+                            const {name} = server;
 
-                          _openServer(`${registryUrl}/servers/${name}`, true);
+                            _openServer(`${registryUrl}/servers/${name}`, true);
+                          }
                         }
 
                         intersectionSpecs[i] = null;
@@ -2421,10 +2433,12 @@ function animate(time, frame) {
 
                         const gamepads = navigator.getGamepads();
                         const gamepad = gamepads[i];
-                        const pressed = gamepad.buttons[1].pressed;
-                        const lastPressed = lastPresseds[i];
-                        if (pressed && !lastPressed) {
-                          _closeServer();
+                        if (gamepad) {
+                          const pressed = gamepad.buttons[1].pressed;
+                          const lastPressed = lastPresseds[i];
+                          if (pressed && !lastPressed) {
+                            _closeServer();
+                          }
                         }
 
                         intersectionSpecs[i] = null;
@@ -2445,14 +2459,16 @@ function animate(time, frame) {
 
                 const gamepads = navigator.getGamepads();
                 const gamepad = gamepads[i];
-                const pressed = gamepad.buttons[1].pressed;
-                if (pressed) {
-                  const list = menuMesh.optionsMesh.list === 'tabs' ? tabs : links;
-                  menuMesh.listMesh.scrollIndex = Math.floor(yFactor*list.length);
-                  if (menuMesh.listMesh.scrollIndex >= list.length) {
-                    menuMesh.listMesh.scrollIndex = list.length;
+                if (gamepad) {
+                  const pressed = gamepad.buttons[1].pressed;
+                  if (pressed) {
+                    const list = menuMesh.optionsMesh.list === 'tabs' ? tabs : links;
+                    menuMesh.listMesh.scrollIndex = Math.floor(yFactor*list.length);
+                    if (menuMesh.listMesh.scrollIndex >= list.length) {
+                      menuMesh.listMesh.scrollIndex = list.length;
+                    }
+                    menuMesh.listMesh.updateList();
                   }
-                  menuMesh.listMesh.updateList();
                 }
 
                 intersectionSpecs[i] = null;
@@ -2475,37 +2491,40 @@ function animate(time, frame) {
       }
 
       const gamepad = navigator.getGamepads()[i];
-      lastPresseds[i] = gamepad.buttons[1].pressed;
+      if (gamepad) {
+        const pressed = gamepad.buttons[1].pressed;
+        const padPressed = gamepad.buttons[0].pressed;
+        const padTouched = gamepad.buttons[0].touched;
 
-      const padTouched = gamepad.buttons[0].touched;
-      const {axes} = gamepad;
-      const lastPadTouched = lastPadToucheds[i];
-      const lastAxis = lastAxes[i];
-      if (padTouched && lastPadTouched && rig.open && !moves[i]) {
-        const dx = axes[0] - lastAxis[0];
-        const dy = axes[1] - lastAxis[1];
+        const {axes} = gamepad;
+        const lastPadTouched = lastPadToucheds[i];
+        const lastAxis = lastAxes[i];
+        if (padTouched && lastPadTouched && rig.open && !moves[i]) {
+          const dx = axes[0] - lastAxis[0];
+          const dy = axes[1] - lastAxis[1];
 
-        rig.menuMesh.listMesh.updateWheel(dx*4, dy*4);
-      }
-      lastPadToucheds[i] = padTouched;
+          rig.menuMesh.listMesh.updateWheel(dx*4, dy*4);
+        }
 
-      const padPressed = gamepad.buttons[0].pressed;
-      if (padPressed && moves[i]) {
-        if (padPressed) {
-          if (gamepad.axes[1] > 0.5) {
-            scrollFactors[i] += 1/20;
-          } else if (gamepad.axes[1] < -0.5) {
-            scrollFactors[i] -= 1/20;
-          } else if (gamepad.axes[0] > 0.5) {
-            scaleFactors[i] = Math.min(scaleFactors[i] *= 1.02, 100);
-          } else if (gamepad.axes[0] < -0.5) {
-            scaleFactors[i] = Math.max(scaleFactors[i] /= 1.02, 0.01);
+        if (padPressed && moves[i]) {
+          if (padPressed) {
+            if (gamepad.axes[1] > 0.5) {
+              scrollFactors[i] += 1/20;
+            } else if (gamepad.axes[1] < -0.5) {
+              scrollFactors[i] -= 1/20;
+            } else if (gamepad.axes[0] > 0.5) {
+              scaleFactors[i] = Math.min(scaleFactors[i] *= 1.02, 100);
+            } else if (gamepad.axes[0] < -0.5) {
+              scaleFactors[i] = Math.max(scaleFactors[i] /= 1.02, 0.01);
+            }
           }
         }
-      }
 
-      lastAxis[0] = axes[0];
-      lastAxis[1] = axes[1];
+        lastPresseds[i] = pressed;
+        lastPadToucheds[i] = padTouched;
+        lastAxis[0] = axes[0];
+        lastAxis[1] = axes[1];
+      }
     }
   };
   _updateIntersections();

--- a/examples/realitytabs.html
+++ b/examples/realitytabs.html
@@ -2070,7 +2070,7 @@ function animate(time, frame) {
 
                   const gamepads = navigator.getGamepads();
                   const gamepad = gamepads[i];
-                  if (gamepad && gamepad.buttons[1].pressed) {
+                  if (gamepad.buttons[1].pressed) {
                     const textX = x - cursorWidth;
                     let closestIndex = -1;
                     let closestDistance = Infinity;
@@ -2106,7 +2106,7 @@ function animate(time, frame) {
 
                   const gamepads = navigator.getGamepads();
                   const gamepad = gamepads[i];
-                  if (gamepad && gamepad.buttons[1].pressed) {
+                  if (gamepad.buttons[1].pressed) {
                     _closeRig();
                   }
 
@@ -2146,7 +2146,7 @@ function animate(time, frame) {
 
                 const gamepads = navigator.getGamepads();
                 const gamepad = gamepads[i];
-                if (gamepad && gamepad.buttons[1].pressed) {
+                if (gamepad.buttons[1].pressed) {
                   const optionX = Math.floor(x/(menuWidth*0.2));
                   if (optionX === 0) {
                     menuMesh.optionsMesh.d = 3;
@@ -2230,20 +2230,18 @@ function animate(time, frame) {
 
                         const gamepads = navigator.getGamepads();
                         const gamepad = gamepads[i];
-                        if (gamepad) {
-                          const pressed = gamepad.buttons[1].pressed;
-                          const lastPressed = lastPresseds[i];
-                          if (pressed && !lastPressed) {
-                            const tab = tabs[menuMesh.listMesh.scrollIndex + j];
-                            _closeTab(tab);
+                        const pressed = gamepad.buttons[1].pressed;
+                        const lastPressed = lastPresseds[i];
+                        if (pressed && !lastPressed) {
+                          const tab = tabs[menuMesh.listMesh.scrollIndex + j];
+                          _closeTab(tab);
 
-                            if (focusedTab === tab) {
-                              focusedTab = rig.menuMesh.urlMesh;
-                            }
-
-                            rig.menuMesh.urlMesh.updateText();
-                            _updateRigLists();
+                          if (focusedTab === tab) {
+                            focusedTab = rig.menuMesh.urlMesh;
                           }
+
+                          rig.menuMesh.urlMesh.updateText();
+                          _updateRigLists();
                         }
 
                         intersectionSpecs[i] = null;
@@ -2260,23 +2258,21 @@ function animate(time, frame) {
 
                         const gamepads = navigator.getGamepads();
                         const gamepad = gamepads[i];
-                        if (gamepad) {
-                          const pressed = gamepad.buttons[1].pressed;
-                          const lastPressed = lastPresseds[i];
-                          if (pressed && !lastPressed) {
-                            const tab = tabs[menuMesh.listMesh.scrollIndex + j];
-                            const {iframe} = tab;
-                            if (iframe.d === 3) {
-                              window.browser.devTools.requestDevTools(iframe.contentWindow, document)
-                                .then(devTools => {
-                                  const {position, quaternion} = _getFrontOfCamera();
-                                  // position.add(localVector.set(0, -0.3, 0).applyQuaternion(quaternion));
-                                  _addTab(devTools.getIframe(), position, quaternion, undefined, 2);
-                                })
-                                .catch(err => {
-                                  console.warn(err.stack);
-                                });
-                            }
+                        const pressed = gamepad.buttons[1].pressed;
+                        const lastPressed = lastPresseds[i];
+                        if (pressed && !lastPressed) {
+                          const tab = tabs[menuMesh.listMesh.scrollIndex + j];
+                          const {iframe} = tab;
+                          if (iframe.d === 3) {
+                            window.browser.devTools.requestDevTools(iframe.contentWindow, document)
+                              .then(devTools => {
+                                const {position, quaternion} = _getFrontOfCamera();
+                                // position.add(localVector.set(0, -0.3, 0).applyQuaternion(quaternion));
+                                _addTab(devTools.getIframe(), position, quaternion, undefined, 2);
+                              })
+                              .catch(err => {
+                                console.warn(err.stack);
+                              });
                           }
                         }
 
@@ -2294,25 +2290,23 @@ function animate(time, frame) {
 
                         const gamepads = navigator.getGamepads();
                         const gamepad = gamepads[i];
-                        if (gamepad) {
-                          const pressed = gamepad.buttons[1].pressed;
-                          const lastPressed = lastPresseds[i];
-                          if (pressed && !lastPressed) {
-                            const tab = tabs[menuMesh.listMesh.scrollIndex + j];
-                            moves[i] = tab;
+                        const pressed = gamepad.buttons[1].pressed;
+                        const lastPressed = lastPresseds[i];
+                        if (pressed && !lastPressed) {
+                          const tab = tabs[menuMesh.listMesh.scrollIndex + j];
+                          moves[i] = tab;
 
-                            localVector.fromArray(gamepad.pose.position);
-                            localQuaternion.fromArray(gamepad.pose.orientation);
-                            const distance = localVector
-                              .distanceTo(
-                                localVector2
-                                  .fromArray(tab.iframe.xrOffset.position)
-                              );
-                            scrollFactors[i] = distance;
+                          localVector.fromArray(gamepad.pose.position);
+                          localQuaternion.fromArray(gamepad.pose.orientation);
+                          const distance = localVector
+                            .distanceTo(
+                              localVector2
+                                .fromArray(tab.iframe.xrOffset.position)
+                            );
+                          scrollFactors[i] = distance;
 
-                            const scale = tab.iframe.xrOffset.scale[0];
-                            scaleFactors[i] = scale;
-                          }
+                          const scale = tab.iframe.xrOffset.scale[0];
+                          scaleFactors[i] = scale;
                         }
 
                         intersectionSpecs[i] = null;
@@ -2329,15 +2323,13 @@ function animate(time, frame) {
 
                         const gamepads = navigator.getGamepads();
                         const gamepad = gamepads[i];
-                        if (gamepad) {
-                          const pressed = gamepad.buttons[1].pressed;
-                          const lastPressed = lastPresseds[i];
-                          if (pressed && !lastPressed) {
-                            focusedTab = tabs[menuMesh.listMesh.scrollIndex + j];
+                        const pressed = gamepad.buttons[1].pressed;
+                        const lastPressed = lastPresseds[i];
+                        if (pressed && !lastPressed) {
+                          focusedTab = tabs[menuMesh.listMesh.scrollIndex + j];
 
-                            menuMesh.urlMesh.updateText();
-                            menuMesh.listMesh.updateList();
-                          }
+                          menuMesh.urlMesh.updateText();
+                          menuMesh.listMesh.updateList();
                         }
 
                         intersectionSpecs[i] = null;
@@ -2362,22 +2354,20 @@ function animate(time, frame) {
 
                       const gamepads = navigator.getGamepads();
                       const gamepad = gamepads[i];
-                      if (gamepad) {
-                        const pressed = gamepad.buttons[1].pressed;
-                        const lastPressed = lastPresseds[i];
-                        if (pressed && !lastPressed) {
-                          const link = localLinks[j];
-                          const {url} = link;
+                      const pressed = gamepad.buttons[1].pressed;
+                      const lastPressed = lastPresseds[i];
+                      if (pressed && !lastPressed) {
+                        const link = localLinks[j];
+                        const {url} = link;
 
-                          const {position, quaternion} = _getFrontOfCamera();
-                          _openUrl(url, position, quaternion, undefined, menuMesh.optionsMesh.d);
+                        const {position, quaternion} = _getFrontOfCamera();
+                        _openUrl(url, position, quaternion, undefined, menuMesh.optionsMesh.d);
 
-                          menuMesh.optionsMesh.list = 'tabs';
-                          menuMesh.optionsMesh.updateOptions();
-                          menuMesh.listMesh.scrollIndex = 0;
+                        menuMesh.optionsMesh.list = 'tabs';
+                        menuMesh.optionsMesh.updateOptions();
+                        menuMesh.listMesh.scrollIndex = 0;
 
-                          _updateRigLists();
-                        }
+                        _updateRigLists();
                       }
 
                       intersectionSpecs[i] = null;
@@ -2402,15 +2392,13 @@ function animate(time, frame) {
 
                         const gamepads = navigator.getGamepads();
                         const gamepad = gamepads[i];
-                        if (gamepad) {
-                          const pressed = gamepad.buttons[1].pressed;
-                          const lastPressed = lastPresseds[i];
-                          if (pressed && !lastPressed) {
-                            const server = localServers[j];
-                            const {name} = server;
+                        const pressed = gamepad.buttons[1].pressed;
+                        const lastPressed = lastPresseds[i];
+                        if (pressed && !lastPressed) {
+                          const server = localServers[j];
+                          const {name} = server;
 
-                            _openServer(`${registryUrl}/servers/${name}`, true);
-                          }
+                          _openServer(`${registryUrl}/servers/${name}`, true);
                         }
 
                         intersectionSpecs[i] = null;
@@ -2433,12 +2421,10 @@ function animate(time, frame) {
 
                         const gamepads = navigator.getGamepads();
                         const gamepad = gamepads[i];
-                        if (gamepad) {
-                          const pressed = gamepad.buttons[1].pressed;
-                          const lastPressed = lastPresseds[i];
-                          if (pressed && !lastPressed) {
-                            _closeServer();
-                          }
+                        const pressed = gamepad.buttons[1].pressed;
+                        const lastPressed = lastPresseds[i];
+                        if (pressed && !lastPressed) {
+                          _closeServer();
                         }
 
                         intersectionSpecs[i] = null;
@@ -2459,16 +2445,14 @@ function animate(time, frame) {
 
                 const gamepads = navigator.getGamepads();
                 const gamepad = gamepads[i];
-                if (gamepad) {
-                  const pressed = gamepad.buttons[1].pressed;
-                  if (pressed) {
-                    const list = menuMesh.optionsMesh.list === 'tabs' ? tabs : links;
-                    menuMesh.listMesh.scrollIndex = Math.floor(yFactor*list.length);
-                    if (menuMesh.listMesh.scrollIndex >= list.length) {
-                      menuMesh.listMesh.scrollIndex = list.length;
-                    }
-                    menuMesh.listMesh.updateList();
+                const pressed = gamepad.buttons[1].pressed;
+                if (pressed) {
+                  const list = menuMesh.optionsMesh.list === 'tabs' ? tabs : links;
+                  menuMesh.listMesh.scrollIndex = Math.floor(yFactor*list.length);
+                  if (menuMesh.listMesh.scrollIndex >= list.length) {
+                    menuMesh.listMesh.scrollIndex = list.length;
                   }
+                  menuMesh.listMesh.updateList();
                 }
 
                 intersectionSpecs[i] = null;
@@ -2491,40 +2475,37 @@ function animate(time, frame) {
       }
 
       const gamepad = navigator.getGamepads()[i];
-      if (gamepad) {
-        const pressed = gamepad.buttons[1].pressed;
-        const padPressed = gamepad.buttons[0].pressed;
-        const padTouched = gamepad.buttons[0].touched;
+      lastPresseds[i] = gamepad.buttons[1].pressed;
 
-        const {axes} = gamepad;
-        const lastPadTouched = lastPadToucheds[i];
-        const lastAxis = lastAxes[i];
-        if (padTouched && lastPadTouched && rig.open && !moves[i]) {
-          const dx = axes[0] - lastAxis[0];
-          const dy = axes[1] - lastAxis[1];
+      const padTouched = gamepad.buttons[0].touched;
+      const {axes} = gamepad;
+      const lastPadTouched = lastPadToucheds[i];
+      const lastAxis = lastAxes[i];
+      if (padTouched && lastPadTouched && rig.open && !moves[i]) {
+        const dx = axes[0] - lastAxis[0];
+        const dy = axes[1] - lastAxis[1];
 
-          rig.menuMesh.listMesh.updateWheel(dx*4, dy*4);
-        }
+        rig.menuMesh.listMesh.updateWheel(dx*4, dy*4);
+      }
+      lastPadToucheds[i] = padTouched;
 
-        if (padPressed && moves[i]) {
-          if (padPressed) {
-            if (gamepad.axes[1] > 0.5) {
-              scrollFactors[i] += 1/20;
-            } else if (gamepad.axes[1] < -0.5) {
-              scrollFactors[i] -= 1/20;
-            } else if (gamepad.axes[0] > 0.5) {
-              scaleFactors[i] = Math.min(scaleFactors[i] *= 1.02, 100);
-            } else if (gamepad.axes[0] < -0.5) {
-              scaleFactors[i] = Math.max(scaleFactors[i] /= 1.02, 0.01);
-            }
+      const padPressed = gamepad.buttons[0].pressed;
+      if (padPressed && moves[i]) {
+        if (padPressed) {
+          if (gamepad.axes[1] > 0.5) {
+            scrollFactors[i] += 1/20;
+          } else if (gamepad.axes[1] < -0.5) {
+            scrollFactors[i] -= 1/20;
+          } else if (gamepad.axes[0] > 0.5) {
+            scaleFactors[i] = Math.min(scaleFactors[i] *= 1.02, 100);
+          } else if (gamepad.axes[0] < -0.5) {
+            scaleFactors[i] = Math.max(scaleFactors[i] /= 1.02, 0.01);
           }
         }
-
-        lastPresseds[i] = pressed;
-        lastPadToucheds[i] = padTouched;
-        lastAxis[0] = axes[0];
-        lastAxis[1] = axes[1];
       }
+
+      lastAxis[0] = axes[0];
+      lastAxis[1] = axes[1];
     }
   };
   _updateIntersections();

--- a/examples/realitytabs.html
+++ b/examples/realitytabs.html
@@ -2474,38 +2474,42 @@ function animate(time, frame) {
         _setIntersectionDefault();
       }
 
-      const gamepad = navigator.getGamepads()[i];
-      lastPresseds[i] = gamepad.buttons[1].pressed;
+      const gamepads = navigator.getGamepads();
+      const gamepad = gamepads[i];
+      if (gamepad) {
+        const pressed = gamepad.buttons[1].pressed;
+        const padPressed = gamepad.buttons[0].pressed;
+        const padTouched = gamepad.buttons[0].touched;
 
-      const padTouched = gamepad.buttons[0].touched;
-      const {axes} = gamepad;
-      const lastPadTouched = lastPadToucheds[i];
-      const lastAxis = lastAxes[i];
-      if (padTouched && lastPadTouched && rig.open && !moves[i]) {
-        const dx = axes[0] - lastAxis[0];
-        const dy = axes[1] - lastAxis[1];
+        const {axes} = gamepad;
+        const lastPadTouched = lastPadToucheds[i];
+        const lastAxis = lastAxes[i];
+        if (padTouched && lastPadTouched && rig.open && !moves[i]) {
+          const dx = axes[0] - lastAxis[0];
+          const dy = axes[1] - lastAxis[1];
 
-        rig.menuMesh.listMesh.updateWheel(dx*4, dy*4);
-      }
-      lastPadToucheds[i] = padTouched;
+          rig.menuMesh.listMesh.updateWheel(dx*4, dy*4);
+        }
+        lastPresseds[i] = pressed;
+        lastPadToucheds[i] = padTouched;
 
-      const padPressed = gamepad.buttons[0].pressed;
-      if (padPressed && moves[i]) {
-        if (padPressed) {
-          if (gamepad.axes[1] > 0.5) {
-            scrollFactors[i] += 1/20;
-          } else if (gamepad.axes[1] < -0.5) {
-            scrollFactors[i] -= 1/20;
-          } else if (gamepad.axes[0] > 0.5) {
-            scaleFactors[i] = Math.min(scaleFactors[i] *= 1.02, 100);
-          } else if (gamepad.axes[0] < -0.5) {
-            scaleFactors[i] = Math.max(scaleFactors[i] /= 1.02, 0.01);
+        if (padPressed && moves[i]) {
+          if (padPressed) {
+            if (gamepad.axes[1] > 0.5) {
+              scrollFactors[i] += 1/20;
+            } else if (gamepad.axes[1] < -0.5) {
+              scrollFactors[i] -= 1/20;
+            } else if (gamepad.axes[0] > 0.5) {
+              scaleFactors[i] = Math.min(scaleFactors[i] *= 1.02, 100);
+            } else if (gamepad.axes[0] < -0.5) {
+              scaleFactors[i] = Math.max(scaleFactors[i] /= 1.02, 0.01);
+            }
           }
         }
-      }
 
-      lastAxis[0] = axes[0];
-      lastAxis[1] = axes[1];
+        lastAxis[0] = axes[0];
+        lastAxis[1] = axes[1];
+      }
     }
   };
   _updateIntersections();

--- a/src/VR.js
+++ b/src/VR.js
@@ -610,13 +610,12 @@ class FakeVRDisplay extends VRDisplay {
 
 const createVRDisplay = () => new FakeVRDisplay();
 
-const getGamepads = function(window) {
-
+// Gamepad Vendor IDs
+const oculusVRIdLeft = 'Oculus Touch (Left)';
+const oculusVRIdRight = 'Oculus Touch (Right)';
+const openVRId = 'OpenVR Gamepad';
+const getGamepads = window => {
   let gamepads = null;
-  // Gamepad Vendor IDs
-  const oculusVRIdLeft = 'Oculus Touch (Left)';
-  const oculusVRIdRight = 'Oculus Touch (Right)';
-  const openVRId = 'OpenVR Gamepad';
 
   return function () {
     if (!GlobalContext.vrPresentState.isPresenting) { return []; }

--- a/src/VR.js
+++ b/src/VR.js
@@ -610,7 +610,6 @@ class FakeVRDisplay extends VRDisplay {
 
 const createVRDisplay = () => new FakeVRDisplay();
 
-// Gamepad Vendor IDs
 const oculusVRIdLeft = 'Oculus Touch (Left)';
 const oculusVRIdRight = 'Oculus Touch (Right)';
 const openVRId = 'OpenVR Gamepad';

--- a/src/VR.js
+++ b/src/VR.js
@@ -616,7 +616,11 @@ const oculusVRIdRight = 'Oculus Touch (Right)';
 const openVRId = 'OpenVR Gamepad';
 let gamepads = null;
 function getGamepads(window) {
-  if (GlobalContext.vrPresentState.isPresenting || GlobalContext.mlPresentState.isPresenting) {
+  if (
+    window[symbols.mrDisplaysSymbol].fakeVrDisplay.isPresenting ||
+    window[symbols.mrDisplaysSymbol].oculusVRDisplay.isPresenting ||
+    window[symbols.mrDisplaysSymbol].magicLeapARDisplay.isPresenting
+  ) {
     if (!gamepads) {
       const oculusVRDisplay = window[symbols.mrDisplaysSymbol].oculusVRDisplay;
       const oculusPresenting = oculusVRDisplay && oculusVRDisplay.isPresenting;

--- a/src/VR.js
+++ b/src/VR.js
@@ -616,16 +616,15 @@ const oculusVRIdRight = 'Oculus Touch (Right)';
 const openVRId = 'OpenVR Gamepad';
 let gamepads = null;
 function getGamepads(window) {
+  const {oculusVRDisplay, magicLeapARDisplay} = window[symbols.mrDisplaysSymbol];
   if (
-    window[symbols.mrDisplaysSymbol].fakeVrDisplay.isPresenting ||
-    window[symbols.mrDisplaysSymbol].oculusVRDisplay.isPresenting ||
-    window[symbols.mrDisplaysSymbol].magicLeapARDisplay.isPresenting
+    GlobalContext.fakeVrDisplayEnabled ||
+    oculusVRDisplay.isPresenting ||
+    magicLeapARDisplay.isPresenting
   ) {
     if (!gamepads) {
-      const oculusVRDisplay = window[symbols.mrDisplaysSymbol].oculusVRDisplay;
-      const oculusPresenting = oculusVRDisplay && oculusVRDisplay.isPresenting;
-      const idLeft = oculusPresenting ? oculusVRIdLeft : openVRId;
-      const idRight = oculusPresenting ? oculusVRIdRight : openVRId;
+      const idLeft = oculusVRDisplay.isPresenting ? oculusVRIdLeft : openVRId;
+      const idRight = oculusVRDisplay.isPresenting ? oculusVRIdRight : openVRId;
       gamepads = [
         new Gamepad('left', 0, idLeft),
         new Gamepad('right', 1, idRight),

--- a/src/VR.js
+++ b/src/VR.js
@@ -614,11 +614,9 @@ const createVRDisplay = () => new FakeVRDisplay();
 const oculusVRIdLeft = 'Oculus Touch (Left)';
 const oculusVRIdRight = 'Oculus Touch (Right)';
 const openVRId = 'OpenVR Gamepad';
-const getGamepads = window => {
-  let gamepads = null;
-
-  return function () {
-    if (!GlobalContext.vrPresentState.isPresenting) { return []; }
+let gamepads = null;
+function getGamepads(window) {
+  if (GlobalContext.vrPresentState.isPresenting || GlobalContext.mlPresentState.isPresenting) {
     if (!gamepads) {
       const oculusVRDisplay = window[symbols.mrDisplaysSymbol].oculusVRDisplay;
       const oculusPresenting = oculusVRDisplay && oculusVRDisplay.isPresenting;
@@ -630,7 +628,9 @@ const getGamepads = window => {
       ];
     }
     return gamepads;
-  };
+  } else {
+    return [];
+  }
 };
 GlobalContext.getGamepads = getGamepads;
 

--- a/src/VR.js
+++ b/src/VR.js
@@ -319,6 +319,7 @@ class FakeVRDisplay extends VRDisplay {
   constructor(window) {
     super('FAKE');
 
+    this.window = window;
     this.position = new THREE.Vector3();
     this.quaternion = new THREE.Quaternion();
     this.gamepads = [

--- a/src/Window.js
+++ b/src/Window.js
@@ -1333,7 +1333,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
       GlobalContext.vrPresentState.layers = layers;
     };
 
-    const openVRDevice = new XR.XRDevice('OpenVR');
+    const openVRDevice = new XR.XRDevice('OpenVR', window);
     openVRDevice.onrequestpresent = layers => nativeOpenVR.requestPresent(layers);
     openVRDevice.onexitpresent = () => nativeOpenVR.exitPresent();
     openVRDevice.onrequestanimationframe = _makeRequestAnimationFrame(window);
@@ -1352,7 +1352,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
       GlobalContext.vrPresentState.layers = layers;
     };
 
-    const oculusVRDevice = new XR.XRDevice('OculusVR');
+    const oculusVRDevice = new XR.XRDevice('OculusVR', window);
     oculusVRDevice.onrequestpresent = layers => nativeOculusVR.requestPresent(layers);
     oculusVRDevice.onexitpresent = () => nativeOculusVR.exitPresent();
     oculusVRDevice.onrequestanimationframe = _makeRequestAnimationFrame(window);
@@ -1380,7 +1380,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
       GlobalContext.mlPresentState.layers = layers;
     };
 
-    const magicLeapARDevice = new XR.XRDevice('AR');
+    const magicLeapARDevice = new XR.XRDevice('AR', window);
     magicLeapARDevice.onrequestpresent = layers => nativeMl.requestPresent(layers);
     magicLeapARDevice.onexitpresent = () => nativeMl.exitPresent();
     magicLeapARDevice.onrequestanimationframe = _makeRequestAnimationFrame(window);

--- a/src/Window.js
+++ b/src/Window.js
@@ -493,7 +493,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
       GlobalContext.fakeVrDisplayEnabled = true;
       return window[symbols.mrDisplaysSymbol].fakeVrDisplay;
     },
-    getGamepads: getGamepads(window),
+    getGamepads: getGamepads.bind(null, window),
     clipboard:{
       read:() => Promise.resolve(), // Not implemented yet
       readText: () => new Promise(resolve => {

--- a/src/XR.js
+++ b/src/XR.js
@@ -42,8 +42,9 @@ class XR extends EventEmitter {
 module.exports.XR = XR;
 
 class XRDevice {
-  constructor(name = 'VR') {
+  constructor(name, window) {
     this.name = name; // non-standard
+    this.window = window; // non-standard
     this.session = null; // non-standard
     
     this._layers = [];
@@ -154,7 +155,7 @@ class XRSession extends EventTarget {
     return Promise.resolve();
   }
   update() {
-    const gamepads = GlobalContext.getGamepads();
+    const gamepads = GlobalContext.getGamepads(this.device.window);
     
     for (let i = 0; i < gamepads.length; i++) {
       const gamepad = gamepads[i];

--- a/src/core.js
+++ b/src/core.js
@@ -1,93 +1,29 @@
-const events = require('events');
-const {EventEmitter} = events;
-const path = require('path');
-const fs = require('fs');
 const url = require('url');
-const http = require('http');
-const https = require('https');
-const ws = require('ws');
-const os = require('os');
-const util = require('util');
 const {URL} = url;
-const {TextEncoder, TextDecoder} = util;
-const {performance} = require('perf_hooks');
-
-const mkdirp = require('mkdirp');
 
 const {_makeWindowWithDocument} = require('./Window.js');
-const {FileReader} = require('./File.js');
-
-const {XMLHttpRequest: XMLHttpRequestBase, FormData} = require('window-xhr');
 
 const fetch = require('window-fetch');
-const {Request, Response, Headers, Blob} = fetch;
 
-const WebSocket = require('ws/lib/websocket');
-
-const nativeWorker = require('worker-native');
-
-const {LocalStorage} = require('node-localstorage');
-const indexedDB = require('fake-indexeddb');
-const parseXml = require('@rgrove/parse-xml');
 const THREE = require('../lib/three-min.js');
-const {
-  MRDisplay,
-  VRDisplay,
-  FakeVRDisplay,
-  VRFrameData,
-  VRPose,
-  VRStageParameters,
-  Gamepad,
-  GamepadButton,
-  getGamepads,
-} = require('./VR.js');
 
-const {defaultCanvasSize} = require('./constants');
 const GlobalContext = require('./GlobalContext');
 const symbols = require('./symbols');
-const {urls} = require('./urls');
 
-GlobalContext.args = {};
-GlobalContext.version = '';
-
-// Class imports.
-const {_parseDocument, _parseDocumentAst, Document, DocumentFragment, DocumentType, DOMImplementation, initDocument} = require('./Document');
 const {
   Element,
   HTMLElement,
-  HTMLBodyElement,
-  HTMLAnchorElement,
-  HTMLStyleElement,
-  HTMLScriptElement,
-  HTMLLinkElement,
-  HTMLImageElement,
-  HTMLAudioElement,
-  HTMLVideoElement,
-  HTMLSourceElement,
-  HTMLIFrameElement,
-  SVGElement,
-  HTMLCanvasElement,
-  HTMLTemplateElement,
-  createImageBitmap,
-  DOMRect,
-  DOMPoint,
   Node,
   NodeList,
   Text,
   Comment,
-  HTMLCollection,
 } = require('./DOM');
-const {CustomEvent, DragEvent, ErrorEvent, Event, EventTarget, KeyboardEvent, MessageEvent, MouseEvent, WheelEvent, PromiseRejectionEvent} = require('./Event');
-const {History} = require('./History');
-const {Location} = require('./Location');
-const {XMLHttpRequest} = require('./Network');
-const XR = require('./XR');
-const DevTools = require('./DevTools');
+const {Event, EventTarget} = require('./Event');
 const utils = require('./utils');
-const {_elementGetter, _elementSetter, _download} = utils;
+const {_download} = utils;
 
-const btoa = s => Buffer.from(s, 'binary').toString('base64');
-const atob = s => Buffer.from(s, 'base64').toString('binary');
+GlobalContext.args = {};
+GlobalContext.version = '';
 
 const maxParallelResources = 8;
 class Resource {


### PR DESCRIPTION
The Oculus Desktop support PR https://github.com/exokitxr/exokit/pull/787 broke WebXR gamepads support due to controllers refactoring to support the new Oculus controller ids.

This PR refactors `getGamepads` to work again.