### PR TITLE
Oculus Go Default running

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -413,12 +413,16 @@ int main(int argc, char **argv) {
     if (access("/package/app/index.html", F_OK) != -1) {
       jsString = "/package/app/index.html";
     } else {
-      jsString = "examples/realitytabs.html";
+      jsString = "/package/examples/realitytabs.html";
     }
 
     const char *nodeString = "node";
     const char *experimentalWorkerString = "--experimental-worker";
+#ifndef ANDROID
     const char *dotString = ".";
+#else
+    const char *dotString = "/package";
+#endif
     char argsString[4096];
     int i = 0;
 


### PR DESCRIPTION
Most versions of Exokit default to a `realitytabs.html` test environment for the default page. This wasn't the case for android, which requires a slightly different set of arguments to be passed to `node`.

This PR fixes that, so `exokit.apk` is nominally launchable as a VR activity.