### PR TITLE
DOM static clientWidth/clientHeight

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -979,8 +979,10 @@ class Element extends Node {
     switch (this.tagName) {
       case 'DOCUMENT':
       case 'HTML':
-      case 'BODY':
-        return window.innerWidth;
+      case 'BODY': {
+        const ownerDocument = this.ownerDocument || this;
+        return ownerDocument.defaultView.innerWidth;
+      }
       case 'CANVAS':
       case 'IMAGE':
       case 'VIDEO':
@@ -994,8 +996,10 @@ class Element extends Node {
     switch (this.tagName) {
       case 'DOCUMENT':
       case 'HTML':
-      case 'BODY':
-        return window.innerHeight;
+      case 'BODY': {
+        const ownerDocument = this.ownerDocument || this;
+        return ownerDocument.defaultView.innerHeight;
+      }
       case 'CANVAS':
       case 'IMAGE':
       case 'VIDEO':

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -976,40 +976,33 @@ class Element extends Node {
   }
 
   get clientWidth() {
-    const style = this.ownerDocument.defaultView.getComputedStyle(this);
-    const fontFamily = style.fontFamily;
-    if (fontFamily) {
-       if (fontFamily === 'sans-serif') {
-         return 0;
-       } else {
-         return _hash(fontFamily) * _hash(this.innerHTML);
-       }
-    } else {
-      let result = 1;
-      this.traverse(el => {
-        if (el.tagName === 'CANVAS' || el.tagName === 'IMAGE' || el.tagName === 'VIDEO') {
-          result = Math.max(el.width, result);
-          return true;
-        }
-			});
-      return result / this.ownerDocument.defaultView.devicePixelRatio;
+    switch (this.tagName) {
+      case 'DOCUMENT':
+      case 'HTML':
+      case 'BODY':
+        return window.innerWidth;
+      case 'CANVAS':
+      case 'IMAGE':
+      case 'VIDEO':
+        return this.width;
+      default:
+        return 0;
     }
   }
   set clientWidth(clientWidth) {}
   get clientHeight() {
-    let result = 0;
-    const _recurse = el => {
-      if (el.nodeType === Node.ELEMENT_NODE) {
-        if (el.tagName === 'CANVAS' || el.tagName === 'IMAGE' || el.tagName === 'VIDEO') {
-          result = Math.max(el.height, result);
-        }
-        for (let i = 0; i < el.childNodes.length; i++) {
-          _recurse(el.childNodes[i]);
-        }
-      }
-    };
-    _recurse(this);
-    return result / this.ownerDocument.defaultView.devicePixelRatio;
+    switch (this.tagName) {
+      case 'DOCUMENT':
+      case 'HTML':
+      case 'BODY':
+        return window.innerHeight;
+      case 'CANVAS':
+      case 'IMAGE':
+      case 'VIDEO':
+        return this.height;
+      default:
+        return 0;
+    }
   }
   set clientHeight(clientHeight) {}
 


### PR DESCRIPTION
Previously Exokit tried to emulate CSS for deriving the `clientWidth` and `clientHeight`.

However, in addition to being incorrect and slow, it was also wrong for the `Document` case. Therefore, we  refactor these methods to be simple lookups depending on the `nodeType`.

This is also not correct but Exokit is not attempting to fully implement the CSS specification.