### PR TITLE
WebGL low layency (desynchronized) support

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2294,7 +2294,7 @@ class HTMLCanvasElement extends HTMLElement {
   }
   set texture(texture) {}
 
-  getContext(contextType) {
+  getContext(contextType, attrs = {}) {
     if (contextType === '2d') {
       if (this._context && this._context.constructor && this._context.constructor.name !== 'CanvasRenderingContext2D') {
         this._context.destroy();
@@ -2313,13 +2313,13 @@ class HTMLCanvasElement extends HTMLElement {
 
         if (!window[symbols.optionsSymbol].args || window[symbols.optionsSymbol].args.webgl === '1') {
           if (contextType === 'webgl' || contextType === 'experimental-webgl' || contextType === 'xrpresent') {
-            this._context = new GlobalContext.WebGLRenderingContext(this);
+            this._context = new GlobalContext.WebGLRenderingContext(this, attrs);
           }
         } else {
           if (contextType === 'webgl' || contextType === 'experimental-webgl') {
-            this._context = new GlobalContext.WebGLRenderingContext(this);
+            this._context = new GlobalContext.WebGLRenderingContext(this, attrs);
           } else {
-            this._context = new GlobalContext.WebGL2RenderingContext(this);
+            this._context = new GlobalContext.WebGL2RenderingContext(this, attrs);
           }
         }
       }

--- a/src/Window.js
+++ b/src/Window.js
@@ -1255,11 +1255,13 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
               nativeWindow.blitFrameBuffer(context, vrPresentState.fbo, 0, width, height, dWidth, dHeight, true, false, false);
             }
           } else {
-            const width = context.canvas.width * (args.blit ? 0.5 : 1);
-            const height = context.canvas.height;
-            const {width: dWidth, height: dHeight} = nativeWindow.getFramebufferSize(windowHandle);
-            nativeWindow.blitFrameBuffer(context, context.framebuffer.msFbo, context.framebuffer.fbo, width, height, width, height, true, false, false);
-            nativeWindow.blitFrameBuffer(context, context.framebuffer.fbo, 0, width, height, dWidth, dHeight, true, false, false);
+            if (!context.desynchronized) {
+              const width = context.canvas.width * (args.blit ? 0.5 : 1);
+              const height = context.canvas.height;
+              const {width: dWidth, height: dHeight} = nativeWindow.getFramebufferSize(windowHandle);
+              nativeWindow.blitFrameBuffer(context, context.framebuffer.msFbo, context.framebuffer.fbo, width, height, width, height, true, false, false);
+              nativeWindow.blitFrameBuffer(context, context.framebuffer.fbo, 0, width, height, dWidth, dHeight, true, false, false);
+            }
           }
 
           if (isMac) {


### PR DESCRIPTION
Implements https://www.chromestatus.com/feature/6360971442388992.

The main change when using `{desynchronized: true}` on the `WebGLRenderingContext` is that we will not double-buffer the canvas, and we will not antialias.

This is most useful for the HTML UI composition case in [Studio](https://github.com/exokitxr/exokit/pull/1002).