### PR TITLE
Fix docs instructions and formatting

### DIFF
--- a/docs/api/webxrHardwareExtensionAPIs.md
+++ b/docs/api/webxrHardwareExtensionAPIs.md
@@ -8,11 +8,11 @@ parent_section: api
 
 This currently consists of seperate device-specific APIs, but will be folded into a more generic API, properly coded in Exokit generically on the session objects rather than under a `magicleap` namespace.
 
-# Magic Leap One API
+## Magic Leap One API
 
 The Magic Leap API is exposed to sites under the `window.browser.magicleap` endpoint. This is inspired by the [WebExtension API style](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API). It is not a web standard (yet).
 
-## Classes
+**Classes:**
 
 ### `MLMesher`
 
@@ -221,7 +221,7 @@ The rotation of the eye origin as a world quaternion.
 
 Whether this eye is currently closed (`true`) or open (`false`).
 
-## Endpoints
+### Endpoints
 
 #### `browser.magicleap.RequestMeshing() : MLMesher`
 

--- a/docs/guides/exportMacDMG.md
+++ b/docs/guides/exportMacDMG.md
@@ -14,7 +14,7 @@ In the Exokit [`scripts/exokit-macos`](https://github.com/exokitxr/exokit/blob/m
 ## Prerequisites
 Latest Exokit
 
-## Build dmg
+## Build DMG
 
 Navigate to the Exokit directory
 ```sh

--- a/docs/guides/exportWindowsEXE.md
+++ b/docs/guides/exportWindowsEXE.md
@@ -14,7 +14,7 @@ In the Exokit [`scripts/exokit.sh`](https://github.com/exokitxr/exokit/blob/mast
 ## Prerequisites
 Latest Exokit
 
-## Build exe
+## Build EXE
 
 Install and extract the necessary Node.js version
 ```sh

--- a/docs/introduction/faq.md
+++ b/docs/introduction/faq.md
@@ -20,10 +20,6 @@ The future is immerisve, content should be hardware agnostic, it is not possible
 ## What is WebVR/WebXR?
 The [WebXR Device API](https://github.com/immersive-web/webxr/blob/master/explainer.md) provides access to input and output capabilities commonly associated with Virtual Reality (VR) and Augmented Reality (AR) devices. It allows you develop and host VR and AR experiences on the web.
 
-
---------------------------------------------
-
-
 ## What frameworks does Exokit support?
 The Exokit Engine aspires to support any 3d web framework. Currently Exokit supports common frameworks and libraries such as THREE.js, A-Frame, Babylon.js. If your framework isn't currently supported, start a pull request or open an issue.
 
@@ -47,10 +43,6 @@ Reality Layers are [`<iframe>`](../apis/iframeAPI)'s with added ability to do vo
 ## Can reality layers interact with eachother?
 Yes, reality layers can interact with eachother via `postMessage`.
 
-
---------------------------------------------
-
-  
 ## How can I contribute to Exokit?
 The easiest way to get started is to clone the [Exokit repo](https://github.com/exokitxr/exokit) and then find [an issue](https://github.com/exokitxr/exokit/issues) that you want to take on.
 

--- a/docs/sdk/buildFromSource.md
+++ b/docs/sdk/buildFromSource.md
@@ -27,7 +27,7 @@ npm install
 
 ### Linux dependencies
 
-Linux additionally requires that you install some local dependencies. For `debian`/`ubuntu` they are:
+Linux additionally requires that you install some local dependencies. For `Debian`/`Ubuntu` they are:
 ```sh
 apt-get install -y \
 build-essential wget python libglfw3-dev libglew-dev libfreetype6-dev libfontconfig1-dev uuid-dev libxcursor-dev libxinerama-dev libxi-dev libasound2-dev libexpat1-dev

--- a/docs/sdk/buildFromSource.md
+++ b/docs/sdk/buildFromSource.md
@@ -17,7 +17,8 @@ git clone https://github.com/exokitxr/exokit.git
 
 ## Install and build
 
-All of the Exokit depedencies and native code can be build with `npm install`:
+Make sure to be using Node `v11.6.0`. We recommend using [nvm](https://github.com/nvm-sh/nvm) or [nvm-windows](https://github.com/coreybutler/nvm-windows) for managing Node versions.
+After Node `v11.6.0` is installed, all of the Exokit dependencies and native code can be build with `npm install`:
 
 ```sh
 cd exokit
@@ -32,7 +33,7 @@ apt-get install -y \
 build-essential wget python libglfw3-dev libglew-dev libfreetype6-dev libfontconfig1-dev uuid-dev libxcursor-dev libxinerama-dev libxi-dev libasound2-dev libexpat1-dev
 ```
 
-### Common build errors
+## Common build errors
 This section covers common errors when building the Exokit engine and their solutions.
 
 ### `Error: Cannot find module './build/Release/vm_one.node'`
@@ -62,7 +63,7 @@ From the `exokit` git clone directory, do:
 node . <site URL or file path>
 ```
 
-### Debugging
+## Debugging
 
 You can use the regular Node debugging tools and gdb to debug Exokit Engine. See the [debugging documentation](debugging.md) for more information.
 

--- a/docs/sdk/exokitCommandLineFlags.md
+++ b/docs/sdk/exokitCommandLineFlags.md
@@ -17,16 +17,16 @@ An example of how to use these flags:
 |-|-|-|
 |`-v`|`--version`|Version of Exokit Engine|
 |`-h`|`--home`|Loads realitytabs.html home (default)|
-|`-t`|`--tab`|Load a URL as a reality Tab|
+|`-t <site url>`|`--tab`|Load a URL as a reality Tab|
 |`-w`|`--webgl`|Exposes WebGL, by default Exokit exposes WebGL2|
-|`-x <all, webvr>`|`--xr`|By default loads both WebXR and WebVR, `-x webvr` loads WebVR specifically|
+|`-x <all, webvr>`|`--xr`|By default uses `-x all`, which loads both WebXR and WebVR, `-x webvr` loads WebVR specifically|
 |`-p`|`--perf`|Performance logging to console|
 |`-s <size>`|`--size`|Set window size|
 |`-f`|`--frame`|Get GL call list with arguments to console log|
 |`-m`|`--minimalFrame`|Get GL call list to console log|
-|`-q`|`--quit`|Quit and exit process|
+|`-q`|`--quit`|Quits on load, runs the load phase and quits before render|
 |`-l`|`--log`|Output log to log.txt|
-|`-r <file> <file>`|`--replace`|Replace with a local file|
+|`-r <remote site file> <local file path>`|`--replace`|Replace file from site with a local file|
 |`-u`|`--require`|Require native modules|
 |`-n`|`--headless`|Run Exokit in headless mode|
-|`-d`|`--download`|Download site to `downloads` directory|
+|`-d <site url>`|`--download`|Download site to `downloads` directory|


### PR DESCRIPTION
This PR:

- fixes capitalization issues
- fixes formatting like line breaks or header text mismatches
- add `11.6` requirement to build instructions
- improve command line flag instructions / examples