### PR TITLE
Bump event-loop-native version

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "bugsnag": "^2.4.3",
     "cross-env": "^5.2.0",
     "css": "^2.2.4",
-    "event-loop-native": "0.0.8",
+    "event-loop-native": "0.0.11",
     "events": "^3.0.0",
     "fake-indexeddb": "^2.0.4",
     "fault-zone": "0.0.20",


### PR DESCRIPTION
The `event-loop-native` version was out of sync in the base and in `worker-native` in master. This bumps the root `event-loop-native` to `0.0.11`, to match the `dependencies` of `worker-native`.

Possible fix for https://github.com/exokitxr/exokit/issues/918.