### PR TITLE
Remove source releases from CI configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,29 +89,9 @@ matrix:
     - mkdir -p /tmp/Exokit.app/Contents/Resources
     - cp -R metadata/icon.icns /tmp/Exokit.app/Contents/Resources
     - cp metadata/Info.plist /tmp/Exokit.app/Contents
-    - tar -czf exokit-macos-full.tar.gz --exclude=".*" --exclude="*.tar.gz" *
     - rm -R node
-    - tar -czf exokit-macos.tar.gz --exclude=".*" --exclude="*.tar.gz" *
     - ./scripts/exokit-codesign-macos.sh
     deploy:
-    - provider: releases
-      api_key:
-        secure: aKBSeSFdOxun6xPqONVB3epPtlUP0nYjK8LWhDijoAustwc1zuHCUgC2h3yJeDVjknbgShkPiVbTxpEOZurdJP/5iYhf9Y4hVsAWqBVdCwlKLgZ8Pj6pVZh0A61XEfd2y1ZNiv35aNIMRrt9IFzbJOpL0uO4BNLWp6j5xb8qcTnmUh5FAfVmm1eavFzj3hW+qpHeg1pbqdzPJqpoM5c99bsWnJ9QQGyfck9tMGVYlSnI/OoI2A1BLHQ9lbxRJ5F0YC0vXqUZd2NM1yTeI4Q8FrSIlFg4120OR1/QQ+LIpXhfcvqEl3MI+T9U6wxYbiBk0m5wJ39FQCpONCIytX1dZ7go53uH3jTVDiWe2eAzqX5dly+PYDzbinx2k3i5gCzkKfvcgchmtVAYip5i3wQguK66irFKr9QeZz1zGSgm9bRQ9GUYC2+8vuBbJH5TjJHmaijSfefN+ym9G6KaREtBArahG2600RxNYISmUUOHVyoYUGLG1VKB3gX7isSpSS96eioAASK+fGY3jxxMkTuSsfVeC/j1TgCLDuYbb28BTSapGbzMayZBCTIy/FmlOa3qqv5rVAz+1ZZ5AbqW3Yh0NPBrJWVPELL3XoQ9pQJ9eKUkIdwz2MNhGMyz4pjPZptT3h5VWg44tpc3TAyO/0l1kvn80MGl7lrKI4nJ+KnqWd0=
-      file: exokit-macos.tar.gz
-      body: Exokit git release
-      on:
-        repo: exokitxr/exokit
-        tags: true
-      skip_cleanup: true
-    - provider: releases
-      api_key:
-        secure: aKBSeSFdOxun6xPqONVB3epPtlUP0nYjK8LWhDijoAustwc1zuHCUgC2h3yJeDVjknbgShkPiVbTxpEOZurdJP/5iYhf9Y4hVsAWqBVdCwlKLgZ8Pj6pVZh0A61XEfd2y1ZNiv35aNIMRrt9IFzbJOpL0uO4BNLWp6j5xb8qcTnmUh5FAfVmm1eavFzj3hW+qpHeg1pbqdzPJqpoM5c99bsWnJ9QQGyfck9tMGVYlSnI/OoI2A1BLHQ9lbxRJ5F0YC0vXqUZd2NM1yTeI4Q8FrSIlFg4120OR1/QQ+LIpXhfcvqEl3MI+T9U6wxYbiBk0m5wJ39FQCpONCIytX1dZ7go53uH3jTVDiWe2eAzqX5dly+PYDzbinx2k3i5gCzkKfvcgchmtVAYip5i3wQguK66irFKr9QeZz1zGSgm9bRQ9GUYC2+8vuBbJH5TjJHmaijSfefN+ym9G6KaREtBArahG2600RxNYISmUUOHVyoYUGLG1VKB3gX7isSpSS96eioAASK+fGY3jxxMkTuSsfVeC/j1TgCLDuYbb28BTSapGbzMayZBCTIy/FmlOa3qqv5rVAz+1ZZ5AbqW3Yh0NPBrJWVPELL3XoQ9pQJ9eKUkIdwz2MNhGMyz4pjPZptT3h5VWg44tpc3TAyO/0l1kvn80MGl7lrKI4nJ+KnqWd0=
-      file: exokit-macos-full.tar.gz
-      body: Exokit git release
-      on:
-        repo: exokitxr/exokit
-        tags: true
-      skip_cleanup: true
     - provider: releases
       api_key:
         secure: aKBSeSFdOxun6xPqONVB3epPtlUP0nYjK8LWhDijoAustwc1zuHCUgC2h3yJeDVjknbgShkPiVbTxpEOZurdJP/5iYhf9Y4hVsAWqBVdCwlKLgZ8Pj6pVZh0A61XEfd2y1ZNiv35aNIMRrt9IFzbJOpL0uO4BNLWp6j5xb8qcTnmUh5FAfVmm1eavFzj3hW+qpHeg1pbqdzPJqpoM5c99bsWnJ9QQGyfck9tMGVYlSnI/OoI2A1BLHQ9lbxRJ5F0YC0vXqUZd2NM1yTeI4Q8FrSIlFg4120OR1/QQ+LIpXhfcvqEl3MI+T9U6wxYbiBk0m5wJ39FQCpONCIytX1dZ7go53uH3jTVDiWe2eAzqX5dly+PYDzbinx2k3i5gCzkKfvcgchmtVAYip5i3wQguK66irFKr9QeZz1zGSgm9bRQ9GUYC2+8vuBbJH5TjJHmaijSfefN+ym9G6KaREtBArahG2600RxNYISmUUOHVyoYUGLG1VKB3gX7isSpSS96eioAASK+fGY3jxxMkTuSsfVeC/j1TgCLDuYbb28BTSapGbzMayZBCTIy/FmlOa3qqv5rVAz+1ZZ5AbqW3Yh0NPBrJWVPELL3XoQ9pQJ9eKUkIdwz2MNhGMyz4pjPZptT3h5VWg44tpc3TAyO/0l1kvn80MGl7lrKI4nJ+KnqWd0=

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,33 +15,13 @@ matrix:
     install:
     - docker build -t exokit .
     - docker run exokit cat exokit-linux-bin.tar.gz >exokit-linux-bin.tar.gz
