### PR TITLE
Real devicePixelRatio

### DIFF
--- a/deps/exokit-bindings/egl/src/egl.cc
+++ b/deps/exokit-bindings/egl/src/egl.cc
@@ -151,6 +151,10 @@ NAN_METHOD(GetFramebufferSize) {
   info.GetReturnValue().Set(result);
 }
 
+NAN_METHOD(GetDevicePixelRatio) {
+  info.GetReturnValue().Set(JS_NUM(1));
+}
+
 EGLContext GetGLContext(NATIVEwindow *window) {
   return window->context;
 }
@@ -369,6 +373,7 @@ Local<Object> makeWindow() {
   Nan::SetMethod(target, "setWindowPos", egl::SetWindowPos);
   Nan::SetMethod(target, "getWindowPos", egl::GetWindowPos);
   Nan::SetMethod(target, "getFramebufferSize", egl::GetFramebufferSize);
+  Nan::SetMethod(target, "getDevicePixelRatio", glfw::GetDevicePixelRatio);
   Nan::SetMethod(target, "iconifyWindow", egl::IconifyWindow);
   Nan::SetMethod(target, "restoreWindow", egl::RestoreWindow);
   Nan::SetMethod(target, "setEventHandler", egl::SetEventHandler);

--- a/deps/exokit-bindings/egl/src/egl.cc
+++ b/deps/exokit-bindings/egl/src/egl.cc
@@ -373,7 +373,7 @@ Local<Object> makeWindow() {
   Nan::SetMethod(target, "setWindowPos", egl::SetWindowPos);
   Nan::SetMethod(target, "getWindowPos", egl::GetWindowPos);
   Nan::SetMethod(target, "getFramebufferSize", egl::GetFramebufferSize);
-  Nan::SetMethod(target, "getDevicePixelRatio", glfw::GetDevicePixelRatio);
+  Nan::SetMethod(target, "getDevicePixelRatio", egl::GetDevicePixelRatio);
   Nan::SetMethod(target, "iconifyWindow", egl::IconifyWindow);
   Nan::SetMethod(target, "restoreWindow", egl::RestoreWindow);
   Nan::SetMethod(target, "setEventHandler", egl::SetEventHandler);

--- a/deps/exokit-bindings/glfw/src/glfw.cc
+++ b/deps/exokit-bindings/glfw/src/glfw.cc
@@ -968,6 +968,19 @@ NAN_METHOD(GetFramebufferSize) {
   info.GetReturnValue().Set(result);
 }
 
+double GetDevicePixelRatio() {
+  NATIVEwindow *window = CreateNativeWindow(100, 100, false, nullptr);
+  int width, height;
+  glfwGetFramebufferSize(window, &width, &height);
+  glfwDestroyWindow(window);
+  return (double)width/100.0;
+}
+
+NAN_METHOD(GetDevicePixelRatio) {
+  double devicePixelRatio = GetDevicePixelRatio();
+  info.GetReturnValue().Set(JS_NUM(devicePixelRatio));
+}
+
 NATIVEwindow *GetGLContext(NATIVEwindow *window) {
   return window;
 }
@@ -1748,6 +1761,7 @@ Local<Object> makeWindow() {
   Nan::SetMethod(target, "setWindowPos", glfw::SetWindowPos);
   Nan::SetMethod(target, "getWindowPos", glfw::GetWindowPos);
   Nan::SetMethod(target, "getFramebufferSize", glfw::GetFramebufferSize);
+  Nan::SetMethod(target, "getDevicePixelRatio", glfw::GetDevicePixelRatio);
   Nan::SetMethod(target, "iconifyWindow", glfw::IconifyWindow);
   Nan::SetMethod(target, "restoreWindow", glfw::RestoreWindow);
   Nan::SetMethod(target, "setEventHandler", glfw::SetEventHandler);

--- a/deps/exokit-bindings/glfw/src/glfw.cc
+++ b/deps/exokit-bindings/glfw/src/glfw.cc
@@ -1140,7 +1140,7 @@ NATIVEwindow *CreateNativeWindow(unsigned int width, unsigned int height, bool v
       glfwWindowHint(GLFW_BLUE_BITS, 8);
       glfwWindowHint(GLFW_DEPTH_BITS, 24);
       glfwWindowHint(GLFW_REFRESH_RATE, 0);
-      glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, 0);
+      // glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, 0);
 
       glfwSetErrorCallback([](int err, const char *errString) {
         fprintf(stderr, "%s", errString);

--- a/deps/exokit-bindings/glfw/src/glfw.cc
+++ b/deps/exokit-bindings/glfw/src/glfw.cc
@@ -1140,6 +1140,7 @@ NATIVEwindow *CreateNativeWindow(unsigned int width, unsigned int height, bool v
       glfwWindowHint(GLFW_BLUE_BITS, 8);
       glfwWindowHint(GLFW_DEPTH_BITS, 24);
       glfwWindowHint(GLFW_REFRESH_RATE, 0);
+      glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, 0);
 
       glfwSetErrorCallback([](int err, const char *errString) {
         fprintf(stderr, "%s", errString);

--- a/deps/exokit-bindings/glfw/src/glfw.cc
+++ b/deps/exokit-bindings/glfw/src/glfw.cc
@@ -1140,7 +1140,6 @@ NATIVEwindow *CreateNativeWindow(unsigned int width, unsigned int height, bool v
       glfwWindowHint(GLFW_BLUE_BITS, 8);
       glfwWindowHint(GLFW_DEPTH_BITS, 24);
       glfwWindowHint(GLFW_REFRESH_RATE, 0);
-      // glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, 0);
 
       glfwSetErrorCallback([](int err, const char *errString) {
         fprintf(stderr, "%s", errString);

--- a/examples/fakeDisplay.js
+++ b/examples/fakeDisplay.js
@@ -10,14 +10,31 @@ window._makeFakeDisplay = () => {
         exclusive: true,
       });
 
-      fakeDisplay.layers = layers;
+      await new Promise((accept, reject) => {
+        session.requestAnimationFrame((timestamp, frame) => {
+          fakeDisplay.layers = layers;
 
-      renderer.vr.enabled = true;
-      renderer.vr.setDevice(fakeDisplay);
-      renderer.vr.setSession(session, {
-        frameOfReferenceType: 'stage',
+          renderer.vr.enabled = true;
+          renderer.vr.setDevice(fakeDisplay);
+          renderer.vr.setSession(session, {
+            frameOfReferenceType: 'stage',
+          });
+          renderer.vr.setAnimationLoop(animate);
+          
+          const viewport = session.baseLayer.getViewport(frame.views[0]);
+          const height = viewport.height;
+          const fullWidth = (() => {
+            let result = 0;
+            for (let i = 0; i < frame.views.length; i++) {
+              result += session.baseLayer.getViewport(frame.views[i]).width;
+            }
+            return result;
+          })();
+          renderer.setSize(fullWidth, height);
+          
+          accept();
+        });
       });
-      renderer.vr.setAnimationLoop(animate);
     } else {
       await fakeDisplay.requestPresent([
         {
@@ -30,6 +47,9 @@ window._makeFakeDisplay = () => {
       renderer.vr.enabled = true;
       renderer.vr.setDevice(fakeDisplay);
       renderer.vr.setAnimationLoop(animate);
+      
+      const {renderWidth: width, renderHeight: height} = display.getEyeParameters('left');
+      renderer.setSize(width * 2, height);
     }
 
     const context = renderer.getContext();

--- a/examples/realitytabs.html
+++ b/examples/realitytabs.html
@@ -556,7 +556,7 @@ const _makeRenderer = () => {
   // camera.position.z = 1;
 
   const renderer = new THREE.WebGLRenderer( { antialias: true } );
-  renderer.setPixelRatio( window.devicePixelRatio );
+  // renderer.setPixelRatio( window.devicePixelRatio );
   renderer.setSize( window.innerWidth, window.innerHeight );
   document.body.appendChild(renderer.domElement);
 

--- a/src/VR.js
+++ b/src/VR.js
@@ -411,8 +411,8 @@ class FakeVRDisplay extends VRDisplay {
   requestSession({exclusive = true} = {}) {
     const self = this;
 
-    GlobalContext.xrState.renderWidth[0] = this.window.innerWidth * this.window.devicePixelRatio / 2;
-    GlobalContext.xrState.renderHeight[0] = this.window.innerHeight * this.window.devicePixelRatio;
+    GlobalContext.xrState.renderWidth[0] = this.window.innerWidth / 2;
+    GlobalContext.xrState.renderHeight[0] = this.window.innerHeight;
 
     const session = {
       addEventListener(e, fn) {

--- a/src/VR.js
+++ b/src/VR.js
@@ -381,8 +381,8 @@ class FakeVRDisplay extends VRDisplay {
 
   requestPresent(layers) {
     return Promise.resolve().then(() => {
-      GlobalContext.xrState.renderWidth[0] = this.window.innerWidth * this.window.devicePixelRatio / 2;
-      GlobalContext.xrState.renderHeight[0] = this.window.innerHeight * this.window.devicePixelRatio;
+      GlobalContext.xrState.renderWidth[0] = this.window.innerWidth / 2;
+      GlobalContext.xrState.renderHeight[0] = this.window.innerHeight;
 
       if (this.onrequestpresent) {
         this.onrequestpresent(layers);

--- a/src/Window.js
+++ b/src/Window.js
@@ -426,8 +426,15 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
 
   window.innerWidth = defaultCanvasSize[0];
   window.innerHeight = defaultCanvasSize[1];
-  window.devicePixelRatio = 1;
-
+  Object.defineProperty(window, 'devicePixelRatio', {
+    get() {
+      if (!GlobalContext.xrState.devicePixelRatio[0]) {
+        GlobalContext.xrState.devicePixelRatio[0] = nativeWindow.getDevicePixelRatio();
+      }
+      return GlobalContext.xrState.devicePixelRatio[0];
+    },
+    set(devicePixelRatio) {},
+  });
   window.document = null;
   const location = new Location(options.url);
   Object.defineProperty(window, 'location', {

--- a/src/Window.js
+++ b/src/Window.js
@@ -427,6 +427,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   window.innerWidth = defaultCanvasSize[0];
   window.innerHeight = defaultCanvasSize[1];
   window.devicePixelRatio = 1;
+
   window.document = null;
   const location = new Location(options.url);
   Object.defineProperty(window, 'location', {

--- a/src/index.js
+++ b/src/index.js
@@ -175,13 +175,13 @@ nativeBindings.nativeGl.onconstruct = (gl, canvas) => {
     gl.setWindowHandle(windowHandle);
     gl.setDefaultVao(vao);
 
-    const nativeWindowSize = nativeWindow.getFramebufferSize(windowHandle);
+    /* const nativeWindowSize = nativeWindow.getFramebufferSize(windowHandle);
     const nativeWindowHeight = nativeWindowSize.height;
     const nativeWindowWidth = nativeWindowSize.width;
 
     // Tell DOM how large the window is.
     window.innerHeight = nativeWindowSize.height;
-    window.innerWidth = nativeWindowSize.width;
+    window.innerWidth = nativeWindowSize.width; */
 
     const title = `Exokit ${version}`;
     nativeWindow.setWindowTitle(windowHandle, title);
@@ -1169,13 +1169,13 @@ nativeBindings.nativeWindow.setEventHandler((type, data) => {
         break;
       }
       case 'framebufferResize': {
-        const {width, height} = data;
+        /* const {width, height} = data;
         innerWidth = width;
         innerHeight = height;
 
         window.innerWidth = innerWidth / window.devicePixelRatio;
         window.innerHeight = innerHeight / window.devicePixelRatio;
-        window.dispatchEvent(new window.Event('resize'));
+        window.dispatchEvent(new window.Event('resize')); */
         break;
       }
       case 'keydown': {
@@ -2096,8 +2096,8 @@ const _startRenderLoop = () => {
 let currentRenderLoop = _startRenderLoop();
 
 const _bindWindow = (window, newWindowCb) => {
-  window.innerWidth = innerWidth;
-  window.innerHeight = innerHeight;
+  // window.innerWidth = innerWidth;
+  // window.innerHeight = innerHeight;
 
   window.on('navigate', newWindowCb);
   window.document.on('paste', e => {

--- a/src/index.js
+++ b/src/index.js
@@ -1401,7 +1401,7 @@ const _startRenderLoop = () => {
             const width = vrPresentState.glContext.canvas.width * (args.blit ? 0.5 : 1);
             const height = vrPresentState.glContext.canvas.height;
             const {width: dWidth, height: dHeight} = nativeWindow.getFramebufferSize(windowHandle);
-            nativeWindow.blitFrameBuffer(context, vrPresentState.msFbo, 0, width, height, dWidth, dHeight, true, false, false);
+            nativeWindow.blitFrameBuffer(context, vrPresentState.fbo, 0, width, height, dWidth, dHeight, true, false, false);
           } else if (oculusMobileVrPresentState.glContext === context && oculusMobileVrPresentState.hasPose) {
             if (oculusMobileVrPresentState.layers.length > 0) {
               const {oculusMobileVrDisplay} = window[symbols.mrDisplaysSymbol];

--- a/src/index.js
+++ b/src/index.js
@@ -1384,7 +1384,9 @@ const _startRenderLoop = () => {
             
             const width = vrPresentState.glContext.canvas.width * (args.blit ? 0.5 : 1);
             const height = vrPresentState.glContext.canvas.height;
-            nativeWindow.blitFrameBuffer(context, vrPresentState.msFbo, 0, width, height, width * window.devicePixelRatio, height * window.devicePixelRatio, true, false, false);
+            const dWidth = !isMac ? width / window.devicePixelRatio : width * window.devicePixelRatio;
+            const dHeight = !isMac ? height / window.devicePixelRatio : height * window.devicePixelRatio;
+            nativeWindow.blitFrameBuffer(context, vrPresentState.msFbo, 0, width, height, dWidth, dHeight, true, false, false);
           } else if (vrPresentState.glContext === context && vrPresentState.system && vrPresentState.hasPose) {
             if (vrPresentState.layers.length > 0) {
               const {openVRDisplay} = window[symbols.mrDisplaysSymbol];
@@ -1399,7 +1401,9 @@ const _startRenderLoop = () => {
 
             const width = vrPresentState.glContext.canvas.width * (args.blit ? 0.5 : 1);
             const height = vrPresentState.glContext.canvas.height;
-            nativeWindow.blitFrameBuffer(context, vrPresentState.msFbo, 0, width, height, width * window.devicePixelRatio, height * window.devicePixelRatio, true, false, false);
+            const dWidth = !isMac ? width / window.devicePixelRatio : width * window.devicePixelRatio;
+            const dHeight = !isMac ? height / window.devicePixelRatio : height * window.devicePixelRatio;
+            nativeWindow.blitFrameBuffer(context, vrPresentState.msFbo, 0, width, height, dWidth, dHeight, true, false, false);
           } else if (oculusMobileVrPresentState.glContext === context && oculusMobileVrPresentState.hasPose) {
             if (oculusMobileVrPresentState.layers.length > 0) {
               const {oculusMobileVrDisplay} = window[symbols.mrDisplaysSymbol];
@@ -1433,7 +1437,9 @@ const _startRenderLoop = () => {
 
             const width = context.canvas.width * (args.blit ? 0.5 : 1);
             const height = context.canvas.height;
-            nativeWindow.blitFrameBuffer(context, context.framebuffer.fbo, 0, width, height, width * window.devicePixelRatio, height * window.devicePixelRatio, true, false, false);
+            const dWidth = !isMac ? width / window.devicePixelRatio : width * window.devicePixelRatio;
+            const dHeight = !isMac ? height / window.devicePixelRatio : height * window.devicePixelRatio;
+            nativeWindow.blitFrameBuffer(context, context.framebuffer.fbo, 0, width, height, dWidth, dHeight, true, false, false);
           }
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1384,8 +1384,7 @@ const _startRenderLoop = () => {
             
             const width = vrPresentState.glContext.canvas.width * (args.blit ? 0.5 : 1);
             const height = vrPresentState.glContext.canvas.height;
-            const dWidth = !isMac ? width / window.devicePixelRatio : width * window.devicePixelRatio;
-            const dHeight = !isMac ? height / window.devicePixelRatio : height * window.devicePixelRatio;
+            const {width: dWidth, height: dHeight} = nativeWindow.getFramebufferSize(windowHandle);
             nativeWindow.blitFrameBuffer(context, vrPresentState.msFbo, 0, width, height, dWidth, dHeight, true, false, false);
           } else if (vrPresentState.glContext === context && vrPresentState.system && vrPresentState.hasPose) {
             if (vrPresentState.layers.length > 0) {
@@ -1401,8 +1400,7 @@ const _startRenderLoop = () => {
 
             const width = vrPresentState.glContext.canvas.width * (args.blit ? 0.5 : 1);
             const height = vrPresentState.glContext.canvas.height;
-            const dWidth = !isMac ? width / window.devicePixelRatio : width * window.devicePixelRatio;
-            const dHeight = !isMac ? height / window.devicePixelRatio : height * window.devicePixelRatio;
+            const {width: dWidth, height: dHeight} = nativeWindow.getFramebufferSize(windowHandle);
             nativeWindow.blitFrameBuffer(context, vrPresentState.msFbo, 0, width, height, dWidth, dHeight, true, false, false);
           } else if (oculusMobileVrPresentState.glContext === context && oculusMobileVrPresentState.hasPose) {
             if (oculusMobileVrPresentState.layers.length > 0) {
@@ -1437,8 +1435,7 @@ const _startRenderLoop = () => {
 
             const width = context.canvas.width * (args.blit ? 0.5 : 1);
             const height = context.canvas.height;
-            const dWidth = !isMac ? width / window.devicePixelRatio : width * window.devicePixelRatio;
-            const dHeight = !isMac ? height / window.devicePixelRatio : height * window.devicePixelRatio;
+            const {width: dWidth, height: dHeight} = nativeWindow.getFramebufferSize(windowHandle);
             nativeWindow.blitFrameBuffer(context, context.framebuffer.fbo, 0, width, height, dWidth, dHeight, true, false, false);
           }
         }

--- a/src/index.js
+++ b/src/index.js
@@ -1352,12 +1352,6 @@ const _startRenderLoop = () => {
       }
     }
   };
-  const _getFramebufferPixelRatio = () =>{
-    if (!xrState.devicePixelRatio[0]) {
-      xrState.devicePixelRatio[0] = nativeBindings.nativeWindow.getDevicePixelRatio();
-    }
-    return xrState.devicePixelRatio[0];
-  };
   const _blit = () => {
     for (let i = 0; i < contexts.length; i++) {
       const context = contexts[i];
@@ -1375,7 +1369,6 @@ const _startRenderLoop = () => {
         const isVisible = nativeWindow.isVisible(windowHandle) || vrPresentState.glContext === context || oculusMobileVrPresentState.glContext === context || mlPresentState.mlGlContext === context;
         if (isVisible) {
           const window = context.canvas.ownerDocument.defaultView;
-          const framebufferPixelRatio = _getFramebufferPixelRatio();
 
           if (vrPresentState.glContext === context && vrPresentState.oculusSystem && vrPresentState.hasPose) {
             if (vrPresentState.layers.length > 0) {
@@ -1391,7 +1384,7 @@ const _startRenderLoop = () => {
             
             const width = vrPresentState.glContext.canvas.width * (args.blit ? 0.5 : 1);
             const height = vrPresentState.glContext.canvas.height;
-            nativeWindow.blitFrameBuffer(context, vrPresentState.msFbo, 0, width, height, width * framebufferPixelRatio, height * framebufferPixelRatio, true, false, false);
+            nativeWindow.blitFrameBuffer(context, vrPresentState.msFbo, 0, width, height, width * window.devicePixelRatio, height * window.devicePixelRatio, true, false, false);
           } else if (vrPresentState.glContext === context && vrPresentState.system && vrPresentState.hasPose) {
             if (vrPresentState.layers.length > 0) {
               const {openVRDisplay} = window[symbols.mrDisplaysSymbol];
@@ -1406,7 +1399,7 @@ const _startRenderLoop = () => {
 
             const width = vrPresentState.glContext.canvas.width * (args.blit ? 0.5 : 1);
             const height = vrPresentState.glContext.canvas.height;
-            nativeWindow.blitFrameBuffer(context, vrPresentState.msFbo, 0, width, height, width * framebufferPixelRatio, height * framebufferPixelRatio, true, false, false);
+            nativeWindow.blitFrameBuffer(context, vrPresentState.msFbo, 0, width, height, width * window.devicePixelRatio, height * window.devicePixelRatio, true, false, false);
           } else if (oculusMobileVrPresentState.glContext === context && oculusMobileVrPresentState.hasPose) {
             if (oculusMobileVrPresentState.layers.length > 0) {
               const {oculusMobileVrDisplay} = window[symbols.mrDisplaysSymbol];
@@ -1440,7 +1433,7 @@ const _startRenderLoop = () => {
 
             const width = context.canvas.width * (args.blit ? 0.5 : 1);
             const height = context.canvas.height;
-            nativeWindow.blitFrameBuffer(context, context.framebuffer.fbo, 0, width, height, width * framebufferPixelRatio, height * framebufferPixelRatio, true, false, false);
+            nativeWindow.blitFrameBuffer(context, context.framebuffer.fbo, 0, width, height, width * window.devicePixelRatio, height * window.devicePixelRatio, true, false, false);
           }
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -179,12 +179,9 @@ nativeBindings.nativeGl.onconstruct = (gl, canvas) => {
     const nativeWindowHeight = nativeWindowSize.height;
     const nativeWindowWidth = nativeWindowSize.width;
 
-    // Calculate devicePixelRatio.
-    window.devicePixelRatio = nativeWindowWidth / canvasWidth;
-
     // Tell DOM how large the window is.
-    window.innerHeight = nativeWindowHeight / window.devicePixelRatio;
-    window.innerWidth = nativeWindowWidth / window.devicePixelRatio;
+    window.innerHeight = nativeWindowSize.height;
+    window.innerWidth = nativeWindowSize.width;
 
     const title = `Exokit ${version}`;
     nativeWindow.setWindowTitle(windowHandle, title);
@@ -478,6 +475,7 @@ class XRState {
       }
       return result;
     })();
+    this.devicePixelRatio = _makeTypedArray(Uint32Array, 1);
   }
 }
 const xrState = GlobalContext.xrState = new XRState();
@@ -1354,6 +1352,12 @@ const _startRenderLoop = () => {
       }
     }
   };
+  const _getFramebufferPixelRatio = () =>{
+    if (!xrState.devicePixelRatio[0]) {
+      xrState.devicePixelRatio[0] = nativeBindings.nativeWindow.getDevicePixelRatio();
+    }
+    return xrState.devicePixelRatio[0];
+  };
   const _blit = () => {
     for (let i = 0; i < contexts.length; i++) {
       const context = contexts[i];
@@ -1371,6 +1375,7 @@ const _startRenderLoop = () => {
         const isVisible = nativeWindow.isVisible(windowHandle) || vrPresentState.glContext === context || oculusMobileVrPresentState.glContext === context || mlPresentState.mlGlContext === context;
         if (isVisible) {
           const window = context.canvas.ownerDocument.defaultView;
+          const framebufferPixelRatio = _getFramebufferPixelRatio();
 
           if (vrPresentState.glContext === context && vrPresentState.oculusSystem && vrPresentState.hasPose) {
             if (vrPresentState.layers.length > 0) {
@@ -1386,7 +1391,7 @@ const _startRenderLoop = () => {
             
             const width = vrPresentState.glContext.canvas.width * (args.blit ? 0.5 : 1);
             const height = vrPresentState.glContext.canvas.height;
-            nativeWindow.blitFrameBuffer(context, vrPresentState.msFbo, 0, width, height, width * window.devicePixelRatio, height * window.devicePixelRatio, true, false, false);
+            nativeWindow.blitFrameBuffer(context, vrPresentState.msFbo, 0, width, height, width * framebufferPixelRatio, height * framebufferPixelRatio, true, false, false);
           } else if (vrPresentState.glContext === context && vrPresentState.system && vrPresentState.hasPose) {
             if (vrPresentState.layers.length > 0) {
               const {openVRDisplay} = window[symbols.mrDisplaysSymbol];
@@ -1401,7 +1406,7 @@ const _startRenderLoop = () => {
 
             const width = vrPresentState.glContext.canvas.width * (args.blit ? 0.5 : 1);
             const height = vrPresentState.glContext.canvas.height;
-            nativeWindow.blitFrameBuffer(context, vrPresentState.msFbo, 0, width, height, width * window.devicePixelRatio, height * window.devicePixelRatio, true, false, false);
+            nativeWindow.blitFrameBuffer(context, vrPresentState.msFbo, 0, width, height, width * framebufferPixelRatio, height * framebufferPixelRatio, true, false, false);
           } else if (oculusMobileVrPresentState.glContext === context && oculusMobileVrPresentState.hasPose) {
             if (oculusMobileVrPresentState.layers.length > 0) {
               const {oculusMobileVrDisplay} = window[symbols.mrDisplaysSymbol];
@@ -1435,7 +1440,7 @@ const _startRenderLoop = () => {
 
             const width = context.canvas.width * (args.blit ? 0.5 : 1);
             const height = context.canvas.height;
-            nativeWindow.blitFrameBuffer(context, context.framebuffer.fbo, 0, width, height, width * window.devicePixelRatio, height * window.devicePixelRatio, true, false, false);
+            nativeWindow.blitFrameBuffer(context, context.framebuffer.fbo, 0, width, height, width * framebufferPixelRatio, height * framebufferPixelRatio, true, false, false);
           }
         }
 


### PR DESCRIPTION
For a long time we've faked the `window. devicePixelRatio` property. This PR actually queries for it, while allowing Retina (scaling) mode on MacOS to function normally, by adding another framebuffer stretch blit phase to the 2D rendering case.

This allows us to get antialiasing to the main framebuffer, which improves the quality of rendering in the 2D (non-HMD) case, including WebXR emulation.

Fixes https://github.com/exokitxr/exokit/issues/982.