### PR TITLE
Fix bindings to nativeBindings in index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2462,7 +2462,7 @@ if (require.main === module) {
     }
   }
   if (args.frame || args.minimalFrame) {
-    bindings.nativeGl = (OldWebGLRenderingContext => {
+    nativeBindings.nativeGl = (OldWebGLRenderingContext => {
       function WebGLRenderingContext() {
         const result = Reflect.construct(OldWebGLRenderingContext, arguments);
         for (const k in result) {
@@ -2483,7 +2483,7 @@ if (require.main === module) {
         WebGLRenderingContext[k] = OldWebGLRenderingContext[k];
       }
       return WebGLRenderingContext;
-    })(bindings.nativeGl);
+    })(nativeBindings.nativeGl);
   }
 
   _prepare()


### PR DESCRIPTION
This PR fixes a reference to bindings to nativeBindings in index.js. This was found when testing the `--frame` command line flag [here](https://github.com/exokitxr/exokit/blob/985ccdd8ee4e32a2ba6656387909a16101f42ee5/src/index.js#L2464-L2487).