### PR TITLE
Reality tabs re-present to HMD

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -480,12 +480,13 @@ if (nativeBindings.nativeOculusVR) {
     const layer = layers.find(layer => layer && layer.source && layer.source.tagName === 'CANVAS');
     if (layer) {
       const canvas = layer.source;
-      if (vrPresentState.glContext !== canvas._context) {
+      const window = canvas.ownerDocument.defaultView;
+
+      if (!vrPresentState.glContext || (vrPresentState.glContext.canvas.ownerDocument.defaultView === window && vrPresentState.glContext !== canvas._context)) {
         let context = canvas._context;
         if (!(context && context.constructor && context.constructor.name === 'WebGLRenderingContext')) {
           context = canvas.getContext('webgl');
         }
-        const window = canvas.ownerDocument.defaultView;
 
         const windowHandle = context.getWindowHandle();
         nativeBindings.nativeWindow.setCurrentWindowContext(windowHandle);
@@ -597,13 +598,13 @@ if (nativeBindings.nativeOpenVR) {
     const layer = layers.find(layer => layer && layer.source && layer.source.tagName === 'CANVAS');
     if (layer) {
       const canvas = layer.source;
+      const window = canvas.ownerDocument.defaultView;
 
-      if (vrPresentState.glContext !== canvas._context) {
+      if (!vrPresentState.glContext || (vrPresentState.glContext.canvas.ownerDocument.defaultView === window && vrPresentState.glContext !== canvas._context)) {
         let context = canvas._context;
         if (!(context && context.constructor && context.constructor.name === 'WebGLRenderingContext')) {
           context = canvas.getContext('webgl');
         }
-        const window = canvas.ownerDocument.defaultView;
 
         const windowHandle = context.getWindowHandle();
         nativeBindings.nativeWindow.setCurrentWindowContext(windowHandle);
@@ -764,8 +765,9 @@ if (nativeBindings.nativeMl) {
     const layer = layers.find(layer => layer && layer.source && layer.source.tagName === 'CANVAS');
     if (layer) {
       const canvas = layer.source;
+      const window = canvas.ownerDocument.defaultView;
 
-      if (mlPresentState.mlGlContext !== canvas._context) {
+      if (!mlPresentState.mlGlContext || (mlPresentState.mlGlContext.canvas.ownerDocument.defaultView === window && mlPresentState.mlGlContext !== canvas._context)) {
         let context = canvas._context;
         if (!(context && context.constructor && context.constructor.name === 'WebGLRenderingContext')) {
           context = canvas.getContext('webgl');


### PR DESCRIPTION
The [double-present PR](https://github.com/exokitxr/exokit/pull/931) broke all (single-threaded) reality tabs cases.

This is because reality tabs always ask for a re-present from the lower `<iframe/>`, which will already be (correctly) occupied by a session from the parent page (the browser UI). We do _not_ want to re-present to the headset in this case, or else the lower page will have taken over from the parent, which is not what we want.

The way to check for this is to only allow double presentation from the same page that initiated it. If there is another window already present, then we want to ignore the new presentation request and simply re-use the framebuffer.

Related: https://github.com/exokitxr/exokit/issues/932