### PR TITLE
Add default DOM <head> and <body>

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1442,6 +1442,12 @@ class HTMLLoadableElement extends HTMLElement {
 }
 module.exports.HTMLLoadableElement = HTMLLoadableElement;
 
+class HTMLHeadElement extends HTMLElement {
+  constructor(window) {
+    super(window, 'HEAD');
+  }
+}
+
 class HTMLBodyElement extends HTMLElement {
   constructor(window) {
     super(window, 'BODY');
@@ -3104,6 +3110,7 @@ const getBoundDOMElements = window => {
   return {
     Element: bind(Element, b => function Element() { return b.apply(this, arguments); }),
     HTMLElement: bind(HTMLElement, b => function HTMLElement() { return b.apply(this, arguments); }),
+    HTMLHeadElement: bind(HTMLHeadElement, b => function HTMLHeadElement() { return b.apply(this, arguments); }),
     HTMLBodyElement: bind(HTMLBodyElement, b => function HTMLBodyElement() { return b.apply(this, arguments); }),
     HTMLAnchorElement: bind(HTMLAnchorElement, b => function HTMLAnchorElement() { return b.apply(this, arguments); }),
     HTMLStyleElement: bind(HTMLStyleElement, b => function HTMLStyleElement() { return b.apply(this, arguments); }),

--- a/src/Document.js
+++ b/src/Document.js
@@ -28,8 +28,8 @@ module.exports._parseDocumentAst = _parseDocumentAst;
 function initDocument (document, window) {
   const html = document.childNodes.find(el => el.tagName === 'HTML');
   const documentElement = html || (document.childNodes.length > 0 ? document.childNodes[0] : null);
-  const head = html ? html.childNodes.find(el => el.tagName === 'HEAD') : null;
-  const body = html ? html.childNodes.find(el => el.tagName === 'BODY') : null;
+  const head = html ? html.childNodes.find(el => el.tagName === 'HEAD') : new window.HTMLHeadElement();
+  const body = html ? html.childNodes.find(el => el.tagName === 'BODY') : new window.HTMLBodyElement();
 
   document.documentElement = documentElement;
   document.readyState = 'loading';

--- a/src/Window.js
+++ b/src/Window.js
@@ -764,6 +764,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   const {
     Element,
     HTMLElement,
+    HTMLHeadElement,
     HTMLBodyElement,
     HTMLAnchorElement,
     HTMLStyleElement,
@@ -788,6 +789,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   } = getBoundDOMElements(window);
   window.Element = Element;
   window.HTMLElement = HTMLElement;
+  window.HTMLHeadElement = HTMLHeadElement;
   window.HTMLBodyElement = HTMLBodyElement;
   window.HTMLAnchorElement = HTMLAnchorElement;
   window.HTMLStyleElement = HTMLStyleElement;
@@ -810,6 +812,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   window.Comment = Comment;
   window[symbols.htmlTagsSymbol] = {
     DOCUMENT: Document,
+    HEAD: HTMLHeadElement,
     BODY: HTMLBodyElement,
     A: HTMLAnchorElement,
     STYLE: HTMLStyleElement,


### PR DESCRIPTION
When the `<head>` and/or `<body>` tags were not present, we used to default them to `null`, but it seems the proper behavior expected from some game engines is to default to empty elements for this case.

Therefore, add them as defaults if they are not present in the HTML parse.

Also, defines `HTMLHeadElement`, which was missing.