### PR TITLE
fix display to fakeDisplay

### DIFF
--- a/examples/fakeDisplay.js
+++ b/examples/fakeDisplay.js
@@ -48,7 +48,7 @@ window._makeFakeDisplay = () => {
       renderer.vr.setDevice(fakeDisplay);
       renderer.vr.setAnimationLoop(animate);
       
-      const {renderWidth: width, renderHeight: height} = display.getEyeParameters('left');
+      const {renderWidth: width, renderHeight: height} = fakeDisplay.getEyeParameters('left');
       renderer.setSize(width * 2, height);
     }
 


### PR DESCRIPTION
getting on latest master, desktop windows 10, this PR fixes that.

```
$ node --experimental-worker . -x webvr -h
THREE.WebGLRenderer 96dev
request device
no vr displays
TypeError: Cannot read property 'getEyeParameters' of undefined
    at FakeVRDisplay.fakeDisplay.enter (fakeDisplay.js:51:66)
```