-    - docker run exokit cat exokit-linux-full.tar.gz >exokit-linux-full.tar.gz
-    - docker run exokit cat exokit-linux.tar.gz >exokit-linux.tar.gz
     script:
     - echo "skipping 'npm run test' outside of docker"
     deploy:
     - provider: releases
       api_key:
         secure: aKBSeSFdOxun6xPqONVB3epPtlUP0nYjK8LWhDijoAustwc1zuHCUgC2h3yJeDVjknbgShkPiVbTxpEOZurdJP/5iYhf9Y4hVsAWqBVdCwlKLgZ8Pj6pVZh0A61XEfd2y1ZNiv35aNIMRrt9IFzbJOpL0uO4BNLWp6j5xb8qcTnmUh5FAfVmm1eavFzj3hW+qpHeg1pbqdzPJqpoM5c99bsWnJ9QQGyfck9tMGVYlSnI/OoI2A1BLHQ9lbxRJ5F0YC0vXqUZd2NM1yTeI4Q8FrSIlFg4120OR1/QQ+LIpXhfcvqEl3MI+T9U6wxYbiBk0m5wJ39FQCpONCIytX1dZ7go53uH3jTVDiWe2eAzqX5dly+PYDzbinx2k3i5gCzkKfvcgchmtVAYip5i3wQguK66irFKr9QeZz1zGSgm9bRQ9GUYC2+8vuBbJH5TjJHmaijSfefN+ym9G6KaREtBArahG2600RxNYISmUUOHVyoYUGLG1VKB3gX7isSpSS96eioAASK+fGY3jxxMkTuSsfVeC/j1TgCLDuYbb28BTSapGbzMayZBCTIy/FmlOa3qqv5rVAz+1ZZ5AbqW3Yh0NPBrJWVPELL3XoQ9pQJ9eKUkIdwz2MNhGMyz4pjPZptT3h5VWg44tpc3TAyO/0l1kvn80MGl7lrKI4nJ+KnqWd0=
