### PR TITLE
Oculus Go direct rendering

### DIFF
--- a/deps/exokit-bindings/egl/src/egl.cc
+++ b/deps/exokit-bindings/egl/src/egl.cc
@@ -247,8 +247,6 @@ NAN_METHOD(Create3D) {
     glGenTextures(sizeof(framebufferTextures)/sizeof(framebufferTextures[0]), framebufferTextures);
   }
 
-  windowsystembase::InitializeLocalGlState(gl);
-
   GLuint vao;
   glGenVertexArrays(1, &vao);
   glBindVertexArray(vao);

--- a/deps/exokit-bindings/glfw/src/glfw.cc
+++ b/deps/exokit-bindings/glfw/src/glfw.cc
@@ -1210,8 +1210,6 @@ NAN_METHOD(Create3D) {
     glfwSetCursorEnterCallback(windowHandle, cursorEnterCB);
     glfwSetScrollCallback(windowHandle, scrollCB);
     
-    windowsystembase::InitializeLocalGlState(gl);
-    
     GLuint vao;
     glGenVertexArrays(1, &vao);
     glBindVertexArray(vao);

--- a/deps/exokit-bindings/webglcontext/include/webgl.h
+++ b/deps/exokit-bindings/webglcontext/include/webgl.h
@@ -85,6 +85,11 @@ enum GlKey {
   GL_KEY_PLANE,
 };
 
+class GlShader {
+public:
+  virtual ~GlShader() = 0;
+};
+
 void flipImageData(char *dstData, char *srcData, size_t width, size_t height, size_t pixelSize);
 
 class ViewportState {

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -1177,7 +1177,7 @@ WebGLRenderingContext::WebGLRenderingContext() :
 
 WebGLRenderingContext::~WebGLRenderingContext() {
   for (auto iter = keys.begin(); iter != keys.end(); iter++) {
-    GlShader *glShader (GlShader *)iter->second;
+    GlShader *glShader = (GlShader *)iter->second;
     delete glShader;
   }
 }

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -1175,7 +1175,12 @@ WebGLRenderingContext::WebGLRenderingContext() :
   activeTexture(GL_TEXTURE0)
   {}
 
-WebGLRenderingContext::~WebGLRenderingContext() {}
+WebGLRenderingContext::~WebGLRenderingContext() {
+  for (auto iter = keys.begin(); iter != keys.end(); iter++) {
+    GlShader *glShader (GlShader *)iter->second;
+    delete glShader;
+  }
+}
 
 NAN_METHOD(WebGLRenderingContext::New) {
   WebGLRenderingContext *gl = new WebGLRenderingContext();

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -36,6 +36,8 @@ void unregisterGLObj(GLuint obj); */
 
 #define JS_GL_CONSTANT(name) JS_GL_SET_CONSTANT(#name, GL_ ## name)
 
+GlShader::~GlShader() {}
+
 template<NAN_METHOD(F)>
 NAN_METHOD(glCallWrap) {
   Local<Object> glObj = info.This();

--- a/deps/exokit-bindings/windowsystem/include/windowsystem.h
+++ b/deps/exokit-bindings/windowsystem/include/windowsystem.h
@@ -27,6 +27,7 @@ enum class LayerType {
 
 class LayerSpec {
 public:
+  LayerType layerType;
   int width;
   int height;
   GLuint msTex;

--- a/deps/exokit-bindings/windowsystem/include/windowsystem.h
+++ b/deps/exokit-bindings/windowsystem/include/windowsystem.h
@@ -43,7 +43,7 @@ public:
   ComposeGlShader();
   virtual ~ComposeGlShader();
 
-  static const GlKey key = GlKey::GL_KEY_COMPOSE;
+  static GlKey key;
 
   GLuint composeVao;
   GLuint composeProgram;
@@ -62,7 +62,7 @@ public:
   PlaneGlShader();
   virtual ~PlaneGlShader();
 
-  static const GlKey key = GlKey::GL_KEY_PLANE;
+  static GlKey key;
 
   GLuint planeVao;
   GLuint planeProgram;

--- a/deps/exokit-bindings/windowsystem/include/windowsystem.h
+++ b/deps/exokit-bindings/windowsystem/include/windowsystem.h
@@ -34,7 +34,6 @@ public:
   GLuint msDepthTex;
   GLuint tex;
   GLuint depthTex;
-  float *viewports[2];
   float *modelView[2];
   float *projection[2];
 };

--- a/deps/exokit-bindings/windowsystem/include/windowsystem.h
+++ b/deps/exokit-bindings/windowsystem/include/windowsystem.h
@@ -40,8 +40,8 @@ public:
 
 class ComposeGlShader : public GlShader {
 public:
-  GlShader();
-  virtual ~GlShader();
+  ComposeGlShader();
+  virtual ~ComposeGlShader();
 
   static const GlKey key = GlKey::GL_KEY_COMPOSE;
 

--- a/deps/exokit-bindings/windowsystem/include/windowsystem.h
+++ b/deps/exokit-bindings/windowsystem/include/windowsystem.h
@@ -38,8 +38,13 @@ public:
   float *projection[2];
 };
 
-class ComposeSpec {
+class ComposeGlShader : public GlShader {
 public:
+  GlShader();
+  virtual ~GlShader();
+
+  static const GlKey key = GlKey::GL_KEY_COMPOSE;
+
   GLuint composeVao;
   GLuint composeProgram;
   GLint positionLocation;
@@ -52,8 +57,13 @@ public:
   GLuint indexBuffer;
 };
 
-class PlaneSpec {
+class PlaneGlShader : public GlShader {
 public:
+  PlaneGlShader();
+  virtual ~PlaneGlShader();
+
+  static const GlKey key = GlKey::GL_KEY_PLANE;
+
   GLuint planeVao;
   GLuint planeProgram;
   GLint positionLocation;
@@ -66,7 +76,6 @@ public:
   GLuint indexBuffer;
 };
 
-void InitializeLocalGlState(WebGLRenderingContext *gl);
 bool CreateRenderTarget(WebGLRenderingContext *gl, int width, int height, GLuint sharedColorTex, GLuint sharedDepthStencilTex, GLuint sharedMsColorTex, GLuint sharedMsDepthStencilTex, GLuint *pfbo, GLuint *pcolorTex, GLuint *pdepthStencilTex, GLuint *pmsFbo, GLuint *pmsColorTex, GLuint *pmsDepthStencilTex);
 NAN_METHOD(CreateRenderTarget);
 NAN_METHOD(ResizeRenderTarget);

--- a/deps/exokit-bindings/windowsystem/src/windowsystem.cc
+++ b/deps/exokit-bindings/windowsystem/src/windowsystem.cc
@@ -35,7 +35,7 @@ uniform sampler2DMS msDepthTex;\n\
 uniform vec4 texSize;\n\
 \n\
 vec4 textureMultisample(sampler2DMS sampler, vec2 uv) {\n\
-  ivec2 iUv = ivec2((uv + texSize.xy) * texSize.zw);\n\
+  ivec2 iUv = ivec2(texSize.xy) + ivec2(uv * texSize.zw);\n\
 \n\
   vec4 color = vec4(0.0);\n\
   for (int i = 0; i < texSamples; i++) {\n\

--- a/deps/exokit-bindings/windowsystem/src/windowsystem.cc
+++ b/deps/exokit-bindings/windowsystem/src/windowsystem.cc
@@ -32,10 +32,10 @@ out vec4 fragColor;\n\
 int texSamples = 4;\n\
 uniform sampler2DMS msTex;\n\
 uniform sampler2DMS msDepthTex;\n\
-uniform vec2 texSize;\n\
+uniform vec4 texSize;\n\
 \n\
 vec4 textureMultisample(sampler2DMS sampler, vec2 uv) {\n\
-  ivec2 iUv = ivec2(uv * texSize);\n\
+  ivec2 iUv = ivec2((uv + texSize.xy) * texSize.zw);\n\
 \n\
   vec4 color = vec4(0.0);\n\
   for (int i = 0; i < texSamples; i++) {\n\
@@ -553,7 +553,7 @@ void ComposeLayer(ComposeSpec *composeSpec, PlaneSpec *planeSpec, const LayerSpe
     glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, layer.msDepthTex);
     glUniform1i(composeSpec->msDepthTexLocation, 1);
 
-    glUniform2f(composeSpec->texSizeLocation, layer.width, layer.height);
+    glUniform4f(composeSpec->texSizeLocation, 0, 0, layer.width, layer.height);
 
     glViewport(0, 0, layer.width, layer.height);
     // glScissor(0, 0, width, height);

--- a/deps/exokit-bindings/windowsystem/src/windowsystem.cc
+++ b/deps/exokit-bindings/windowsystem/src/windowsystem.cc
@@ -541,7 +541,7 @@ NAN_METHOD(DestroyRenderTarget) {
 }
 
 void ComposeLayer(ComposeSpec *composeSpec, PlaneSpec *planeSpec, const LayerSpec &layer) {
-  if (layer.viewports[0] == nullptr) {
+  if (layer.layerType == IFRAME_3D || layer.layerType == RAW_CANVAS) {
     glBindVertexArray(composeSpec->composeVao);
     glUseProgram(composeSpec->composeProgram);
 
@@ -679,6 +679,7 @@ NAN_METHOD(ComposeLayers) {
             int height = TO_INT32(JS_OBJ(framebufferObj->Get(JS_STR("canvas")))->Get(JS_STR("height")));
 
             layers.push_back(LayerSpec{
+              LayerType::IFRAME_3D,
               width,
               height,
               msTex,
@@ -713,6 +714,7 @@ NAN_METHOD(ComposeLayers) {
             int height = TO_INT32(browserObj->Get(JS_STR("height")));
 
             layers.push_back(LayerSpec{
+              LayerType::IFRAME_2D,
               width,
               height,
               0,
@@ -744,6 +746,7 @@ NAN_METHOD(ComposeLayers) {
             int height = TO_INT32(elementObj->Get(JS_STR("height")));
 
             layers.push_back(LayerSpec{
+              LayerType::RAW_CANVAS,
               width,
               height,
               msTex,

--- a/deps/exokit-bindings/windowsystem/src/windowsystem.cc
+++ b/deps/exokit-bindings/windowsystem/src/windowsystem.cc
@@ -625,18 +625,18 @@ void ComposeLayer(WebGLRenderingContext *gl, GLuint *fbos, const LayerSpec &laye
   } else {
     PlaneGlShader *planeGlShader = getGlShader<ComposeGlShader>(gl);
 
-    glBindVertexArray(planeSpec->planeVao);
-    glUseProgram(planeSpec->planeProgram);
+    glBindVertexArray(planeGlShader->planeVao);
+    glUseProgram(planeGlShader->planeProgram);
 
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, layer.tex);
-    glUniform1i(planeSpec->texLocation, 0);
+    glUniform1i(planeGlShader->texLocation, 0);
 
     {
       glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fbos[0]);
 
-      glUniformMatrix4fv(planeSpec->modelViewMatrixLocation, 1, false, layer.modelView[0]);
-      glUniformMatrix4fv(planeSpec->projectionMatrixLocation, 1, false, layer.projection[0]);
+      glUniformMatrix4fv(planeGlShader->modelViewMatrixLocation, 1, false, layer.modelView[0]);
+      glUniformMatrix4fv(planeGlShader->projectionMatrixLocation, 1, false, layer.projection[0]);
 
       // glViewport(layer.viewports[0][0], layer.viewports[0][1], layer.viewports[0][2], layer.viewports[0][3]);
       glViewport(0, 0, layer.width/2, layer.height);
@@ -646,8 +646,8 @@ void ComposeLayer(WebGLRenderingContext *gl, GLuint *fbos, const LayerSpec &laye
     {
       glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fbos[1]);
 
-      glUniformMatrix4fv(planeSpec->modelViewMatrixLocation, 1, false, layer.modelView[1]);
-      glUniformMatrix4fv(planeSpec->projectionMatrixLocation, 1, false, layer.projection[1]);
+      glUniformMatrix4fv(planeGlShader->modelViewMatrixLocation, 1, false, layer.modelView[1]);
+      glUniformMatrix4fv(planeGlShader->projectionMatrixLocation, 1, false, layer.projection[1]);
 
       // glViewport(layer.viewports[1][0], layer.viewports[1][1], layer.viewports[1][2], layer.viewports[1][3]);
       glViewport(layer.width/2, 0, layer.width/2, layer.height);

--- a/deps/exokit-bindings/windowsystem/src/windowsystem.cc
+++ b/deps/exokit-bindings/windowsystem/src/windowsystem.cc
@@ -651,6 +651,7 @@ void ComposeLayers(WebGLRenderingContext *gl, size_t numFbos, GLuint *fbos, cons
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fbos[i]);
     glClear(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT|GL_STENCIL_BUFFER_BIT);
   }
+  // XXX if there is one layer, we can disable depth test/depth write
   if (numFbos == 1) {
     for (size_t i = 0; i < layers.size(); i++) {
       ComposeLayer(composeSpec, planeSpec, layers[i]);

--- a/deps/exokit-bindings/windowsystem/src/windowsystem.cc
+++ b/deps/exokit-bindings/windowsystem/src/windowsystem.cc
@@ -51,6 +51,128 @@ void main() {\n\
 }\n\
 ";
 
+ComposeGlShader::ComposeGlShader() {
+  glGenVertexArrays(1, &this->composeVao);
+
+  // vertex array
+  glBindVertexArray(this->composeVao);
+
+  // vertex shader
+  GLuint composeVertex = glCreateShader(GL_VERTEX_SHADER);
+  glShaderSource(composeVertex, 1, &composeVsh, NULL);
+  glCompileShader(composeVertex);
+  GLint success;
+  glGetShaderiv(composeVertex, GL_COMPILE_STATUS, &success);
+  if (!success) {
+    char infoLog[4096];
+    GLsizei length;
+    glGetShaderInfoLog(composeVertex, sizeof(infoLog), &length, infoLog);
+    infoLog[length] = '\0';
+    exout << "ML compose vertex shader compilation failed:\n" << infoLog << std::endl;
+    return;
+  };
+
+  // fragment shader
+  GLuint composeFragment = glCreateShader(GL_FRAGMENT_SHADER);
+  glShaderSource(composeFragment, 1, &composeFsh, NULL);
+  glCompileShader(composeFragment);
+  glGetShaderiv(composeFragment, GL_COMPILE_STATUS, &success);
+  if (!success) {
+    char infoLog[4096];
+    GLsizei length;
+    glGetShaderInfoLog(composeFragment, sizeof(infoLog), &length, infoLog);
+    infoLog[length] = '\0';
+    exout << "ML compose fragment shader compilation failed:\n" << infoLog << std::endl;
+    return;
+  };
+
+  // shader program
+  this->composeProgram = glCreateProgram();
+  glAttachShader(this->composeProgram, composeVertex);
+  glAttachShader(this->composeProgram, composeFragment);
+  glLinkProgram(this->composeProgram);
+  glGetProgramiv(this->composeProgram, GL_LINK_STATUS, &success);
+  if (!success) {
+    char infoLog[4096];
+    GLsizei length;
+    glGetShaderInfoLog(this->composeProgram, sizeof(infoLog), &length, infoLog);
+    infoLog[length] = '\0';
+    exout << "ML compose program linking failed\n" << infoLog << std::endl;
+    return;
+  }
+
+  this->positionLocation = glGetAttribLocation(this->composeProgram, "position");
+  if (this->positionLocation == -1) {
+    exout << "ML compose program failed to get attrib location for 'position'" << std::endl;
+    return;
+  }
+  this->uvLocation = glGetAttribLocation(this->composeProgram, "uv");
+  if (this->uvLocation == -1) {
+    exout << "ML compose program failed to get attrib location for 'uv'" << std::endl;
+    return;
+  }
+  this->msTexLocation = glGetUniformLocation(this->composeProgram, "msTex");
+  if (this->msTexLocation == -1) {
+    exout << "ML compose program failed to get uniform location for 'msTex'" << std::endl;
+    return;
+  }
+  this->msDepthTexLocation = glGetUniformLocation(this->composeProgram, "msDepthTex");
+  if (this->msDepthTexLocation == -1) {
+    exout << "ML compose program failed to get uniform location for 'msDepthTex'" << std::endl;
+    return;
+  }
+  this->texSizeLocation = glGetUniformLocation(this->composeProgram, "texSize");
+  if (this->texSizeLocation == -1) {
+    exout << "ML compose program failed to get uniform location for 'texSize'" << std::endl;
+    return;
+  }
+
+  // delete the shaders as they're linked into our program now and no longer necessery
+  glDeleteShader(composeVertex);
+  glDeleteShader(composeFragment);
+
+  glGenBuffers(1, &this->positionBuffer);
+  glBindBuffer(GL_ARRAY_BUFFER, this->positionBuffer);
+  static const float positions[] = {
+    -1.0f, 1.0f,
+    1.0f, 1.0f,
+    -1.0f, -1.0f,
+    1.0f, -1.0f,
+  };
+  glBufferData(GL_ARRAY_BUFFER, sizeof(positions), positions, GL_STATIC_DRAW);
+  glEnableVertexAttribArray(this->positionLocation);
+  glVertexAttribPointer(this->positionLocation, 2, GL_FLOAT, false, 0, 0);
+
+  glGenBuffers(1, &this->uvBuffer);
+  glBindBuffer(GL_ARRAY_BUFFER, this->uvBuffer);
+  static const float uvs[] = {
+    0.0f, 1.0f,
+    1.0f, 1.0f,
+    0.0f, 0.0f,
+    1.0f, 0.0f,
+  };
+  glBufferData(GL_ARRAY_BUFFER, sizeof(uvs), uvs, GL_STATIC_DRAW);
+  glEnableVertexAttribArray(this->uvLocation);
+  glVertexAttribPointer(this->uvLocation, 2, GL_FLOAT, false, 0, 0);
+
+  glGenBuffers(1, &this->indexBuffer);
+  static const uint16_t indices[] = {0, 2, 1, 2, 3, 1};
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->indexBuffer);
+  glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices, GL_STATIC_DRAW);
+
+  if (gl->HasVertexArrayBinding()) {
+    glBindVertexArray(gl->GetVertexArrayBinding());
+  } else {
+    glBindVertexArray(gl->defaultVao);
+  }
+  if (gl->HasBufferBinding(GL_ARRAY_BUFFER)) {
+    glBindBuffer(GL_ARRAY_BUFFER, gl->GetBufferBinding(GL_ARRAY_BUFFER));
+  } else {
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+  }
+}
+ComposeGlShader::~ComposeGlShader() {}
+
 const char *planeVsh = ""
 #ifdef ANDROID
 "#version 300 es\n"
@@ -85,248 +207,116 @@ void main() {\n\
 }\n\
 ";
 
-void InitializeLocalGlState(WebGLRenderingContext *gl) {
-  // compose
-  {
-    ComposeSpec *composeSpec = new ComposeSpec();
+PlaneGlShader::PlaneGlShader() {
+  glGenVertexArrays(1, &this->planeVao);
 
-    glGenVertexArrays(1, & composeSpec->composeVao);
+  // vertex array
+  glBindVertexArray(this->planeVao);
 
-    // vertex array
-    glBindVertexArray(composeSpec->composeVao);
+  // vertex shader
+  GLuint planeVertex = glCreateShader(GL_VERTEX_SHADER);
+  glShaderSource(planeVertex, 1, &planeVsh, NULL);
+  glCompileShader(planeVertex);
+  GLint success;
+  glGetShaderiv(planeVertex, GL_COMPILE_STATUS, &success);
+  if (!success) {
+    char infoLog[4096];
+    GLsizei length;
+    glGetShaderInfoLog(planeVertex, sizeof(infoLog), &length, infoLog);
+    infoLog[length] = '\0';
+    exout << "plane vertex shader compilation failed:\n" << infoLog << std::endl;
+    return;
+  };
 
-    // vertex shader
-    GLuint composeVertex = glCreateShader(GL_VERTEX_SHADER);
-    glShaderSource(composeVertex, 1, &composeVsh, NULL);
-    glCompileShader(composeVertex);
-    GLint success;
-    glGetShaderiv(composeVertex, GL_COMPILE_STATUS, &success);
-    if (!success) {
-      char infoLog[4096];
-      GLsizei length;
-      glGetShaderInfoLog(composeVertex, sizeof(infoLog), &length, infoLog);
-      infoLog[length] = '\0';
-      exout << "ML compose vertex shader compilation failed:\n" << infoLog << std::endl;
-      return;
-    };
+  // fragment shader
+  GLuint planeFragment = glCreateShader(GL_FRAGMENT_SHADER);
+  glShaderSource(planeFragment, 1, &planeFsh, NULL);
+  glCompileShader(planeFragment);
+  glGetShaderiv(planeFragment, GL_COMPILE_STATUS, &success);
+  if (!success) {
+    char infoLog[4096];
+    GLsizei length;
+    glGetShaderInfoLog(planeFragment, sizeof(infoLog), &length, infoLog);
+    infoLog[length] = '\0';
+    exout << "plane fragment shader compilation failed:\n" << infoLog << std::endl;
+    return;
+  };
 
-    // fragment shader
-    GLuint composeFragment = glCreateShader(GL_FRAGMENT_SHADER);
-    glShaderSource(composeFragment, 1, &composeFsh, NULL);
-    glCompileShader(composeFragment);
-    glGetShaderiv(composeFragment, GL_COMPILE_STATUS, &success);
-    if (!success) {
-      char infoLog[4096];
-      GLsizei length;
-      glGetShaderInfoLog(composeFragment, sizeof(infoLog), &length, infoLog);
-      infoLog[length] = '\0';
-      exout << "ML compose fragment shader compilation failed:\n" << infoLog << std::endl;
-      return;
-    };
-
-    // shader program
-    composeSpec->composeProgram = glCreateProgram();
-    glAttachShader(composeSpec->composeProgram, composeVertex);
-    glAttachShader(composeSpec->composeProgram, composeFragment);
-    glLinkProgram(composeSpec->composeProgram);
-    glGetProgramiv(composeSpec->composeProgram, GL_LINK_STATUS, &success);
-    if (!success) {
-      char infoLog[4096];
-      GLsizei length;
-      glGetShaderInfoLog(composeSpec->composeProgram, sizeof(infoLog), &length, infoLog);
-      infoLog[length] = '\0';
-      exout << "ML compose program linking failed\n" << infoLog << std::endl;
-      return;
-    }
-
-    composeSpec->positionLocation = glGetAttribLocation(composeSpec->composeProgram, "position");
-    if (composeSpec->positionLocation == -1) {
-      exout << "ML compose program failed to get attrib location for 'position'" << std::endl;
-      return;
-    }
-    composeSpec->uvLocation = glGetAttribLocation(composeSpec->composeProgram, "uv");
-    if (composeSpec->uvLocation == -1) {
-      exout << "ML compose program failed to get attrib location for 'uv'" << std::endl;
-      return;
-    }
-    composeSpec->msTexLocation = glGetUniformLocation(composeSpec->composeProgram, "msTex");
-    if (composeSpec->msTexLocation == -1) {
-      exout << "ML compose program failed to get uniform location for 'msTex'" << std::endl;
-      return;
-    }
-    composeSpec->msDepthTexLocation = glGetUniformLocation(composeSpec->composeProgram, "msDepthTex");
-    if (composeSpec->msDepthTexLocation == -1) {
-      exout << "ML compose program failed to get uniform location for 'msDepthTex'" << std::endl;
-      return;
-    }
-    composeSpec->texSizeLocation = glGetUniformLocation(composeSpec->composeProgram, "texSize");
-    if (composeSpec->texSizeLocation == -1) {
-      exout << "ML compose program failed to get uniform location for 'texSize'" << std::endl;
-      return;
-    }
-
-    // delete the shaders as they're linked into our program now and no longer necessery
-    glDeleteShader(composeVertex);
-    glDeleteShader(composeFragment);
-
-    glGenBuffers(1, &composeSpec->positionBuffer);
-    glBindBuffer(GL_ARRAY_BUFFER, composeSpec->positionBuffer);
-    static const float positions[] = {
-      -1.0f, 1.0f,
-      1.0f, 1.0f,
-      -1.0f, -1.0f,
-      1.0f, -1.0f,
-    };
-    glBufferData(GL_ARRAY_BUFFER, sizeof(positions), positions, GL_STATIC_DRAW);
-    glEnableVertexAttribArray(composeSpec->positionLocation);
-    glVertexAttribPointer(composeSpec->positionLocation, 2, GL_FLOAT, false, 0, 0);
-
-    glGenBuffers(1, &composeSpec->uvBuffer);
-    glBindBuffer(GL_ARRAY_BUFFER, composeSpec->uvBuffer);
-    static const float uvs[] = {
-      0.0f, 1.0f,
-      1.0f, 1.0f,
-      0.0f, 0.0f,
-      1.0f, 0.0f,
-    };
-    glBufferData(GL_ARRAY_BUFFER, sizeof(uvs), uvs, GL_STATIC_DRAW);
-    glEnableVertexAttribArray(composeSpec->uvLocation);
-    glVertexAttribPointer(composeSpec->uvLocation, 2, GL_FLOAT, false, 0, 0);
-
-    glGenBuffers(1, &composeSpec->indexBuffer);
-    static const uint16_t indices[] = {0, 2, 1, 2, 3, 1};
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, composeSpec->indexBuffer);
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices, GL_STATIC_DRAW);
-
-    gl->keys[GlKey::GL_KEY_COMPOSE] = composeSpec;
+  // shader program
+  this->planeProgram = glCreateProgram();
+  glAttachShader(this->planeProgram, planeVertex);
+  glAttachShader(this->planeProgram, planeFragment);
+  glLinkProgram(this->planeProgram);
+  glGetProgramiv(this->planeProgram, GL_LINK_STATUS, &success);
+  if (!success) {
+    char infoLog[4096];
+    GLsizei length;
+    glGetShaderInfoLog(this->planeProgram, sizeof(infoLog), &length, infoLog);
+    infoLog[length] = '\0';
+    exout << "plane program linking failed\n" << infoLog << std::endl;
+    return;
   }
 
-  // plane
-  {
-    PlaneSpec *planeSpec = new PlaneSpec();
-
-    glGenVertexArrays(1, &planeSpec->planeVao);
-
-    // vertex array
-    glBindVertexArray(planeSpec->planeVao);
-
-    // vertex shader
-    GLuint planeVertex = glCreateShader(GL_VERTEX_SHADER);
-    glShaderSource(planeVertex, 1, &planeVsh, NULL);
-    glCompileShader(planeVertex);
-    GLint success;
-    glGetShaderiv(planeVertex, GL_COMPILE_STATUS, &success);
-    if (!success) {
-      char infoLog[4096];
-      GLsizei length;
-      glGetShaderInfoLog(planeVertex, sizeof(infoLog), &length, infoLog);
-      infoLog[length] = '\0';
-      exout << "plane vertex shader compilation failed:\n" << infoLog << std::endl;
-      return;
-    };
-
-    // fragment shader
-    GLuint planeFragment = glCreateShader(GL_FRAGMENT_SHADER);
-    glShaderSource(planeFragment, 1, &planeFsh, NULL);
-    glCompileShader(planeFragment);
-    glGetShaderiv(planeFragment, GL_COMPILE_STATUS, &success);
-    if (!success) {
-      char infoLog[4096];
-      GLsizei length;
-      glGetShaderInfoLog(planeFragment, sizeof(infoLog), &length, infoLog);
-      infoLog[length] = '\0';
-      exout << "plane fragment shader compilation failed:\n" << infoLog << std::endl;
-      return;
-    };
-
-    // shader program
-    planeSpec->planeProgram = glCreateProgram();
-    glAttachShader(planeSpec->planeProgram, planeVertex);
-    glAttachShader(planeSpec->planeProgram, planeFragment);
-    glLinkProgram(planeSpec->planeProgram);
-    glGetProgramiv(planeSpec->planeProgram, GL_LINK_STATUS, &success);
-    if (!success) {
-      char infoLog[4096];
-      GLsizei length;
-      glGetShaderInfoLog(planeSpec->planeProgram, sizeof(infoLog), &length, infoLog);
-      infoLog[length] = '\0';
-      exout << "plane program linking failed\n" << infoLog << std::endl;
-      return;
-    }
-
-    planeSpec->positionLocation = glGetAttribLocation(planeSpec->planeProgram, "position");
-    if (planeSpec->positionLocation == -1) {
-      exout << "plane program failed to get attrib location for 'position'" << std::endl;
-      return;
-    }
-    planeSpec->uvLocation = glGetAttribLocation(planeSpec->planeProgram, "uv");
-    if (planeSpec->uvLocation == -1) {
-      exout << "plane program failed to get attrib location for 'uv'" << std::endl;
-      return;
-    }
-    planeSpec->modelViewMatrixLocation = glGetUniformLocation(planeSpec->planeProgram, "modelViewMatrix");
-    if (planeSpec->modelViewMatrixLocation == -1) {
-      exout << "plane program failed to get uniform location for 'modelViewMatrix'" << std::endl;
-      return;
-    }
-    planeSpec->projectionMatrixLocation = glGetUniformLocation(planeSpec->planeProgram, "projectionMatrix");
-    if (planeSpec->projectionMatrixLocation == -1) {
-      exout << "plane program failed to get uniform location for 'projectionMatrix'" << std::endl;
-      return;
-    }
-    planeSpec->texLocation = glGetUniformLocation(planeSpec->planeProgram, "tex");
-    if (planeSpec->texLocation == -1) {
-      exout << "plane program failed to get uniform location for 'tex'" << std::endl;
-      return;
-    }
-
-    // delete the shaders as they're linked into our program now and no longer necessery
-    glDeleteShader(planeVertex);
-    glDeleteShader(planeFragment);
-
-    glGenBuffers(1, &planeSpec->positionBuffer);
-    glBindBuffer(GL_ARRAY_BUFFER, planeSpec->positionBuffer);
-    static const float positions[] = {
-      -1.0f, 1.0f,
-      1.0f, 1.0f,
-      -1.0f, -1.0f,
-      1.0f, -1.0f,
-    };
-    glBufferData(GL_ARRAY_BUFFER, sizeof(positions), positions, GL_STATIC_DRAW);
-    glEnableVertexAttribArray(planeSpec->positionLocation);
-    glVertexAttribPointer(planeSpec->positionLocation, 2, GL_FLOAT, false, 0, 0);
-
-    glGenBuffers(1, &planeSpec->uvBuffer);
-    glBindBuffer(GL_ARRAY_BUFFER, planeSpec->uvBuffer);
-    static const float uvs[] = {
-      0.0f, 0.0f,
-      1.0f, 0.0f,
-      0.0f, 1.0f,
-      1.0f, 1.0f,
-    };
-    glBufferData(GL_ARRAY_BUFFER, sizeof(uvs), uvs, GL_STATIC_DRAW);
-    glEnableVertexAttribArray(planeSpec->uvLocation);
-    glVertexAttribPointer(planeSpec->uvLocation, 2, GL_FLOAT, false, 0, 0);
-
-    glGenBuffers(1, &planeSpec->indexBuffer);
-    static const uint16_t indices[] = {0, 2, 1, 2, 3, 1};
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, planeSpec->indexBuffer);
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices, GL_STATIC_DRAW);
-
-    gl->keys[GlKey::GL_KEY_PLANE] = planeSpec;
+  this->positionLocation = glGetAttribLocation(this->planeProgram, "position");
+  if (this->positionLocation == -1) {
+    exout << "plane program failed to get attrib location for 'position'" << std::endl;
+    return;
+  }
+  this->uvLocation = glGetAttribLocation(this->planeProgram, "uv");
+  if (this->uvLocation == -1) {
+    exout << "plane program failed to get attrib location for 'uv'" << std::endl;
+    return;
+  }
+  this->modelViewMatrixLocation = glGetUniformLocation(this->planeProgram, "modelViewMatrix");
+  if (this->modelViewMatrixLocation == -1) {
+    exout << "plane program failed to get uniform location for 'modelViewMatrix'" << std::endl;
+    return;
+  }
+  this->projectionMatrixLocation = glGetUniformLocation(this->planeProgram, "projectionMatrix");
+  if (this->projectionMatrixLocation == -1) {
+    exout << "plane program failed to get uniform location for 'projectionMatrix'" << std::endl;
+    return;
+  }
+  this->texLocation = glGetUniformLocation(this->planeProgram, "tex");
+  if (this->texLocation == -1) {
+    exout << "plane program failed to get uniform location for 'tex'" << std::endl;
+    return;
   }
 
-  if (gl->HasVertexArrayBinding()) {
-    glBindVertexArray(gl->GetVertexArrayBinding());
-  } else {
-    glBindVertexArray(gl->defaultVao);
-  }
-  if (gl->HasBufferBinding(GL_ARRAY_BUFFER)) {
-    glBindBuffer(GL_ARRAY_BUFFER, gl->GetBufferBinding(GL_ARRAY_BUFFER));
-  } else {
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-  }
+  // delete the shaders as they're linked into our program now and no longer necessery
+  glDeleteShader(planeVertex);
+  glDeleteShader(planeFragment);
+
+  glGenBuffers(1, &this->positionBuffer);
+  glBindBuffer(GL_ARRAY_BUFFER, this->positionBuffer);
+  static const float positions[] = {
+    -1.0f, 1.0f,
+    1.0f, 1.0f,
+    -1.0f, -1.0f,
+    1.0f, -1.0f,
+  };
+  glBufferData(GL_ARRAY_BUFFER, sizeof(positions), positions, GL_STATIC_DRAW);
+  glEnableVertexAttribArray(this->positionLocation);
+  glVertexAttribPointer(this->positionLocation, 2, GL_FLOAT, false, 0, 0);
+
+  glGenBuffers(1, &this->uvBuffer);
+  glBindBuffer(GL_ARRAY_BUFFER, this->uvBuffer);
+  static const float uvs[] = {
+    0.0f, 0.0f,
+    1.0f, 0.0f,
+    0.0f, 1.0f,
+    1.0f, 1.0f,
+  };
+  glBufferData(GL_ARRAY_BUFFER, sizeof(uvs), uvs, GL_STATIC_DRAW);
+  glEnableVertexAttribArray(this->uvLocation);
+  glVertexAttribPointer(this->uvLocation, 2, GL_FLOAT, false, 0, 0);
+
+  glGenBuffers(1, &this->indexBuffer);
+  static const uint16_t indices[] = {0, 2, 1, 2, 3, 1};
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->indexBuffer);
+  glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices, GL_STATIC_DRAW);
 }
+PlaneGlShader::~PlaneGlShader() {}
 
 constexpr GLint MAX_TEXTURE_SIZE = 4096;
 bool CreateRenderTarget(WebGLRenderingContext *gl, int width, int height, GLuint sharedColorTex, GLuint sharedDepthStencilTex, GLuint sharedMsColorTex, GLuint sharedMsDepthStencilTex, GLuint *pfbo, GLuint *pcolorTex, GLuint *pdepthStencilTex, GLuint *pmsFbo, GLuint *pmsColorTex, GLuint *pmsDepthStencilTex) {
@@ -540,35 +530,66 @@ NAN_METHOD(DestroyRenderTarget) {
   }
 }
 
-void ComposeLayer(ComposeSpec *composeSpec, PlaneSpec *planeSpec, const LayerSpec &layer) {
+template <typename T>
+T *getGlShader(WebGLRenderingContext *gl) {
+  const GlKey &key = T::key;
+  auto iter = gl->keys.find(key);
+  if (iter != gl->keys.end()) {
+    return (T *)iter->second;
+  } else {
+    T *t = new T();
+
+    {
+      if (gl->HasVertexArrayBinding()) {
+        glBindVertexArray(gl->GetVertexArrayBinding());
+      } else {
+        glBindVertexArray(gl->defaultVao);
+      }
+      if (gl->HasBufferBinding(GL_ARRAY_BUFFER)) {
+        glBindBuffer(GL_ARRAY_BUFFER, gl->GetBufferBinding(GL_ARRAY_BUFFER));
+      } else {
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
+      }
+    }
+
+    gl->keys[key] = t;
+    return t;
+  }
+}
+
+void ComposeLayer(WebGLRenderingContext *gl, const LayerSpec &layer) {
   if (layer.layerType == LayerType::IFRAME_3D || layer.layerType == LayerType::RAW_CANVAS) {
-    glBindVertexArray(composeSpec->composeVao);
-    glUseProgram(composeSpec->composeProgram);
+    ComposeGlShader *composeGlShader = getGlShader<ComposeGlShader>(gl);
+
+    glBindVertexArray(composeGlShader->composeVao);
+    glUseProgram(composeGlShader->composeProgram);
 
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, layer.msTex);
-    glUniform1i(composeSpec->msTexLocation, 0);
+    glUniform1i(composeGlShader->msTexLocation, 0);
 
     glActiveTexture(GL_TEXTURE1);
     glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, layer.msDepthTex);
-    glUniform1i(composeSpec->msDepthTexLocation, 1);
+    glUniform1i(composeGlShader->msDepthTexLocation, 1);
 
-    glUniform4f(composeSpec->texSizeLocation, 0, 0, layer.width, layer.height);
+    glUniform4f(composeGlShader->texSizeLocation, 0, 0, layer.width, layer.height);
 
     glViewport(0, 0, layer.width, layer.height);
     // glScissor(0, 0, width, height);
     glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, 0);
   } else {
-    glBindVertexArray(planeSpec->planeVao);
-    glUseProgram(planeSpec->planeProgram);
+    PlaneGlShader *planeGlShader = getGlShader<ComposeGlShader>(gl);
+
+    glBindVertexArray(planeGlShader->planeVao);
+    glUseProgram(planeGlShader->planeProgram);
 
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, layer.tex);
-    glUniform1i(planeSpec->texLocation, 0);
+    glUniform1i(planeGlShader->texLocation, 0);
 
     {
-      glUniformMatrix4fv(planeSpec->modelViewMatrixLocation, 1, false, layer.modelView[0]);
-      glUniformMatrix4fv(planeSpec->projectionMatrixLocation, 1, false, layer.projection[0]);
+      glUniformMatrix4fv(planeGlShader->modelViewMatrixLocation, 1, false, layer.modelView[0]);
+      glUniformMatrix4fv(planeGlShader->projectionMatrixLocation, 1, false, layer.projection[0]);
 
       // glViewport(layer.viewports[0][0], layer.viewports[0][1], layer.viewports[0][2], layer.viewports[0][3]);
       glViewport(0, 0, layer.width/2, layer.height);
@@ -576,8 +597,8 @@ void ComposeLayer(ComposeSpec *composeSpec, PlaneSpec *planeSpec, const LayerSpe
       glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, 0);
     }
     {
-      glUniformMatrix4fv(planeSpec->modelViewMatrixLocation, 1, false, layer.modelView[1]);
-      glUniformMatrix4fv(planeSpec->projectionMatrixLocation, 1, false, layer.projection[1]);
+      glUniformMatrix4fv(planeGlShader->modelViewMatrixLocation, 1, false, layer.modelView[1]);
+      glUniformMatrix4fv(planeGlShader->projectionMatrixLocation, 1, false, layer.projection[1]);
 
       // glViewport(layer.viewports[1][0], layer.viewports[1][1], layer.viewports[1][2], layer.viewports[1][3]);
       glViewport(layer.width/2, 0, layer.width/2, layer.height);
@@ -587,18 +608,20 @@ void ComposeLayer(ComposeSpec *composeSpec, PlaneSpec *planeSpec, const LayerSpe
   }
 }
 
-void ComposeLayer(ComposeSpec *composeSpec, PlaneSpec *planeSpec, GLuint *fbos, const LayerSpec &layer) {
+void ComposeLayer(WebGLRenderingContext *gl, GLuint *fbos, const LayerSpec &layer) {
   if (layer.layerType == LayerType::IFRAME_3D || layer.layerType == LayerType::RAW_CANVAS) {
-    glBindVertexArray(composeSpec->composeVao);
-    glUseProgram(composeSpec->composeProgram);
+    ComposeGlShader *composeGlShader = getGlShader<ComposeGlShader>(gl);
+
+    glBindVertexArray(composeGlShader->composeVao);
+    glUseProgram(composeGlShader->composeProgram);
 
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, layer.msTex);
-    glUniform1i(composeSpec->msTexLocation, 0);
+    glUniform1i(composeGlShader->msTexLocation, 0);
 
     glActiveTexture(GL_TEXTURE1);
     glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, layer.msDepthTex);
-    glUniform1i(composeSpec->msDepthTexLocation, 1);
+    glUniform1i(composeGlShader->msDepthTexLocation, 1);
 
     glViewport(0, 0, layer.width/2, layer.height);
     // glScissor(0, 0, width, height);
@@ -606,11 +629,13 @@ void ComposeLayer(ComposeSpec *composeSpec, PlaneSpec *planeSpec, GLuint *fbos, 
     for (size_t i = 0; i < 2; i++) {
       glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fbos[i]);
 
-      glUniform4f(composeSpec->texSizeLocation, i*(layer.width/2), 0, layer.width/2, layer.height);
+      glUniform4f(composeGlShader->texSizeLocation, i*(layer.width/2), 0, layer.width/2, layer.height);
 
       glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, 0);
     }
   } else {
+    PlaneGlShader *planeGlShader = getGlShader<ComposeGlShader>(gl);
+
     glBindVertexArray(planeSpec->planeVao);
     glUseProgram(planeSpec->planeProgram);
 
@@ -644,9 +669,6 @@ void ComposeLayer(ComposeSpec *composeSpec, PlaneSpec *planeSpec, GLuint *fbos, 
 }
 
 void ComposeLayers(WebGLRenderingContext *gl, size_t numFbos, GLuint *fbos, const std::vector<LayerSpec> &layers) {
-  ComposeSpec *composeSpec = (ComposeSpec *)(gl->keys[GlKey::GL_KEY_COMPOSE]);
-  PlaneSpec *planeSpec = (PlaneSpec *)(gl->keys[GlKey::GL_KEY_PLANE]);
-
   for (size_t i = 0; i < numFbos; i++) {
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fbos[i]);
     glClear(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT|GL_STENCIL_BUFFER_BIT);
@@ -654,11 +676,11 @@ void ComposeLayers(WebGLRenderingContext *gl, size_t numFbos, GLuint *fbos, cons
   // XXX if there is one layer, we can disable depth test/depth write
   if (numFbos == 1) {
     for (size_t i = 0; i < layers.size(); i++) {
-      ComposeLayer(composeSpec, planeSpec, layers[i]);
+      ComposeLayer(gl, layers[i]);
     }
   } else {
     for (size_t i = 0; i < layers.size(); i++) {
-      ComposeLayer(composeSpec, planeSpec, fbos, layers[i]);
+      ComposeLayer(gl, fbos, layers[i]);
     }
   }
 

--- a/deps/exokit-bindings/windowsystem/src/windowsystem.cc
+++ b/deps/exokit-bindings/windowsystem/src/windowsystem.cc
@@ -567,7 +567,7 @@ void ComposeLayer(WebGLRenderingContext *gl, const LayerSpec &layer) {
     // glScissor(0, 0, width, height);
     glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, 0);
   } else {
-    PlaneGlShader *planeGlShader = getGlShader<ComposeGlShader>(gl);
+    PlaneGlShader *planeGlShader = getGlShader<PlaneGlShader>(gl);
 
     glBindVertexArray(planeGlShader->planeVao);
     glUseProgram(planeGlShader->planeProgram);
@@ -623,7 +623,7 @@ void ComposeLayer(WebGLRenderingContext *gl, GLuint *fbos, const LayerSpec &laye
       glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, 0);
     }
   } else {
-    PlaneGlShader *planeGlShader = getGlShader<ComposeGlShader>(gl);
+    PlaneGlShader *planeGlShader = getGlShader<PlaneGlShader>(gl);
 
     glBindVertexArray(planeGlShader->planeVao);
     glUseProgram(planeGlShader->planeProgram);

--- a/deps/exokit-bindings/windowsystem/src/windowsystem.cc
+++ b/deps/exokit-bindings/windowsystem/src/windowsystem.cc
@@ -161,6 +161,7 @@ ComposeGlShader::ComposeGlShader() {
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices, GL_STATIC_DRAW);
 }
 ComposeGlShader::~ComposeGlShader() {}
+GlKey ComposeGlShader::key = GlKey::GL_KEY_COMPOSE;
 
 const char *planeVsh = ""
 #ifdef ANDROID
@@ -306,6 +307,7 @@ PlaneGlShader::PlaneGlShader() {
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices, GL_STATIC_DRAW);
 }
 PlaneGlShader::~PlaneGlShader() {}
+GlKey PlaneGlShader::key = GlKey::GL_KEY_PLANE;
 
 constexpr GLint MAX_TEXTURE_SIZE = 4096;
 bool CreateRenderTarget(WebGLRenderingContext *gl, int width, int height, GLuint sharedColorTex, GLuint sharedDepthStencilTex, GLuint sharedMsColorTex, GLuint sharedMsDepthStencilTex, GLuint *pfbo, GLuint *pcolorTex, GLuint *pdepthStencilTex, GLuint *pmsFbo, GLuint *pmsColorTex, GLuint *pmsDepthStencilTex) {

--- a/deps/exokit-bindings/windowsystem/src/windowsystem.cc
+++ b/deps/exokit-bindings/windowsystem/src/windowsystem.cc
@@ -570,7 +570,8 @@ void ComposeLayer(ComposeSpec *composeSpec, PlaneSpec *planeSpec, const LayerSpe
       glUniformMatrix4fv(planeSpec->modelViewMatrixLocation, 1, false, layer.modelView[0]);
       glUniformMatrix4fv(planeSpec->projectionMatrixLocation, 1, false, layer.projection[0]);
 
-      glViewport(layer.viewports[0][0], layer.viewports[0][1], layer.viewports[0][2], layer.viewports[0][3]);
+      // glViewport(layer.viewports[0][0], layer.viewports[0][1], layer.viewports[0][2], layer.viewports[0][3]);
+      glViewport(0, 0, layer.width/2, layer.height);
       // glScissor(0, 0, width, height);
       glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, 0);
     }
@@ -578,7 +579,8 @@ void ComposeLayer(ComposeSpec *composeSpec, PlaneSpec *planeSpec, const LayerSpe
       glUniformMatrix4fv(planeSpec->modelViewMatrixLocation, 1, false, layer.modelView[1]);
       glUniformMatrix4fv(planeSpec->projectionMatrixLocation, 1, false, layer.projection[1]);
 
-      glViewport(layer.viewports[1][0], layer.viewports[1][1], layer.viewports[1][2], layer.viewports[1][3]);
+      // glViewport(layer.viewports[1][0], layer.viewports[1][1], layer.viewports[1][2], layer.viewports[1][3]);
+      glViewport(layer.width/2, 0, layer.width/2, layer.height);
       // glScissor(0, 0, width, height);
       glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, 0);
     }
@@ -687,7 +689,6 @@ NAN_METHOD(ComposeLayers) {
               tex,
               depthTex,
               {nullptr,nullptr},
-              {nullptr,nullptr},
               {nullptr,nullptr}
             });
             break;
@@ -695,11 +696,11 @@ NAN_METHOD(ComposeLayers) {
           case LayerType::IFRAME_2D: {
             Local<Object> browserObj = Local<Object>::Cast(elementObj->Get(JS_STR("browser")));
             GLuint tex = TO_UINT32(Local<Object>::Cast(browserObj->Get(JS_STR("texture")))->Get(JS_STR("id")));
-            Local<Array> viewportsArray = Local<Array>::Cast(browserObj->Get(JS_STR("viewports")));
+            /* Local<Array> viewportsArray = Local<Array>::Cast(browserObj->Get(JS_STR("viewports"))); // XXX get rid of this in callers
             Local<Float32Array> viewportsFloat32Arrays[] = {
               Local<Float32Array>::Cast(viewportsArray->Get(0)),
               Local<Float32Array>::Cast(viewportsArray->Get(1)),
-            };
+            }; */
             Local<Array> modelViewArray = Local<Array>::Cast(browserObj->Get(JS_STR("modelView")));
             Local<Float32Array> modelViewFloat32Arrays[] = {
               Local<Float32Array>::Cast(modelViewArray->Get(0)),
@@ -721,10 +722,6 @@ NAN_METHOD(ComposeLayers) {
               0,
               tex,
               0,
-              { // viewports
-                (float *)((char *)(viewportsFloat32Arrays[0]->Buffer()->GetContents().Data()) + viewportsFloat32Arrays[0]->ByteOffset()),
-                (float *)((char *)(viewportsFloat32Arrays[1]->Buffer()->GetContents().Data()) + viewportsFloat32Arrays[1]->ByteOffset())
-              },
               { // modelView
                 (float *)((char *)(modelViewFloat32Arrays[0]->Buffer()->GetContents().Data()) + modelViewFloat32Arrays[0]->ByteOffset()),
                 (float *)((char *)(modelViewFloat32Arrays[1]->Buffer()->GetContents().Data()) + modelViewFloat32Arrays[1]->ByteOffset())
@@ -753,7 +750,6 @@ NAN_METHOD(ComposeLayers) {
               msDepthTex,
               tex,
               depthTex,
-              {nullptr,nullptr},
               {nullptr,nullptr},
               {nullptr,nullptr}
             });

--- a/deps/exokit-bindings/windowsystem/src/windowsystem.cc
+++ b/deps/exokit-bindings/windowsystem/src/windowsystem.cc
@@ -541,7 +541,7 @@ NAN_METHOD(DestroyRenderTarget) {
 }
 
 void ComposeLayer(ComposeSpec *composeSpec, PlaneSpec *planeSpec, const LayerSpec &layer) {
-  if (layer.layerType == IFRAME_3D || layer.layerType == RAW_CANVAS) {
+  if (layer.layerType == LayerType::IFRAME_3D || layer.layerType == LayerType::RAW_CANVAS) {
     glBindVertexArray(composeSpec->composeVao);
     glUseProgram(composeSpec->composeProgram);
 
@@ -588,25 +588,26 @@ void ComposeLayer(ComposeSpec *composeSpec, PlaneSpec *planeSpec, const LayerSpe
 }
 
 void ComposeLayer(ComposeSpec *composeSpec, PlaneSpec *planeSpec, GLuint *fbos, const LayerSpec &layer) {
-  if (layer.layerType == IFRAME_3D || layer.layerType == RAW_CANVAS) {
+  if (layer.layerType == LayerType::IFRAME_3D || layer.layerType == LayerType::RAW_CANVAS) {
+    glBindVertexArray(composeSpec->composeVao);
+    glUseProgram(composeSpec->composeProgram);
+
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, layer.msTex);
+    glUniform1i(composeSpec->msTexLocation, 0);
+
+    glActiveTexture(GL_TEXTURE1);
+    glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, layer.msDepthTex);
+    glUniform1i(composeSpec->msDepthTexLocation, 1);
+
+    glViewport(0, 0, layer.width/2, layer.height);
+    // glScissor(0, 0, width, height);
+
     for (size_t i = 0; i < 2; i++) {
       glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fbos[i]);
 
-      glBindVertexArray(composeSpec->composeVao);
-      glUseProgram(composeSpec->composeProgram);
-
-      glActiveTexture(GL_TEXTURE0);
-      glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, layer.msTex);
-      glUniform1i(composeSpec->msTexLocation, 0);
-
-      glActiveTexture(GL_TEXTURE1);
-      glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, layer.msDepthTex);
-      glUniform1i(composeSpec->msDepthTexLocation, 1);
-
       glUniform4f(composeSpec->texSizeLocation, i*(layer.width/2), 0, layer.width/2, layer.height);
 
-      glViewport(0, 0, layer.width/2, layer.height);
-      // glScissor(0, 0, width, height);
       glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, 0);
     }
   } else {
@@ -752,7 +753,7 @@ NAN_METHOD(ComposeLayers) {
             int height = TO_INT32(JS_OBJ(framebufferObj->Get(JS_STR("canvas")))->Get(JS_STR("height")));
 
             layers.push_back(LayerSpec{
-              LayerType::IFRAME_3D,
+              layerType,
               width,
               height,
               msTex,
@@ -786,7 +787,7 @@ NAN_METHOD(ComposeLayers) {
             int height = TO_INT32(browserObj->Get(JS_STR("height")));
 
             layers.push_back(LayerSpec{
-              LayerType::IFRAME_2D,
+              layerType,
               width,
               height,
               0,
@@ -814,7 +815,7 @@ NAN_METHOD(ComposeLayers) {
             int height = TO_INT32(elementObj->Get(JS_STR("height")));
 
             layers.push_back(LayerSpec{
-              LayerType::RAW_CANVAS,
+              layerType,
               width,
               height,
               msTex,

--- a/deps/exokit-bindings/windowsystem/src/windowsystem.cc
+++ b/deps/exokit-bindings/windowsystem/src/windowsystem.cc
@@ -593,57 +593,6 @@ void ComposeLayers(WebGLRenderingContext *gl, GLuint fbo, const std::vector<Laye
 
   glClear(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT|GL_STENCIL_BUFFER_BIT);
 
-  /* // blit
-  for (size_t i = 0; i < layers.size(); i++) {
-    const LayerSpec &layer = layers[i];
-
-    if (layer.blit) {
-      glBindFramebuffer(GL_READ_FRAMEBUFFER, composeSpec->composeReadFbo);
-      glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D_MULTISAMPLE, layer.msColorTex, 0);
-      glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D_MULTISAMPLE, layer.msDepthTex, 0);
-
-      glBindFramebuffer(GL_DRAW_FRAMEBUFFER, composeSpec->composeWriteFbo);
-      glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, layer.colorTex, 0);
-      glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, layer.depthTex, 0);
-
-      glBlitFramebuffer(
-        0, 0,
-        layer.width, layer.height,
-        0, 0,
-        layer.width, layer.height,
-        GL_COLOR_BUFFER_BIT,
-        GL_LINEAR);
-
-      glBlitFramebuffer(
-        0, 0,
-        layer.width, layer.height,
-        0, 0,
-        layer.width, layer.height,
-        GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT,
-        GL_NEAREST);
-
-      glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fbo);
-    }
-  }
-
-  // render unblitted
-  for (size_t i = 0; i < layers.size(); i++) {
-    const LayerSpec &layer = layers[i];
-
-    if (!layer.blit) {
-      ComposeLayer(composeSpec, layer);
-    }
-  }
-
-  // render blitted
-  for (size_t i = 0; i < layers.size(); i++) {
-    const LayerSpec &layer = layers[i];
-
-    if (layer.blit) {
-      ComposeLayer(composeSpec, layer);
-    }
-  } */
-
   for (size_t i = 0; i < layers.size(); i++) {
     const LayerSpec &layer = layers[i];
     ComposeLayer(composeSpec, planeSpec, layer);

--- a/deps/exokit-bindings/windowsystem/src/windowsystem.cc
+++ b/deps/exokit-bindings/windowsystem/src/windowsystem.cc
@@ -159,17 +159,6 @@ ComposeGlShader::ComposeGlShader() {
   static const uint16_t indices[] = {0, 2, 1, 2, 3, 1};
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->indexBuffer);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices, GL_STATIC_DRAW);
-
-  if (gl->HasVertexArrayBinding()) {
-    glBindVertexArray(gl->GetVertexArrayBinding());
-  } else {
-    glBindVertexArray(gl->defaultVao);
-  }
-  if (gl->HasBufferBinding(GL_ARRAY_BUFFER)) {
-    glBindBuffer(GL_ARRAY_BUFFER, gl->GetBufferBinding(GL_ARRAY_BUFFER));
-  } else {
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-  }
 }
 ComposeGlShader::~ComposeGlShader() {}
 

--- a/deps/oculus-mobile/include/oculus-context.h
+++ b/deps/oculus-mobile/include/oculus-context.h
@@ -14,7 +14,7 @@ class OculusMobileContext : public ObjectWrap {
 public:
   static Local<Function> Initialize();
 
-  void RequestPresent();
+  void RequestPresent(int width, int height);
   static void handleAppCmd(struct android_app *app, int32_t cmd);
   void CreateSwapChain(WebGLRenderingContext *gl, int width, int height);
   void PollEvents(bool wait);
@@ -22,6 +22,7 @@ public:
   static NAN_METHOD(New);
   void Destroy();
 
+  static NAN_METHOD(RequestPresent);
   static NAN_METHOD(WaitGetPoses);
   static NAN_METHOD(Submit);
   static NAN_METHOD(GetRecommendedRenderTargetSize);
@@ -34,11 +35,10 @@ public:
   ovrMobile *ovrState;
   bool running;
   ANativeWindow *androidNativeWindow;
-  ovrTextureSwapChain *swapChains[2];
+  ovrTextureSwapChain *swapChain;
   int swapChainMetrics[2];
   int swapChainLength;
   int swapChainIndex;
-  bool hasSwapChain;
   GLuint fboId;
   ovrTracking2 tracking;
   long long frameIndex;

--- a/deps/oculus-mobile/include/oculus-context.h
+++ b/deps/oculus-mobile/include/oculus-context.h
@@ -10,11 +10,16 @@ namespace oculusmobile {
 
 extern ovrJava java;
 
+typedef struct SwapChain {
+  ovrTextureSwapChain *Color;
+  ovrTextureSwapChain *Depth;
+} EyeSwapChain;
+
 class OculusMobileContext : public ObjectWrap {
 public:
   static Local<Function> Initialize();
 
-  void RequestPresent(int width, int height);
+  void RequestPresent();
   static void handleAppCmd(struct android_app *app, int32_t cmd);
   void CreateSwapChain(WebGLRenderingContext *gl, int width, int height);
   void PollEvents(bool wait);
@@ -23,6 +28,7 @@ public:
   void Destroy();
 
   static NAN_METHOD(RequestPresent);
+  static NAN_METHOD(CreateSwapChain);
   static NAN_METHOD(WaitGetPoses);
   static NAN_METHOD(Submit);
   static NAN_METHOD(GetRecommendedRenderTargetSize);
@@ -35,11 +41,15 @@ public:
   ovrMobile *ovrState;
   bool running;
   ANativeWindow *androidNativeWindow;
-  ovrTextureSwapChain *swapChain;
+  SwapChain swapChain;
   int swapChainMetrics[2];
+  WebGLRenderingContext *swapChainGl;
   int swapChainLength;
   int swapChainIndex;
-  GLuint fboId;
+  GLuint fbo;
+  GLuint msFbo;
+  GLuint msColorTex;
+  GLuint msDepthStencilTex;
   ovrTracking2 tracking;
   long long frameIndex;
 	double displayTime;

--- a/deps/oculus-mobile/include/oculus-context.h
+++ b/deps/oculus-mobile/include/oculus-context.h
@@ -41,12 +41,12 @@ public:
   ovrMobile *ovrState;
   bool running;
   ANativeWindow *androidNativeWindow;
-  SwapChain swapChain;
+  SwapChain swapChains[2];
   int swapChainMetrics[2];
   WebGLRenderingContext *swapChainGl;
   int swapChainLength;
   int swapChainIndex;
-  GLuint fbo;
+  GLuint fbos[2];
   GLuint msFbo;
   GLuint msColorTex;
   GLuint msDepthStencilTex;

--- a/deps/oculus-mobile/include/oculus-mobile.h
+++ b/deps/oculus-mobile/include/oculus-mobile.h
@@ -1,6 +1,8 @@
 #ifndef _OCULUS_MOBILE_H_
 #define _OCULUS_MOBILE_H_
 
+#include <unistd.h>
+
 #include <v8.h>
 #include <nan.h>
 

--- a/deps/oculus-mobile/src/oculus-context.cpp
+++ b/deps/oculus-mobile/src/oculus-context.cpp
@@ -97,6 +97,7 @@ Local<Function> OculusMobileContext::Initialize() {
   // prototype
   Local<ObjectTemplate> proto = ctor->PrototypeTemplate();
   Nan::SetMethod(proto, "RequestPresent", RequestPresent);
+  Nan::SetMethod(proto, "CreateSwapChain", CreateSwapChain);
   Nan::SetMethod(proto, "WaitGetPoses", WaitGetPoses);
   Nan::SetMethod(proto, "Submit", Submit);
   Nan::SetMethod(proto, "GetRecommendedRenderTargetSize", GetRecommendedRenderTargetSize);
@@ -308,6 +309,18 @@ NAN_METHOD(OculusMobileContext::CreateSwapChain) {
   int height = TO_INT32(info[2]);
 
   oculusMobileContext->CreateSwapChain(gl, width, height);
+
+  GLuint colorTex = 0;
+  GLuint depthStencilTex = 0;
+
+  Local<Array> array = Array::New(Isolate::GetCurrent(), 6);
+  array->Set(0, JS_INT(oculusMobileContext->fbo));
+  array->Set(1, JS_INT(colorTex));
+  array->Set(2, JS_INT(depthStencilTex));
+  array->Set(3, JS_INT(oculusMobileContext->msFbo));
+  array->Set(4, JS_INT(oculusMobileContext->msColorTex));
+  array->Set(5, JS_INT(oculusMobileContext->msDepthStencilTex));
+  info.GetReturnValue().Set(array);
 }
 
 NAN_METHOD(OculusMobileContext::WaitGetPoses) {
@@ -451,7 +464,7 @@ NAN_METHOD(OculusMobileContext::GetRecommendedRenderTargetSize) {
 
 NAN_METHOD(OculusMobileContext::Submit) {
   OculusMobileContext *oculusMobileContext = ObjectWrap::Unwrap<OculusMobileContext>(info.This());
-  WebGLRenderingContext *gl = ObjectWrap::Unwrap<WebGLRenderingContext>(Local<Object>::Cast(info[0]));
+  // WebGLRenderingContext *gl = ObjectWrap::Unwrap<WebGLRenderingContext>(Local<Object>::Cast(info[0]));
 
   ovrLayerProjection2 layer = vrapi_DefaultLayerProjection2();
   layer.HeadPose = oculusMobileContext->tracking.HeadPose;

--- a/deps/oculus-mobile/src/oculus-context.cpp
+++ b/deps/oculus-mobile/src/oculus-context.cpp
@@ -530,9 +530,13 @@ NAN_METHOD(OculusMobileContext::Submit) {
 
   if (oculusMobileContext->swapChainGl->HasFramebufferBinding(GL_READ_FRAMEBUFFER)) {
     glBindFramebuffer(GL_READ_FRAMEBUFFER, oculusMobileContext->swapChainGl->GetFramebufferBinding(GL_READ_FRAMEBUFFER));
+  } else {
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, oculusMobileContext->swapChainGl->defaultFramebuffer);
   }
   if (oculusMobileContext->swapChainGl->HasFramebufferBinding(GL_DRAW_FRAMEBUFFER)) {
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, oculusMobileContext->swapChainGl->GetFramebufferBinding(GL_DRAW_FRAMEBUFFER));
+  } else {
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, oculusMobileContext->swapChainGl->defaultFramebuffer);
   }
 }
 

--- a/deps/oculus-mobile/src/oculus-mobile.cpp
+++ b/deps/oculus-mobile/src/oculus-mobile.cpp
@@ -18,6 +18,9 @@ Nan::Persistent<v8::Object> oculusMobileContext;
 NAN_METHOD(OculusMobile_Init) {
   std::cout << "OculusMobile_Init 1" << std::endl;
 
+  int width = TO_INT32(info[0]);
+  int height = TO_INT32(info[1]);
+
   Local<Array> windowHandleArray = Local<Array>::Cast(info[0]);
 
   if (oculusMobileContextConstructor.IsEmpty()) {
@@ -33,8 +36,6 @@ NAN_METHOD(OculusMobile_Init) {
   oculusMobileContext.Reset(oculusMobileContextObj);
 
   OculusMobileContext *omc = ObjectWrap::Unwrap<OculusMobileContext>(oculusMobileContextObj);
-  omc->RequestPresent();
-
   info.GetReturnValue().Set(oculusMobileContextObj);
 }
 

--- a/deps/oculus-mobile/src/oculus-mobile.cpp
+++ b/deps/oculus-mobile/src/oculus-mobile.cpp
@@ -18,9 +18,6 @@ Nan::Persistent<v8::Object> oculusMobileContext;
 NAN_METHOD(OculusMobile_Init) {
   std::cout << "OculusMobile_Init 1" << std::endl;
 
-  int width = TO_INT32(info[0]);
-  int height = TO_INT32(info[1]);
-
   Local<Array> windowHandleArray = Local<Array>::Cast(info[0]);
 
   if (oculusMobileContextConstructor.IsEmpty()) {

--- a/deps/oculus-mobile/src/oculus-mobile.cpp
+++ b/deps/oculus-mobile/src/oculus-mobile.cpp
@@ -36,6 +36,7 @@ NAN_METHOD(OculusMobile_Init) {
   oculusMobileContext.Reset(oculusMobileContextObj);
 
   OculusMobileContext *omc = ObjectWrap::Unwrap<OculusMobileContext>(oculusMobileContextObj);
+  omc->RequestPresent();
   info.GetReturnValue().Set(oculusMobileContextObj);
 }
 

--- a/scripts/gen-assets-h.js
+++ b/scripts/gen-assets-h.js
@@ -80,7 +80,7 @@ Promise.all([
     // console.log('write 2', b.toString('utf8'));
     // process.stdout.write(b);
     process.stdout.write(b);
-    process.stderr.write(JSON.stringify(assetStat,null,2) + '\n');
+    // process.stderr.write(JSON.stringify(assetStat,null,2) + '\n');
 
     /* console.log(`  { // ${assetStat.path}`);
     console.log(`    AssetStat *as = &assetStats[${i}];`);

--- a/src/Window.js
+++ b/src/Window.js
@@ -1430,8 +1430,8 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
     };
 
     const oculusMobileVrDevice = new XR.XRDevice('OculusMobileVR', window);
-    oculusMobileVrDevice.onrequestpresent = layers => nativeOculusMobileVr.requestPresent(layers);
-    oculusMobileVrDevice.onexitpresent = () => nativeOculusMobileVr.exitPresent();
+    oculusMobileVrDevice.onrequestpresent = layers => nativeOculusMobileVR.requestPresent(layers);
+    oculusMobileVrDevice.onexitpresent = () => nativeOculusMobileVR.exitPresent();
     oculusMobileVrDevice.onrequestanimationframe = _makeRequestAnimationFrame(window);
     oculusMobileVrDevice.oncancelanimationframe = window.cancelAnimationFrame;
     oculusMobileVrDevice.requestSession = (requestSession => function() {

--- a/src/Window.js
+++ b/src/Window.js
@@ -1430,8 +1430,8 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
     };
 
     const oculusMobileVrDevice = new XR.XRDevice('OculusMobileVR', window);
-    oculusMobileVrDevice.onrequestpresent = layers => nativeOculusMobileVR.requestPresent(layers);
-    oculusMobileVrDevice.onexitpresent = () => nativeOculusMobileVR.exitPresent();
+    oculusMobileVrDevice.onrequestpresent = layers => nativeOculusMobileVr.requestPresent(layers);
+    oculusMobileVrDevice.onexitpresent = () => nativeOculusMobileVr.exitPresent();
     oculusMobileVrDevice.onrequestanimationframe = _makeRequestAnimationFrame(window);
     oculusMobileVrDevice.oncancelanimationframe = window.cancelAnimationFrame;
     oculusMobileVrDevice.requestSession = (requestSession => function() {

--- a/src/index.js
+++ b/src/index.js
@@ -795,25 +795,26 @@ if (nativeBindings.nativeOculusMobileVr) {
 
         // fps = VR_FPS;
 
-        const vrContext = oculusMobileVrPresentState.vrContext = oculusMobileVrPresentState.vrContext || nativeBindings.nativeOculusMobileVr.OculusMobile_Init(context.getWindowHandle());
+        const vrContext = oculusMobileVrPresentState.vrContext || nativeBindings.nativeOculusMobileVr.OculusMobile_Init(context.getWindowHandle());
 
         vrContext.SetupSwapChain(context);
 
         const {width: halfWidth, height} = vrContext.GetRecommendedRenderTargetSize();
-        const MAX_TEXTURE_SIZE = 4096;
+        /* const MAX_TEXTURE_SIZE = 4096;
         const MAX_TEXTURE_SIZE_HALF = MAX_TEXTURE_SIZE/2;
         if (halfWidth > MAX_TEXTURE_SIZE_HALF) {
           const factor = halfWidth / MAX_TEXTURE_SIZE_HALF;
           halfWidth = MAX_TEXTURE_SIZE_HALF;
           height = Math.floor(height / factor);
-        }
+        } */
         const width = halfWidth * 2;
         xrState.renderWidth[0] = halfWidth;
         xrState.renderHeight[0] = height;
 
         const cleanups = [];
 
-        const [fbo, tex, depthTex, msFbo, msTex, msDepthTex] = nativeBindings.nativeWindow.createRenderTarget(context, width, height, 0, 0, 0, 0);
+        const [fbo, tex, depthTex, msFbo, msTex, msDepthTex] = vrContext.CreateSwapChain(context, width, height);
+        // const [fbo, tex, depthTex, msFbo, msTex, msDepthTex] = nativeBindings.nativeWindow.createRenderTarget(context, width, height, 0, 0, 0, 0);
 
         context.setDefaultFramebuffer(msFbo);
 
@@ -843,7 +844,20 @@ if (nativeBindings.nativeOculusMobileVr) {
           if (name === 'width' || name === 'height') {
             nativeBindings.nativeWindow.setCurrentWindowContext(windowHandle);
 
-            nativeBindings.nativeWindow.resizeRenderTarget(context, canvas.width, canvas.height, fbo, tex, depthTex, msFbo, msTex, msDepthTex);
+            const [fbo, tex, depthTex, msFbo, msTex, msDepthTex] = vrContext.CreateSwapChain(context, canvas.width, canvas.height);
+            context.setDefaultFramebuffer(msFbo);
+            oculusMobileVrPresentState.fbo = fbo;
+            oculusMobileVrPresentState.tex = tex;
+            oculusMobileVrPresentState.depthTex = depthTex;
+            oculusMobileVrPresentState.msFbo = msFbo;
+            oculusMobileVrPresentState.msTex = msTex;
+            oculusMobileVrPresentState.msDepthTex = msDepthTex;
+            canvas.framebuffer.fbo = fbo;
+            canvas.framebuffer.tex = tex;
+            canvas.framebuffer.depthTex = depthTex;
+            canvas.framebuffer.msFbo = msFbo;
+            canvas.framebuffer.msTex = msTex;
+            canvas.framebuffer.msDepthTex = msDepthTex;
           }
         };
         canvas.on('attribute', _attribute);
@@ -1414,7 +1428,7 @@ const _startRenderLoop = () => {
               nativeWindow.blitFrameBuffer(context, oculusMobileVrPresentState.msFbo, oculusMobileVrPresentState.fbo, oculusMobileVrPresentState.glContext.canvas.width, oculusMobileVrPresentState.glContext.canvas.height, oculusMobileVrPresentState.glContext.canvas.width, oculusMobileVrPresentState.glContext.canvas.height, true, false, false);
             }
 
-            oculusMobileVrPresentState.vrContext.Submit(oculusMobileVrPresentState.glContext);
+            oculusMobileVrPresentState.vrContext.Submit();
             oculusMobileVrPresentState.hasPose = false;
           } else if (mlPresentState.mlGlContext === context && mlPresentState.mlHasPose) {
             if (mlPresentState.layers.length > 0) { // TODO: composition can be directly to the output texture array

--- a/src/index.js
+++ b/src/index.js
@@ -795,6 +795,8 @@ if (nativeBindings.nativeOculusMobileVr) {
 
         const vrContext = oculusMobileVrPresentState.vrContext = oculusMobileVrPresentState.vrContext || nativeBindings.nativeOculusMobileVr.OculusMobile_Init(context.getWindowHandle());
 
+        vrContext.SetupSwapChain(context);
+
         const {width: halfWidth, height} = vrContext.GetRecommendedRenderTargetSize();
         const MAX_TEXTURE_SIZE = 4096;
         const MAX_TEXTURE_SIZE_HALF = MAX_TEXTURE_SIZE/2;
@@ -1828,11 +1830,6 @@ const _startRenderLoop = () => {
           rightGamepad.connected[0] = 0;
         }
       }
-
-      /* vrPresentState.system.GetProjectionRaw(0, localFovArray);
-      for (let i = 0; i < localFovArray.length; i++) {
-        xrState.leftFov[i] = Math.atan(localFovArray[i]) / Math.PI * 180;
-      } */
     } else if (mlPresentState.mlGlContext) {
       mlPresentState.mlHasPose = await new Promise((accept, reject) => {
         mlPresentState.mlContext.RequestGetPoses(

--- a/src/index.js
+++ b/src/index.js
@@ -1419,7 +1419,7 @@ const _startRenderLoop = () => {
               _decorateModelViewProjections(oculusMobileVrPresentState.layers, vrDisplay, 2); // note: vrDisplay mirrors xrDisplay
               nativeWindow.composeLayers(context, oculusMobileVrPresentState.fbos, oculusMobileVrPresentState.layers);
             } else {
-              nativeWindow.blitFrameBuffer(context, oculusMobileVrPresentState.msFbo, oculusMobileVrPresentState.fbos, oculusMobileVrPresentState.glContext.canvas.width, oculusMobileVrPresentState.glContext.canvas.height, oculusMobileVrPresentState.glContext.canvas.width, oculusMobileVrPresentState.glContext.canvas.height, true, false, false);
+              nativeWindow.composeLayers(context, oculusMobileVrPresentState.fbos, [context.canvas]);
             }
 
             oculusMobileVrPresentState.vrContext.Submit();

--- a/src/index.js
+++ b/src/index.js
@@ -800,13 +800,6 @@ if (nativeBindings.nativeOculusMobileVr) {
         vrContext.SetupSwapChain(context);
 
         const {width: halfWidth, height} = vrContext.GetRecommendedRenderTargetSize();
-        /* const MAX_TEXTURE_SIZE = 4096;
-        const MAX_TEXTURE_SIZE_HALF = MAX_TEXTURE_SIZE/2;
-        if (halfWidth > MAX_TEXTURE_SIZE_HALF) {
-          const factor = halfWidth / MAX_TEXTURE_SIZE_HALF;
-          halfWidth = MAX_TEXTURE_SIZE_HALF;
-          height = Math.floor(height / factor);
-        } */
         const width = halfWidth * 2;
         xrState.renderWidth[0] = halfWidth;
         xrState.renderHeight[0] = height;

--- a/src/index.js
+++ b/src/index.js
@@ -1424,9 +1424,9 @@ const _startRenderLoop = () => {
             if (oculusMobileVrPresentState.layers.length > 0) {
               const {oculusMobileVrDisplay} = window[symbols.mrDisplaysSymbol];
               _decorateModelViewProjections(oculusMobileVrPresentState.layers, vrDisplay, 2); // note: vrDisplay mirrors xrDisplay
-              nativeWindow.composeLayers(context, oculusMobileVrPresentState.fbo, oculusMobileVrPresentState.layers);
+              nativeWindow.composeLayers(context, oculusMobileVrPresentState.fbos, oculusMobileVrPresentState.layers);
             } else {
-              nativeWindow.blitFrameBuffer(context, oculusMobileVrPresentState.msFbo, oculusMobileVrPresentState.fbo, oculusMobileVrPresentState.glContext.canvas.width, oculusMobileVrPresentState.glContext.canvas.height, oculusMobileVrPresentState.glContext.canvas.width, oculusMobileVrPresentState.glContext.canvas.height, true, false, false);
+              nativeWindow.blitFrameBuffer(context, oculusMobileVrPresentState.msFbo, oculusMobileVrPresentState.fbos, oculusMobileVrPresentState.glContext.canvas.width, oculusMobileVrPresentState.glContext.canvas.height, oculusMobileVrPresentState.glContext.canvas.width, oculusMobileVrPresentState.glContext.canvas.height, true, false, false);
             }
 
             oculusMobileVrPresentState.vrContext.Submit();

--- a/src/index.js
+++ b/src/index.js
@@ -645,8 +645,6 @@ if (nativeBindings.nativeOpenVR) {
 
         const cleanups = [];
 
-        system.RequestPresent(context, width, height); // XXX use this instead of the below swap chain
-
         const [fbo, tex, depthTex, msFbo, msTex, msDepthTex] = nativeBindings.nativeWindow.createRenderTarget(context, width, height, 0, 0, 0, 0);
 
         context.setDefaultFramebuffer(msFbo);

--- a/src/index.js
+++ b/src/index.js
@@ -768,7 +768,7 @@ const oculusMobileVrPresentState = {
   msFbo: null,
   msTex: null,
   msDepthTex: null,
-  fbo: null,
+  fbos: null,
   tex: null,
   depthTex: null,
   cleanups: null,
@@ -813,7 +813,7 @@ if (nativeBindings.nativeOculusMobileVr) {
 
         const cleanups = [];
 
-        const [fbo, tex, depthTex, msFbo, msTex, msDepthTex] = vrContext.CreateSwapChain(context, width, height);
+        const [fbos, tex, depthTex, msFbo, msTex, msDepthTex] = vrContext.CreateSwapChain(context, width, height);
         // const [fbo, tex, depthTex, msFbo, msTex, msDepthTex] = nativeBindings.nativeWindow.createRenderTarget(context, width, height, 0, 0, 0, 0);
 
         context.setDefaultFramebuffer(msFbo);
@@ -824,7 +824,7 @@ if (nativeBindings.nativeOculusMobileVr) {
         oculusMobileVrPresentState.msFbo = msFbo;
         oculusMobileVrPresentState.msTex = msTex;
         oculusMobileVrPresentState.msDepthTex = msDepthTex;
-        oculusMobileVrPresentState.fbo = fbo;
+        oculusMobileVrPresentState.fbos = fbos;
         oculusMobileVrPresentState.tex = tex;
         oculusMobileVrPresentState.depthTex = depthTex;
         oculusMobileVrPresentState.cleanups = cleanups;
@@ -835,7 +835,7 @@ if (nativeBindings.nativeOculusMobileVr) {
           msFbo,
           msTex,
           msDepthTex,
-          fbo,
+          fbos,
           tex,
           depthTex,
         };
@@ -844,15 +844,15 @@ if (nativeBindings.nativeOculusMobileVr) {
           if (name === 'width' || name === 'height') {
             nativeBindings.nativeWindow.setCurrentWindowContext(windowHandle);
 
-            const [fbo, tex, depthTex, msFbo, msTex, msDepthTex] = vrContext.CreateSwapChain(context, canvas.width, canvas.height);
+            const [fbos, tex, depthTex, msFbo, msTex, msDepthTex] = vrContext.CreateSwapChain(context, canvas.width, canvas.height);
             context.setDefaultFramebuffer(msFbo);
-            oculusMobileVrPresentState.fbo = fbo;
+            oculusMobileVrPresentState.fbos = fbos;
             oculusMobileVrPresentState.tex = tex;
             oculusMobileVrPresentState.depthTex = depthTex;
             oculusMobileVrPresentState.msFbo = msFbo;
             oculusMobileVrPresentState.msTex = msTex;
             oculusMobileVrPresentState.msDepthTex = msDepthTex;
-            canvas.framebuffer.fbo = fbo;
+            canvas.framebuffer.fbos = fbos;
             canvas.framebuffer.tex = tex;
             canvas.framebuffer.depthTex = depthTex;
             canvas.framebuffer.msFbo = msFbo;
@@ -874,14 +874,14 @@ if (nativeBindings.nativeOculusMobileVr) {
         return canvas.framebuffer;
       } else if (canvas.ownerDocument.framebuffer) {
         const {width, height} = canvas;
-        const {msFbo, msTex, msDepthTex, fbo, tex, depthTex} = canvas.ownerDocument.framebuffer;
+        const {msFbo, msTex, msDepthTex, fbos, tex, depthTex} = canvas.ownerDocument.framebuffer;
         return {
           width,
           height,
           msFbo,
           msTex,
           msDepthTex,
-          fbo,
+          fbos,
           tex,
           depthTex,
         };
@@ -889,14 +889,14 @@ if (nativeBindings.nativeOculusMobileVr) {
         /* const {width: halfWidth, height} = oculusMobileVrPresentState.vrContext.GetRecommendedRenderTargetSize();
         const width = halfWidth * 2; */
 
-        const {msFbo, msTex, msDepthTex, fbo, tex, depthTex} = oculusMobileVrPresentState;
+        const {msFbo, msTex, msDepthTex, fbos, tex, depthTex} = oculusMobileVrPresentState;
         return {
           width: xrState.renderWidth[0] * 2,
           height: xrState.renderHeight[0],
           msFbo,
           msTex,
           msDepthTex,
-          fbo,
+          fbos,
           tex,
           depthTex,
         };
@@ -909,8 +909,9 @@ if (nativeBindings.nativeOculusMobileVr) {
     if (oculusMobileVrPresentState.isPresenting) {
       nativeBindings.nativeOculusMobileVr.OculusMobile_Shutdown();
 
-      nativeBindings.nativeWindow.destroyRenderTarget(oculusMobileVrPresentState.msFbo, oculusMobileVrPresentState.msTex, oculusMobileVrPresentState.msDepthStencilTex);
-      nativeBindings.nativeWindow.destroyRenderTarget(oculusMobileVrPresentState.fbo, oculusMobileVrPresentState.tex, oculusMobileVrPresentState.msDepthTex);
+      // XXX destroy the swap chain
+      // nativeBindings.nativeWindow.destroyRenderTarget(oculusMobileVrPresentState.msFbo, oculusMobileVrPresentState.msTex, oculusMobileVrPresentState.msDepthStencilTex);
+      // nativeBindings.nativeWindow.destroyRenderTarget(oculusMobileVrPresentState.fbo, oculusMobileVrPresentState.tex, oculusMobileVrPresentState.msDepthTex);
 
       const context = oculusMobileVrPresentState.glContext;
       nativeBindings.nativeWindow.setCurrentWindowContext(context.getWindowHandle());
@@ -926,7 +927,7 @@ if (nativeBindings.nativeOculusMobileVr) {
       oculusMobileVrPresentState.msFbo = null;
       oculusMobileVrPresentState.msTex = null;
       oculusMobileVrPresentState.msDepthTex = null;
-      oculusMobileVrPresentState.fbo = null;
+      oculusMobileVrPresentState.fbos = null;
       oculusMobileVrPresentState.tex = null;
       oculusMobileVrPresentState.depthTex = null;
       oculusMobileVrPresentState.cleanups = null;

--- a/src/index.js
+++ b/src/index.js
@@ -797,8 +797,6 @@ if (nativeBindings.nativeOculusMobileVr) {
 
         const vrContext = oculusMobileVrPresentState.vrContext || nativeBindings.nativeOculusMobileVr.OculusMobile_Init(context.getWindowHandle());
 
-        vrContext.SetupSwapChain(context);
-
         const {width: halfWidth, height} = vrContext.GetRecommendedRenderTargetSize();
         const width = halfWidth * 2;
         xrState.renderWidth[0] = halfWidth;

--- a/src/index.js
+++ b/src/index.js
@@ -645,6 +645,8 @@ if (nativeBindings.nativeOpenVR) {
 
         const cleanups = [];
 
+        system.RequestPresent(context, width, height); // XXX use this instead of the below swap chain
+
         const [fbo, tex, depthTex, msFbo, msTex, msDepthTex] = nativeBindings.nativeWindow.createRenderTarget(context, width, height, 0, 0, 0, 0);
 
         context.setDefaultFramebuffer(msFbo);
@@ -1412,7 +1414,7 @@ const _startRenderLoop = () => {
               nativeWindow.blitFrameBuffer(context, oculusMobileVrPresentState.msFbo, oculusMobileVrPresentState.fbo, oculusMobileVrPresentState.glContext.canvas.width, oculusMobileVrPresentState.glContext.canvas.height, oculusMobileVrPresentState.glContext.canvas.width, oculusMobileVrPresentState.glContext.canvas.height, true, false, false);
             }
 
-            oculusMobileVrPresentState.vrContext.Submit(oculusMobileVrPresentState.glContext, oculusMobileVrPresentState.fbo, oculusMobileVrPresentState.glContext.canvas.width, oculusMobileVrPresentState.glContext.canvas.height);
+            oculusMobileVrPresentState.vrContext.Submit(oculusMobileVrPresentState.glContext);
             oculusMobileVrPresentState.hasPose = false;
           } else if (mlPresentState.mlGlContext === context && mlPresentState.mlHasPose) {
             if (mlPresentState.layers.length > 0) { // TODO: composition can be directly to the output texture array


### PR DESCRIPTION
Sibling of Oculus desktop direct rendering https://github.com/exokitxr/exokit/pull/929.

This refactors the Oculus mobile swap chain to render directly to the headset swap chain texture instead of blitting to it from our own framebuffer.

This should save some non-trivial performance, since it saves a full synchronous memory copy each frame.