### PR TITLE
Bugfix HTMLTemplateElement DocumentFragment construction

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2346,7 +2346,8 @@ class HTMLTemplateElement extends HTMLElement {
   }
 
   get content() {
-    const content = new GlobalContext.DocumentFragment(this.ownerDocument.defaultView);
+    const window = this.ownerDocument.defaultView;
+    const content = new window.DocumentFragment();
     content.ownerDocument = this.ownerDocument;
     content.childNodes = new NodeList(this._childNodes);
     return content;

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2346,7 +2346,7 @@ class HTMLTemplateElement extends HTMLElement {
   }
 
   get content() {
-    const content = new GlobalContext.DocumentFragment();
+    const content = new GlobalContext.DocumentFragment(this.ownerDocument.defaultView);
     content.ownerDocument = this.ownerDocument;
     content.childNodes = new NodeList(this._childNodes);
     return content;


### PR DESCRIPTION
This was an oversight when we moved to DOM elements self-binding to `window`. We need to construct from the bound class on the current `window`, instead of the unbound class on `GlobalConstext`.

Found on https://vrland.io/dev