### PR TITLE
Remove stackoverflow and slack references in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,23 +1,16 @@
-[slack]: https://exokit.slack.com/join/shared_invite/enQtNDI3NjcxNzYwMDIxLWU2NmFmOTEzMzk4NWNiYjRhMjVkYzcyNjg5YjUyMzZkYWM1ZGI4M2IwYWZiMjNlMTJjMDlkM2U3Y2JiNTc2M2Q
-[stackoverflow]: http://stackoverflow.com/questions/tagged/exokit
 
 Interested in contributing? As an open source project, we'd appreciate any help
 and contributions! On top of the Exokit engine itself, you can also
 contribute to any [related projects](https://github.com/exokitxr).
 
 
-# Join the Community on Slack
+# Join the Community on Discord 
 
-1. [Invite yourself][slack] to the Exokit Slack channel.
-2. [Join the discussion](https://exokit.slack.com)!
+[Invite yourself](https://discord.gg/Apk6cZN) to the Exokit Discord.
 
 # Get Help or Ask a Question
 
-If you're not sure how to do something with Exokit, please post a question
-(and any code you've tried so far) to [Stack Overflow under the 'exokit'
-tag][stackoverflow]. Questions there will automatically create notifications in
-[Slack][slack], and are easier for others to find so new developers can learn
-from your questions too.
+If you're not sure how to do something with Exokit, please ask in [Discord](https://discord.gg/Apk6cZN).
 
 # File an Issue
 
@@ -53,39 +46,25 @@ under the [MIT License](LICENSE).
 
 1. Create something awesome using Exokit.
 2. Publish your work to Github (and GitHub pages) so everyone can learn from your work.
-3. Share it on [Slack](https://exokit.slack.com), Twitter, etc.
+3. Share it on [Discord](https://discord.gg/Apk6cZN), Twitter, etc.
 4. For bonus points, write and publish a case study to explain how you built it.
 
 # Update Documentation
 
-If you catch a typo or error in the [documentation](https://github.com/exokitxr/webmr-docs), we'd greatly appreciate a
+If you catch a typo or error in the [documentation](https://github.com/exokitxr/exokit/tree/master/docs), we'd greatly appreciate a
 pull request.
 
 
 
 ## Add Examples to Documentation
 
-We like to have simple and interesting [Glitch](https://glitch.com/~exokit)
-examples listed on relevant documentation pages. Glitch lets people remix/fork
-examples and code right in the browser with live updates. If you have a Glitch
-that might be useful in the documentation, request to add it!
-
-If a Glitch example needs to be updated for whatever reason, we can remix the
-Glitch and update the `src` URL.
+We like to have simple and interesting examples listed on relevant documentation pages. If you have an example that might be useful in the documentation, request to add it!
 
 # Help Your Fellow Exokit users
 
-## On Slack
-
-1. [Invite yourself][slack] to the Exokit Slack channel.
-2. Help answer questions that people might have and welcome new people.
-3. Redirect or cross-post questions to the [Stack Overflow Exokit tag][stackoverflow].
-
 ## On GitHub
 
-1. Help respond to [newly-filed GitHub issues](https://github.com/exokitxr/exokit/issues)
-2. Redirect developers to [Stack Overflow][stackoverflow] if a question is filed rather than an issue.
-3. For extra points, cross-post and answer the question on Stack Overflow after redirecting!
+Help respond to [newly-filed GitHub issues](https://github.com/exokitxr/exokit/issues)
 
 # Curate and Make Efforts Known
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 <p align="center"><b>:dark_sunglasses: Native VR and AR engine for JavaScript 🦖</b></p>
 
 <p align="center">
-  <a href="https://join.slack.com/t/exokit/shared_invite/enQtNDI3NjcxNzYwMDIxLWU2NmFmOTEzMzk4NWNiYjRhMjVkYzcyNjg5YjUyMzZkYWM1ZGI4M2IwYWZiMjNlMTJjMDlkM2U3Y2JiNTc2M2Q"><img src="https://img.shields.io/badge/slack-join-green.svg?logo=slack&longCache=true&style=flat"></a>
   <a href="https://github.com/exokitxr/exokit/releases"><img src="https://img.shields.io/github/downloads/exokitxr/exokit/total.svg"></a>
   <a href="https://www.npmjs.com/package/exokit"><img src="https://img.shields.io/npm/v/exokit.svg"></a>
   <a href="https://travis-ci.org/modulesio/exokit-windows"><img src="https://travis-ci.org/modulesio/exokit-windows.svg?branch=master"></a>
@@ -17,8 +16,6 @@
   <a href="https://exokit.org/docs/">Docs</a>
   &mdash;
   <a href="https://discordapp.com/invite/Apk6cZN">Discord</a>
-  &mdash;
-  <a href="https://exokit.slack.com/join/shared_invite/enQtNDI3NjcxNzYwMDIxLWU2NmFmOTEzMzk4NWNiYjRhMjVkYzcyNjg5YjUyMzZkYWM1ZGI4M2IwYWZiMjNlMTJjMDlkM2U3Y2JiNTc2M2Q">Slack</a>
   &mdash;
   <a href="https://twitter.com/exokitxr">Twitter</a>
   &mdash;
@@ -178,13 +175,8 @@ Now you have a handle on the window object as you test your application, and
 you can set `debugger` breakpoints, inspect memory, profile CPU, etc.
 
 
-## Questions
-
-For questions and support, [ask on StackOverflow](https://stackoverflow.com/questions/ask/?tags=exokit).
-
 ## Stay in Touch
 
-- [Join our Slack](https://join.slack.com/t/exokit/shared_invite/enQtNDI3NjcxNzYwMDIxLWU2NmFmOTEzMzk4NWNiYjRhMjVkYzcyNjg5YjUyMzZkYWM1ZGI4M2IwYWZiMjNlMTJjMDlkM2U3Y2JiNTc2M2Q) for development.
 - [Join our Discord](https://discord.gg/Apk6cZN) for hanging out.
 - [Follow @exokitxr on Twitter](https://twitter.com/exokitxr) for updates.
 

--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -164,7 +164,6 @@ Exokit:
 2. Read through the documentation to get a grasp.
 
 3. Stay in Touch:
-- [Join our Slack](https://join.slack.com/t/exokit/shared_invite/enQtNDI3NjcxNzYwMDIxLWU2NmFmOTEzMzk4NWNiYjRhMjVkYzcyNjg5YjUyMzZkYWM1ZGI4M2IwYWZiMjNlMTJjMDlkM2U3Y2JiNTc2M2Q) for development.
 - [Join our Discord](https://discord.gg/Apk6cZN) for hanging out.
 - [Follow @exokitxr on Twitter](https://twitter.com/exokitxr) for updates.
 


### PR DESCRIPTION
This PR removes stackoverflow and slack references in docs in favor of directing people to Discord.