### PR TITLE
Add android debugging scripts

### DIFF
--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -63,4 +63,7 @@ pushd android
 ./gradlew build && ./gradlew assembleDebug
 popd
 
+# for debugging symbols lookup
+rsync -a --copy-links android/app/build/intermediates/cmake/debug/obj/arm64-v8a/libnative-main.so android/app/src/main/arm64-v8a/libnative-main.so
+
 popd

--- a/scripts/debug-android.sh
+++ b/scripts/debug-android.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Initialization.
+
+set -e
+
+# Preface.
+
+cd "$(dirname "$0")/.."
+
+pushd ./android/app/src/main
+"$ANDROID_HOME/ndk-bundle/ndk-gdb" --adb="$ANDROID_HOME/platform-tools/adb" --launch=android.app.NativeActivity
+popd


### PR DESCRIPTION
Adds `apk` debuggability bootstrapping scripts, based on `ndk-gdb`.