### PR TITLE
Web Workers de-nativization

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,6 @@ const path = require('path');
 const fs = require('fs');
 const url = require('url');
 
-const bindings = require('./native-bindings');
 const symbols = require('./symbols');
 const mkdirp = require('mkdirp');
 const parseIntStrict = require('parse-int');
@@ -130,12 +129,12 @@ const _normalizePrototype = (obj, targetContext) => {
 
   // Normalize to window prototype.
   if (isToWindow) {
-    bindings.nativeVm.setPrototype(obj, targetContext[symbols.prototypesSymbol][name].prototype || targetContext[name].prototype);
+    Object.setPrototypeOf(obj, targetContext[symbols.prototypesSymbol][name].prototype || targetContext[name].prototype);
     return obj;
   }
 
   // Normalize to native prototype.
-  bindings.nativeVm.setPrototype(obj, targetContext[name].prototype);
+  Object.setPrototypeOf(obj, targetContext[name].prototype);
   return obj;
 };
 module.exports._normalizePrototype = _normalizePrototype;


### PR DESCRIPTION
Exokit supports Web Workers, but until we land [multithreading](https://github.com/exokitxr/exokit/pull/760), we probably won't be doing native module functionality (such as image processing) in workers. This is much easier with a true threading model as presented via `worker_threads`.

This PR removes the native functionality from being required by the Web Worker implementation as a stopgap for site that want to continue to use Web Workers until then.