### PR TITLE
Fix tutorial.html texture

### DIFF
--- a/examples/tutorial.html
+++ b/examples/tutorial.html
@@ -148,8 +148,8 @@
           THREE.UVMapping,
           THREE.RepeatWrapping,
           THREE.RepeatWrapping,
-          THREE.NearestFilter,
-          THREE.NearestFilter,
+          THREE.NearestMipMapLinearFilter,
+          THREE.NearestMipMapLinearFilter,
           THREE.RGBAFormat,
           THREE.UnsignedByteType,
           1


### PR DESCRIPTION
Noticed that tutorial.html text becomes unreadable from a distance. 

Before:
![blurCapture](https://user-images.githubusercontent.com/29695350/57052175-4a83a800-6c4b-11e9-8164-fc77ac1b9c88.PNG)

After:
![slight3Capture](https://user-images.githubusercontent.com/29695350/57052173-48b9e480-6c4b-11e9-8b61-2be83b5a696e.PNG)
