### PR TITLE
Remove ndb for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,24 +160,6 @@ npm install
 node --experimental-worker . <url> # or node --experimental-worker . -h for home
 ```
 
-## Debugging
-
-Uses [ndb](https://github.com/GoogleChromeLabs/ndb).
-
-```sh
-npm run debug
-```
-
-Then in the console, input:
-
-```js
-let window = await require('./src/').load(yourUrl);
-```
-
-Now you have a handle on the window object as you test your application, and
-you can set `debugger` breakpoints, inspect memory, profile CPU, etc.
-
-
 ## Questions
 
 For questions and support, [ask on StackOverflow](https://stackoverflow.com/questions/ask/?tags=exokit).

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "main": "src/index.js",
   "scripts": {
     "build": "node-gyp build",
-    "debug": "ndb",
     "install": "node ./scripts/preinstall.js && node-gyp configure --msvs_version=2017 && node-gyp rebuild",
     "lint": "eslint src tests",
     "rebuild": "shx rm -rf node_modules && npm cache clean --force && npm install",
@@ -99,7 +98,6 @@
     "express": "^4.16.3",
     "find": "^0.2.9",
     "mocha": "^6.0.0-1",
-    "ndb": "^1.0.44",
     "serve": "^9.4.0",
     "shx": "^0.3.2",
     "sinon": "^6.1.4"


### PR DESCRIPTION
This PR removes ndb from package.json and README. I think Exokit debugging has generally been done with gdb/winDbg. A doc page dedicated to debugging might be necessary in this case.