-      file: exokit-linux.tar.gz
-      body: Exokit git release
-      on:
-        repo: exokitxr/exokit
-        tags: true
-      skip_cleanup: true
-    - provider: releases
-      api_key:
-        secure: aKBSeSFdOxun6xPqONVB3epPtlUP0nYjK8LWhDijoAustwc1zuHCUgC2h3yJeDVjknbgShkPiVbTxpEOZurdJP/5iYhf9Y4hVsAWqBVdCwlKLgZ8Pj6pVZh0A61XEfd2y1ZNiv35aNIMRrt9IFzbJOpL0uO4BNLWp6j5xb8qcTnmUh5FAfVmm1eavFzj3hW+qpHeg1pbqdzPJqpoM5c99bsWnJ9QQGyfck9tMGVYlSnI/OoI2A1BLHQ9lbxRJ5F0YC0vXqUZd2NM1yTeI4Q8FrSIlFg4120OR1/QQ+LIpXhfcvqEl3MI+T9U6wxYbiBk0m5wJ39FQCpONCIytX1dZ7go53uH3jTVDiWe2eAzqX5dly+PYDzbinx2k3i5gCzkKfvcgchmtVAYip5i3wQguK66irFKr9QeZz1zGSgm9bRQ9GUYC2+8vuBbJH5TjJHmaijSfefN+ym9G6KaREtBArahG2600RxNYISmUUOHVyoYUGLG1VKB3gX7isSpSS96eioAASK+fGY3jxxMkTuSsfVeC/j1TgCLDuYbb28BTSapGbzMayZBCTIy/FmlOa3qqv5rVAz+1ZZ5AbqW3Yh0NPBrJWVPELL3XoQ9pQJ9eKUkIdwz2MNhGMyz4pjPZptT3h5VWg44tpc3TAyO/0l1kvn80MGl7lrKI4nJ+KnqWd0=
       file: exokit-linux-bin.tar.gz
-      body: Exokit git release
-      on:
-        repo: exokitxr/exokit
-        tags: true
-      skip_cleanup: true
-    - provider: releases
-      api_key:
-        secure: aKBSeSFdOxun6xPqONVB3epPtlUP0nYjK8LWhDijoAustwc1zuHCUgC2h3yJeDVjknbgShkPiVbTxpEOZurdJP/5iYhf9Y4hVsAWqBVdCwlKLgZ8Pj6pVZh0A61XEfd2y1ZNiv35aNIMRrt9IFzbJOpL0uO4BNLWp6j5xb8qcTnmUh5FAfVmm1eavFzj3hW+qpHeg1pbqdzPJqpoM5c99bsWnJ9QQGyfck9tMGVYlSnI/OoI2A1BLHQ9lbxRJ5F0YC0vXqUZd2NM1yTeI4Q8FrSIlFg4120OR1/QQ+LIpXhfcvqEl3MI+T9U6wxYbiBk0m5wJ39FQCpONCIytX1dZ7go53uH3jTVDiWe2eAzqX5dly+PYDzbinx2k3i5gCzkKfvcgchmtVAYip5i3wQguK66irFKr9QeZz1zGSgm9bRQ9GUYC2+8vuBbJH5TjJHmaijSfefN+ym9G6KaREtBArahG2600RxNYISmUUOHVyoYUGLG1VKB3gX7isSpSS96eioAASK+fGY3jxxMkTuSsfVeC/j1TgCLDuYbb28BTSapGbzMayZBCTIy/FmlOa3qqv5rVAz+1ZZ5AbqW3Yh0NPBrJWVPELL3XoQ9pQJ9eKUkIdwz2MNhGMyz4pjPZptT3h5VWg44tpc3TAyO/0l1kvn80MGl7lrKI4nJ+KnqWd0=
-      file: exokit-linux-full.tar.gz
       body: Exokit git release
       on:
         repo: exokitxr/exokit

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,4 @@ RUN \
   cp -R . /tmp/exokit-bin/lib/exokit && \
   cp scripts/exokit-bin.sh /tmp/exokit-bin/bin/exokit && \
   cd /tmp/exokit-bin && \
