### PR TITLE
DOM-to-texture devicePixelRatio

### DIFF
--- a/deps/exokit-bindings/browser/include/browser-common.h
+++ b/deps/exokit-bindings/browser/include/browser-common.h
@@ -65,6 +65,7 @@ EmbeddedBrowser createEmbedded(
   GLuint tex,
   int width,
   int height,
+  float scale,
   int *textureWidth,
   int *textureHeight,
   std::function<EmbeddedBrowser()> getBrowser,
@@ -84,6 +85,8 @@ int getEmbeddedWidth(EmbeddedBrowser browser_);
 void setEmbeddedWidth(EmbeddedBrowser browser_, int width);
 int getEmbeddedHeight(EmbeddedBrowser browser_);
 void setEmbeddedHeight(EmbeddedBrowser browser_, int height);
+float getEmbeddedScale(EmbeddedBrowser browser_);
+void setEmbeddedScale(EmbeddedBrowser browser_, float scale);
 void embeddedGoBack(EmbeddedBrowser browser_);
 void embeddedGoForward(EmbeddedBrowser browser_);
 void embeddedReload(EmbeddedBrowser browser_);

--- a/deps/exokit-bindings/browser/include/browser-desktop.h
+++ b/deps/exokit-bindings/browser/include/browser-desktop.h
@@ -5,6 +5,7 @@
 #include <node.h>
 #include <nan.h>
 
+#include <math.h>
 #include <list>
 #include <functional>
 
@@ -92,7 +93,7 @@ class RenderHandler : public CefRenderHandler {
 public:
   typedef std::function<void(const RectList &, const void *, int, int)> OnPaintFn;
   
-	RenderHandler(OnPaintFn onPaint, int width, int height);
+	RenderHandler(OnPaintFn onPaint, int width, int height, float scale);
   ~RenderHandler();
 
 	// void resize(int w, int h);
@@ -104,6 +105,7 @@ public:
 // protected:
   int width;
   int height;
+  float scale;
   // bool resized;
   std::function<void(const RectList &, const void *, int, int)> onPaint;
 

--- a/deps/exokit-bindings/browser/include/browser.h
+++ b/deps/exokit-bindings/browser/include/browser.h
@@ -29,7 +29,7 @@ public:
   static Local<Object> Initialize(Isolate *isolate);
 
 protected:
-  Browser(WebGLRenderingContext *gl, int width, int height);
+  Browser(WebGLRenderingContext *gl, int width, int height, float scale);
   ~Browser();
 
   static NAN_METHOD(New);
@@ -40,6 +40,8 @@ protected:
   static NAN_SETTER(WidthSetter);
   static NAN_GETTER(HeightGetter);
   static NAN_SETTER(HeightSetter);
+  static NAN_GETTER(ScaleGetter);
+  static NAN_SETTER(ScaleSetter);
   static NAN_GETTER(OnLoadStartGetter);
   static NAN_SETTER(OnLoadStartSetter);
   static NAN_GETTER(OnLoadEndGetter);
@@ -72,6 +74,7 @@ protected:
   NATIVEwindow *window;
   int width;
   int height;
+  float scale;
   GLuint tex;
   int textureWidth;
   int textureHeight;

--- a/deps/exokit-bindings/browser/src/browser-ml.cpp
+++ b/deps/exokit-bindings/browser/src/browser-ml.cpp
@@ -21,6 +21,7 @@ EmbeddedBrowser createEmbedded(
   GLuint tex,
   int width,
   int height,
+  float scale,
   int *textureWidth,
   int *textureHeight,
   std::function<EmbeddedBrowser()> getBrowser,
@@ -137,6 +138,12 @@ int getEmbeddedHeight(EmbeddedBrowser browser_) {
 }
 void setEmbeddedHeight(EmbeddedBrowser browser_, int height) {
   browser_->setHeight(height);
+}
+float getEmbeddedScale(EmbeddedBrowser browser_) {
+  return 1;
+}
+void setEmbeddedScale(EmbeddedBrowser browser_, float scale) {
+  // nothing
 }
 void embeddedGoBack(EmbeddedBrowser browser_) {
   traverse_servo(browser_->getInstance(), -1);

--- a/examples/launcher.html
+++ b/examples/launcher.html
@@ -85,6 +85,7 @@ function init() {
   iframe = document.createElement('iframe');
   iframe.width = window.innerWidth;
   iframe.height = window.innerHeight;
+  iframe.devicePixelRatio = window.devicePixelRatio;
   iframe.d = 2;
   iframe.src = 'launcher/build/index.html';
   iframe.onload = () => {

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1943,6 +1943,7 @@ class HTMLIFrameElement extends HTMLSrcableElement {
                     context,
                     this.width||context.canvas.ownerDocument.defaultView.innerWidth,
                     this.height||context.canvas.ownerDocument.defaultView.innerHeight,
+                    this.devicePixelRatio||1,
                     path.join(this.ownerDocument.defaultView[symbols.optionsSymbol].dataPath, '.cef'),
                     path.join(__dirname, '..', 'node_modules', 'native-browser-deps-macos', 'lib3', 'macos', 'Chromium Embedded Framework.framework')
                   );
@@ -2084,6 +2085,10 @@ class HTMLIFrameElement extends HTMLSrcableElement {
         if (this.browser) {
           this.browser.height = this.height;
         }
+      } else if (name === 'devicePixelRatio') {
+        if (this.browser) {
+          this.browser.scale = this.devicePixelRatio;
+        }
       }
     });
     this.on('destroy', () => {
@@ -2113,6 +2118,14 @@ class HTMLIFrameElement extends HTMLSrcableElement {
   set height(value) {
     if (typeof value === 'number' && isFinite(value)) {
       this.setAttribute('height', value);
+    }
+  }
+  get devicePixelRatio() {
+    return parseInt(this.getAttribute('devicePixelRatio') || 1 + '', 10);
+  }
+  set devicePixelRatio(value) {
+    if (typeof value === 'number' && isFinite(value)) {
+      this.setAttribute('devicePixelRatio', value);
     }
   }
   


### PR DESCRIPTION
This adds `iframe.devicePixelRatio` support for 2D Chromium Embedded layers, making the `launcher.html` render hopefully pixel-perfect to Chrome.

This isn't any sort of final UI but it should get the point across.

![Capture 20](https://user-images.githubusercontent.com/6926057/56946168-6118ea80-6af7-11e9-9545-5196ff64d367.PNG)
