### PR TITLE
Return appropriate gamepad id depending on headset vendor

### DIFF
--- a/deps/oculus-mobile/include/oculus-mobile.h
+++ b/deps/oculus-mobile/include/oculus-mobile.h
@@ -23,12 +23,15 @@ extern JNIEnv *androidJniEnv;
 
 namespace oculusmobile {
 
+extern ovrJava java;
+
 extern Nan::Persistent<v8::Function> oculusMobileContextConstructor;
 extern Nan::Persistent<v8::Object> oculusMobileContext;
 
 /// inline IVRSystem *OculusMobile_Init( EVRInitError *peError, EVRApplicationType eApplicationType );
 NAN_METHOD(OculusMobile_Init);
 NAN_METHOD(OculusMobile_IsHmdPresent);
+NAN_METHOD(OculusMobile_GetDeviceType);
 
 }
 

--- a/deps/oculus-mobile/src/oculus-mobile.cpp
+++ b/deps/oculus-mobile/src/oculus-mobile.cpp
@@ -55,6 +55,24 @@ NAN_METHOD(OculusMobile_IsHmdPresent) {
   info.GetReturnValue().Set(Nan::New<Boolean>(true));
 }
 
+NAN_METHOD(OculusMobile_GetDeviceType) {
+  std::cout << "OculusMobile_GetDeviceType" << std::endl;
+  const char* id;
+  Local<String> result;
+  int deviceType = vrapi_GetSystemPropertyInt(&java, VRAPI_SYS_PROP_DEVICE_TYPE);
+  if (deviceType >= VRAPI_DEVICE_TYPE_GEARVR_START && deviceType <= VRAPI_DEVICE_TYPE_GEARVR_END) {
+    id = "GearVR";
+  }
+  if (deviceType >= VRAPI_DEVICE_TYPE_OCULUSGO_START && deviceType <= VRAPI_DEVICE_TYPE_OCULUSGO_END) {
+    id = "OculusGo";
+  }
+  if (deviceType >= VRAPI_DEVICE_TYPE_OCULUSQUEST_START && deviceType <= VRAPI_DEVICE_TYPE_OCULUSQUEST_END) {
+    id = "OculusQuest";
+  }
+
+  info.GetReturnValue().Set(Nan::New<String>(id).ToLocalChecked());
+}
+
 }
 
 Local<Object> makeOculusMobileVr() {
@@ -65,6 +83,7 @@ Local<Object> makeOculusMobileVr() {
   exports->Set(Nan::New("OculusMobile_Init").ToLocalChecked(), Nan::New<v8::FunctionTemplate>(oculusmobile::OculusMobile_Init)->GetFunction());
   exports->Set(Nan::New("OculusMobile_Shutdown").ToLocalChecked(), Nan::New<v8::FunctionTemplate>(oculusmobile::OculusMobile_Shutdown)->GetFunction());
   exports->Set(Nan::New("OculusMobile_IsHmdPresent").ToLocalChecked(), Nan::New<v8::FunctionTemplate>(oculusmobile::OculusMobile_IsHmdPresent)->GetFunction());
+  exports->Set(Nan::New("OculusMobile_GetDeviceType").ToLocalChecked(), Nan::New<v8::FunctionTemplate>(oculusmobile::OculusMobile_GetDeviceType)->GetFunction());
 
   return scope.Escape(exports);
 }

--- a/src/VR.js
+++ b/src/VR.js
@@ -634,7 +634,7 @@ let gamepads = null;
 function getGamepads(window) {
   const {oculusVRDisplay, openVRDisplay, oculusMobileVrDisplay, magicLeapARDisplay} = window[symbols.mrDisplaysSymbol];
   const presentingDisplay =
-    GlobalContext.fakeVrDisplayEnabled ||
+    (GlobalContext.fakeVrDisplayEnabled && GlobalContext.fakePresentState.fakeVrDisplay) ||
     (oculusVRDisplay.isPresenting && oculusVRDisplay) ||
     (openVRDisplay.isPresenting && openVRDisplay) ||
     (oculusMobileVrDisplay.isPresenting && oculusMobileVrDisplay) ||

--- a/src/VR.js
+++ b/src/VR.js
@@ -610,37 +610,54 @@ class FakeVRDisplay extends VRDisplay {
 const createVRDisplay = () => new FakeVRDisplay();
 
 const controllerIDs = {
-  oculusVRIDLeft: 'Oculus Touch (Left)',
-  oculusVRIDRight: 'Oculus Touch (Right)',
-  oculusMobileVRIDLeft: 'Oculus Touch (Left)',
-  oculusMobileVRIDRight: 'Oculus Touch (Right)',
-  openVRID: 'OpenVR Gamepad',
-  openVRTrackerID: 'OpenVR Tracker'
+  OculusVRLeft: 'Oculus Touch (Left)',
+  OculusVRRight: 'Oculus Touch (Right)',
+  OculusQuestLeft: 'Oculus Touch (Left)',
+  OculusQuestRight: 'Oculus Touch (Right)',
+  OculusGo: 'Oculus Go',
+  GearVR: 'Gear VR',
+  OpenVR: 'OpenVR Gamepad',
+  OpenVRTrackerID: 'Tracker'
 };
+
+function getControllerID(vrDisplay, hand) {
+  if (!vrDisplay) { return; }
+  if (vrDisplay.id === 'OpenVR' ||
+      vrDisplay.id === 'GearVR' ||
+      vrDisplay.id === 'OculusGo') {
+    return controllerIDs[vrDisplay.id];
+  }
+  return controllerIDs[vrDisplay.id + hand.charAt(0).toUpperCase() + hand.slice(1)];
+}
 
 let gamepads = null;
 function getGamepads(window) {
   const {oculusVRDisplay, openVRDisplay, oculusMobileVrDisplay, magicLeapARDisplay} = window[symbols.mrDisplaysSymbol];
-  if (
+  const presentingDisplay =
     GlobalContext.fakeVrDisplayEnabled ||
-    oculusVRDisplay.isPresenting ||
-    openVRDisplay.isPresenting ||
-    oculusMobileVrDisplay.isPresenting ||
-    magicLeapARDisplay.isPresenting
-  ) {
+    (oculusVRDisplay.isPresenting && oculusVRDisplay) ||
+    (openVRDisplay.isPresenting && openVRDisplay) ||
+    (oculusMobileVrDisplay.isPresenting && oculusMobileVrDisplay) ||
+    (magicLeapARDisplay.isPresenting && magicLeapARDisplay);
+
+  if (presentingDisplay) {
     if (!gamepads) {
-      gamepads = Array(2 + maxNumTrackers);
+      const numGamepads = 2;
+      if (presentingDisplay === openVRDisplay) {
+        numGamepads += maxNumTrackers;
+      }
+      gamepads = Array(numGamepads);
       for (let i = 0; i < gamepads.length; i++) {
         let hand, id;
         if (i === 0) {
           hand = 'left';
-          id = openVRDisplay.isPresenting ? controllerIDs.openVRID : controllerIDs.oculusVRIDLeft;
+          id = getControllerID(presentingDisplay, hand);
         } else if (i === 1) {
           hand = 'right';
-          id = openVRDisplay.isPresenting ? controllerIDs.openVRID : controllerIDs.oculusVRIDRight;
+          id = getControllerID(presentingDisplay, hand);
         } else {
           hand = null;
-          id = controllerIDs.openVRTrackerID;
+          id = controllerIDs.OpenVRTrackerID;
         }
         gamepads[i] = new Gamepad(hand, i, id);
       }

--- a/src/VR.js
+++ b/src/VR.js
@@ -621,7 +621,6 @@ const controllerIDs = {
 };
 
 function getControllerID(vrDisplay, hand) {
-  if (!vrDisplay) { return; }
   if (vrDisplay.id === 'OpenVR' ||
       vrDisplay.id === 'GearVR' ||
       vrDisplay.id === 'OculusGo') {

--- a/src/index.js
+++ b/src/index.js
@@ -794,7 +794,8 @@ if (nativeBindings.nativeOculusMobileVr) {
         // fps = VR_FPS;
 
         const vrContext = oculusMobileVrPresentState.vrContext = oculusMobileVrPresentState.vrContext || nativeBindings.nativeOculusMobileVr.OculusMobile_Init(context.getWindowHandle());
-
+        const {oculusMobileVrDisplay} = window[symbols.mrDisplaysSymbol];
+        oculusMobileVrDisplay.id = nativeBindings.nativeOculusMobileVr.OculusMobile_GetDeviceType();
         const {width: halfWidth, height} = vrContext.GetRecommendedRenderTargetSize();
         const MAX_TEXTURE_SIZE = 4096;
         const MAX_TEXTURE_SIZE_HALF = MAX_TEXTURE_SIZE/2;


### PR DESCRIPTION
I made Rift and Quest ids the same since there's not available model at the moment for libraries to integrate accordingly and button mapping is identical. We will have to differentiate in the future.