-  tar -czf /app/exokit-linux-bin.tar.gz --exclude=".*" --exclude="*.tar.gz" * && \
-  cd /app && \
-  tar -czf exokit-linux-full.tar.gz --exclude=".*" --exclude="*.tar.gz" * && \
-  rm -R node && \
-  tar -czf exokit-linux.tar.gz --exclude=".*" --exclude="*.tar.gz" *
-
+  tar -czf /app/exokit-linux-bin.tar.gz --exclude=".*" --exclude="*.tar.gz" * 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ image:
 environment:
   nodejs_version: "11"
   PFX_KEY:
-    secure: ewZJqEOOh1B8ZWAJyd2dikQZ9BtcN4Cv04WEirXNDT8m9J06ZHgsw8hVcYmTinw8 
+    secure: ewZJqEOOh1B8ZWAJyd2dikQZ9BtcN4Cv04WEirXNDT8m9J06ZHgsw8hVcYmTinw8
 
 # Install scripts. (runs after repo cloning)
 install:
@@ -38,27 +38,14 @@ after_test:
       rm -R -fo dist
       & "C:/Program Files (x86)/Microsoft SDKs/Windows/v7.1A/Bin/SignTool.exe" sign /f .\metadata\codesign-windows.pfx /t http://timestamp.comodoca.com/authenticode /p "$env:PFX_KEY" exokit-win-x64.exe
       7z a exokit-windows-full.zip * -xr'!.git' -xr'!buildtools' -xr'!exokit-win-x64.exe'
-      rm -r -fo node
-      7z a exokit-windows.zip * -xr'!.git' -xr'!buildtools' -xr'!exokit-win-x64.exe' -xr'!exokit-windows-full.zip'
 
 artifacts:
-  - path: "exokit-windows.zip"
-    name: exokit-windows
   - path: "exokit-windows-full.zip"
     name: exokit-windows-full
   - path: "exokit-win-x64.exe"
     name: exokit-windows-installer
 
 deploy:
-  - provider: GitHub
-    description: 'Exokit git'
-    auth_token:
-      secure: ewZJqEOOh1B8ZWAJyd2dikQZ9BtcN4Cv04WEirXNDT8m9J06ZHgsw8hVcYmTinw8
-    artifact: "exokit-windows.zip"
-    draft: false
-    prerelease: false
-    on:
-      appveyor_repo_tag: true
   - provider: GitHub
     description: 'Exokit git'
     auth_token:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,26 +35,12 @@ after_test:
       mkdir dist
       .\buildtools\iscc "$pwd\metadata\exokit.iss" "/dMyAppVersion=$version" /odist /qp
       mv dist\*.exe exokit-win-x64.exe
-      rm -R -fo dist
-      & "C:/Program Files (x86)/Microsoft SDKs/Windows/v7.1A/Bin/SignTool.exe" sign /f .\metadata\codesign-windows.pfx /t http://timestamp.comodoca.com/authenticode /p "$env:PFX_KEY" exokit-win-x64.exe
-      7z a exokit-windows-full.zip * -xr'!.git' -xr'!buildtools' -xr'!exokit-win-x64.exe'
 
 artifacts:
-  - path: "exokit-windows-full.zip"
-    name: exokit-windows-full
   - path: "exokit-win-x64.exe"
     name: exokit-windows-installer
 
 deploy:
-  - provider: GitHub
-    description: 'Exokit git'
-    auth_token:
-      secure: ewZJqEOOh1B8ZWAJyd2dikQZ9BtcN4Cv04WEirXNDT8m9J06ZHgsw8hVcYmTinw8
-    artifact: "exokit-windows-full.zip"
-    draft: false
-    prerelease: false
-    on:
-      appveyor_repo_tag: true
   - provider: GitHub
     description: 'Exokit installer'
     auth_token:


### PR DESCRIPTION
This PR proposes moving towards installer for platforms instead of confusing people with source releases. The releases should have per-platform installers / executables, If someone wants source there is a better path to take.
