### PR TITLE
Bugfix AndroidManifest.xml app name

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.native_activity"
+    package="com.webmr.exokit"
     android:versionCode="1"
     android:versionName="1.0"
     android:installLocation="auto">


### PR DESCRIPTION
Fixes `AndroidManifest.xml` to have `com.webmr.exokit` as the app name to help with installability on Oculus Go.

The previous example name was invalid.