### PR TITLE
DOM Element faster construction

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -3102,7 +3102,7 @@ function _hash(s) {
 
 const getBoundDOMElements = window => {
   const bind = (OldClass, makeClass) => {
-    const NewClass = makeClass((a, b, c, d) => Reflect.construct(OldClass, [window, a, b, c, d]));
+    const NewClass = makeClass((a, b, c, d) => new OldClass(window, a, b, c, d));
     NewClass.prototype = OldClass.prototype;
     NewClass.constructor = OldClass;
     return NewClass;

--- a/src/Document.js
+++ b/src/Document.js
@@ -348,7 +348,7 @@ module.exports.Range = Range;
 
 const getBoundDocumentElements = window => {
   const bind = (OldClass, makeClass) => {
-    const NewClass = makeClass((a, b, c, d) => Reflect.construct(OldClass, [window, a, b, c, d]));
+    const NewClass = makeClass((a, b, c, d) => new OldClass(window, a, b, c, d));
     NewClass.prototype = OldClass.prototype;
     NewClass.constructor = OldClass;
     return NewClass;


### PR DESCRIPTION
Skips the `Reflect.construct` call for DOM elements, which is harder for V8 to optimize. This is a relatively hot path for the code.

Follow-up to https://github.com/exokitxr/exokit/pull/957.