### PR TITLE
Initial support for Oculus Quest controllers (6DOF tracking)

### DIFF
--- a/deps/oculus-mobile/src/oculus-context.cpp
+++ b/deps/oculus-mobile/src/oculus-context.cpp
@@ -317,14 +317,6 @@ NAN_METHOD(OculusMobileContext::WaitGetPoses) {
                 ovrTracking tracking;
                 vrapi_GetInputTrackingState(oculusMobileContext->ovrState, capsHeader.DeviceID, predictedDisplayTime, &tracking);
 
-                // 3DOF Controller Tracking
-                if (remoteCaps.ControllerCapabilities & ovrControllerCaps_ModelOculusGo ||
-                    remoteCaps.ControllerCapabilities & ovrControllerCaps_ModelGearVR) {
-                  ovrVector3f pivot{-0.2, 1, 0};
-                  ovrVector3f point{-0.2, 1, -0.2};
-                  tracking.HeadPose.Pose.Position = ovrVector3f_RotateAboutPivot(&tracking.HeadPose.Pose.Orientation, &pivot, &point);
-                }
-
                 const ovrMatrix4f &matrix = vrapi_GetTransformFromPose(&tracking.HeadPose.Pose);
                 const ovrMatrix4f &matrix2 = ovrMatrix4f_Transpose(&matrix);
                 memcpy(controllerMatrixLeft, matrix2.M, sizeof(matrix2.M));
@@ -340,14 +332,7 @@ NAN_METHOD(OculusMobileContext::WaitGetPoses) {
               } else if (remoteCaps.ControllerCapabilities & ovrControllerCaps_RightHand) {
                 ovrTracking tracking;
                 vrapi_GetInputTrackingState(oculusMobileContext->ovrState, capsHeader.DeviceID, predictedDisplayTime, &tracking);
-                // 3DOF Controller Tracking
-                if (remoteCaps.ControllerCapabilities & ovrControllerCaps_ModelOculusGo ||
-                    remoteCaps.ControllerCapabilities & ovrControllerCaps_ModelGearVR) {
-                  ovrVector3f pivot{-0.2, 1, 0};
-                  ovrVector3f point{0.2, 1, -0.2};
-                  tracking.HeadPose.Pose.Position = ovrVector3f_RotateAboutPivot(&tracking.HeadPose.Pose.Orientation, &pivot, &point);
-                }
-                // const ovrMatrix4f &matrix = vrapi_GetViewMatrixFromPose(&tracking.HeadPose.Pose);
+
                 const ovrMatrix4f &matrix = vrapi_GetTransformFromPose(&tracking.HeadPose.Pose);
                 const ovrMatrix4f &matrix2 = ovrMatrix4f_Transpose(&matrix);
                 memcpy(controllerMatrixRight, matrix2.M, sizeof(matrix2.M));

--- a/src/VR.js
+++ b/src/VR.js
@@ -300,7 +300,7 @@ class VRDisplay extends EventEmitter {
   }
 
   submitFrame() {}
-  
+
   get layers() {
     return this._layers;
   }
@@ -609,9 +609,15 @@ class FakeVRDisplay extends VRDisplay {
 
 const createVRDisplay = () => new FakeVRDisplay();
 
-const oculusVRIdLeft = 'Oculus Touch (Left)';
-const oculusVRIdRight = 'Oculus Touch (Right)';
-const openVRId = 'OpenVR Gamepad';
+const controllerIDs = {
+  oculusVRIDLeft: 'Oculus Touch (Left)',
+  oculusVRIDRight: 'Oculus Touch (Right)',
+  oculusMobileVRIDLeft: 'Oculus Touch (Left)',
+  oculusMobileVRIDRight: 'Oculus Touch (Right)',
+  openVRID: 'OpenVR Gamepad',
+  openVRTrackerID: 'OpenVR Tracker'
+};
+
 let gamepads = null;
 function getGamepads(window) {
   const {oculusVRDisplay, openVRDisplay, oculusMobileVrDisplay, magicLeapARDisplay} = window[symbols.mrDisplaysSymbol];
@@ -628,13 +634,13 @@ function getGamepads(window) {
         let hand, id;
         if (i === 0) {
           hand = 'left';
-          id = oculusVRDisplay.isPresenting ? oculusVRIdLeft : openVRId;
+          id = openVRDisplay.isPresenting ? controllerIDs.openVRID : controllerIDs.oculusVRIDLeft;
         } else if (i === 1) {
           hand = 'right';
-          id = oculusVRDisplay.isPresenting ? oculusVRIdRight : openVRId;
+          id = openVRDisplay.isPresenting ? controllerIDs.openVRID : controllerIDs.oculusVRIDRight;
         } else {
           hand = null;
-          id = openVRId;
+          id = controllerIDs.openVRTrackerID;
         }
         gamepads[i] = new Gamepad(hand, i, id);
       }


### PR DESCRIPTION
This PR focus on having two different paths for 3DOF controllers (GearVR, Oculus GO) and 6DOF (Quest). I'll follow up with PRs to fix the buttons mapping and different ids for each controller so applications can discriminate and use the appropriate model.