### PR TITLE
update README platform targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,15 @@
 
 This project **enables developers to build XR experiences using the same code that runs on the web**. Exokit engine is written on top of Node and emulates a web browser, providing native hooks for WebGL, WebXR, WebAudio, and other APIs used in immersive experiences.
 
-:eyeglasses: **Exokit targets the following platforms**:
-* Desktop VR (Steam compatible)
+:eyeglasses: **Exokit currently targets the following platforms**:
+* OpenVR Desktop VR (Steam compatible)
+* Oculus Desktop (Oculus Rift/Rift S)
+* Oculus Mobile (Oculus Quest/Go, GearVR)
 * Magic Leap
-* Mobile AR (ARKit / ARCore) *
-* Mobile VR (Daydream / Gear VR) *
-* Standalone VR (Oculus Quest/Go) *
+* iOS ARKit *
+* Android ARCore *
+* Google VR (Daydream / Cardboard / Mirage Solo) *
+* any XR device, start a [pull request](https://github.com/exokitxr/exokit/compare) with a native binding if it isn't listed here! *
 
 \* not supported yet
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ Exokit runs on Windows, macOS, Linux (x64), Linux (ARM64), and Magic Leap (ARM64
 
 - OpenGL
 - OpenVR (Steam VR)
+- Oculus 
+- Oculus Mobile 
 - Magic Leap
 - Leap Motion
 

--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -14,12 +14,15 @@ examples:
 
 Exokit is an **engine that runs XR experiences made with regular web code**. It emulates a web browser on top of Node.js, providing native hooks for WebGL, WebXR, WebAudio, and other standard APIs for immersive experiences. It works with web pages and your favorite frameworks like A-Frame.
 
-:eyeglasses: **Exokit targets the following platforms**:
-* Desktop VR (Steam compatible)
+:eyeglasses: **Exokit currently targets the following platforms**:
+* OpenVR Desktop VR (Steam compatible)
+* Oculus Desktop (Oculus Rift/Rift S)
+* Oculus Mobile (Oculus Quest/Go, GearVR)
 * Magic Leap
-* Mobile AR (ARKit / ARCore) *
-* Mobile VR (Daydream / Gear VR) *
-* Standalone VR (Oculus Quest/Go) *
+* iOS ARKit *
+* Android ARCore *
+* Google VR (Daydream / Cardboard / Mirage Solo) *
+* any XR device, start a [pull request](https://github.com/exokitxr/exokit/compare) with a native binding if it isn't listed here! *
 
 \* not supported yet
 
@@ -145,6 +148,8 @@ Exokit runs on Windows, macOS, Linux (x64), Linux (ARM64), and Magic Leap (ARM64
 
 - OpenGL
 - OpenVR (Steam VR)
+- Oculus
+- Oculus Mobile
 - Magic Leap
 - Leap Motion
 


### PR DESCRIPTION
The PR updates the README platform targets. To update specifically that Oculus Mobile is now supported and the specific SDKs that are planned to be supported soon.