### PR TITLE
Consider multiple calls to requestPresent with different canvases

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -480,7 +480,7 @@ if (nativeBindings.nativeOculusVR) {
     const layer = layers.find(layer => layer && layer.source && layer.source.tagName === 'CANVAS');
     if (layer) {
       const canvas = layer.source;
-      if (!vrPresentState.glContext) {
+      if (vrPresentState.glContext !== canvas._context) {
         let context = canvas._context;
         if (!(context && context.constructor && context.constructor.name === 'WebGLRenderingContext')) {
           context = canvas.getContext('webgl');

--- a/src/index.js
+++ b/src/index.js
@@ -598,7 +598,7 @@ if (nativeBindings.nativeOpenVR) {
     if (layer) {
       const canvas = layer.source;
 
-      if (!vrPresentState.glContext) {
+      if (vrPresentState.glContext !== canvas._context) {
         let context = canvas._context;
         if (!(context && context.constructor && context.constructor.name === 'WebGLRenderingContext')) {
           context = canvas.getContext('webgl');
@@ -765,7 +765,7 @@ if (nativeBindings.nativeMl) {
     if (layer) {
       const canvas = layer.source;
 
-      if (!mlPresentState.mlGlContext) {
+      if (mlPresentState.glContext !== canvas._context) {
         let context = canvas._context;
         if (!(context && context.constructor && context.constructor.name === 'WebGLRenderingContext')) {
           context = canvas.getContext('webgl');

--- a/src/index.js
+++ b/src/index.js
@@ -765,7 +765,7 @@ if (nativeBindings.nativeMl) {
     if (layer) {
       const canvas = layer.source;
 
-      if (mlPresentState.glContext !== canvas._context) {
+      if (mlPresentState.mlGlContext !== canvas._context) {
         let context = canvas._context;
         if (!(context && context.constructor && context.constructor.name === 'WebGLRenderingContext')) {
           context = canvas.getContext('webgl');


### PR DESCRIPTION
A-Frame master attaches a `vrdisplayactivate` listener early, before the scene loads. If the event triggers, a dummy canvas is used to call `requestPresent` immediately to fit within the time limits that some browsers have to exercise the option of invoking `requestPresent` without user gesture requirement. requestPresent is called again when the scene loads and the real canvas and associated webgl context are initialized. Current code in master will ignore the second call because a glContext is already defined resulting in the scene not presenting.