### PR TITLE
Add common build errors doc

### DIFF
--- a/docs/sdk/commonBuildErrors.md
+++ b/docs/sdk/commonBuildErrors.md
@@ -1,0 +1,19 @@
+---
+title: Common Build Errors 
+type: sdk
+layout: docs
+order: 2
+parent_section: sdk
+---
+
+This doc covers common errors when building the Exokit engine and their solutions.
+
+### `Error: Cannot find module './build/Release/vm_one.node'`
+
+There was a build failure that was ignored and node_modules contains the failure. Wipe node_modules and try to build again.
+
+```sh
+rm -rf node_modules
+npm cache clean
+```
+

--- a/docs/sdk/commonBuildErrors.md
+++ b/docs/sdk/commonBuildErrors.md
@@ -10,7 +10,7 @@ This doc covers common errors when building the Exokit engine and their solution
 
 ### `Error: Cannot find module './build/Release/vm_one.node'`
 
-There was a build failure that was ignored and node_modules contains the failure. Wipe node_modules and try to build again.
+There was a build failure that was ignored and `node_modules` contains the failure. Wipe `node_modules` and try to build again.
 
 ```sh
 rm -rf node_modules

--- a/docs/sdk/exokitCommandLine.md
+++ b/docs/sdk/exokitCommandLine.md
@@ -2,7 +2,7 @@
 title: Command Line
 type: sdk
 layout: docs
-order: 2
+order: 3
 parent_section: sdk
 ---
 

--- a/docs/sdk/exokitCommandLineFlags.md
+++ b/docs/sdk/exokitCommandLineFlags.md
@@ -2,7 +2,7 @@
 title: Command Line Flags
 type: sdk
 layout: docs
-order: 3
+order: 4
 parent_section: sdk
 ---
 

--- a/docs/sdk/realityTabs.md
+++ b/docs/sdk/realityTabs.md
@@ -2,7 +2,7 @@
 title: Reality Tabs
 type: sdk
 layout: docs
-order: 4
+order: 5
 parent_section: sdk
 ---
 


### PR DESCRIPTION
This doc covers common errors when building the Exokit engine and their solutions.