### PR TITLE
Add Windows Subsystem for Linux (WSL) requirement in build docs

### DIFF
--- a/docs/guides/exportMagicLeapOneMPK.md
+++ b/docs/guides/exportMagicLeapOneMPK.md
@@ -12,8 +12,9 @@ This guide explains how to package your XR site with the Exokit Engine as an MPK
 In the Exokit [`main.cpp`](https://github.com/exokitxr/exokit/blob/f10dadf0013de0a35a5e72046140a0345987ab80/main.cpp#L416) is where you will find the default site that the Exokit MPK will load into. Change the `jsString` to your site URL or file path.
 
 ## Prerequisites
-Node `11.6.0`
+Node `11.6.0`  
 Latest Exokit
+Ubuntu Windows Subsystem for Linux (WSL)
 
 ## Install the Magic Leap SDK
 
@@ -38,6 +39,7 @@ cd exokit
 
 Build the MPK
 ```sh
+# Run this inside Ubuntu WSL
 ./scripts/build-ml.sh
 ```
 

--- a/docs/guides/exportOculusAPK.md
+++ b/docs/guides/exportOculusAPK.md
@@ -26,8 +26,10 @@ Building an APK with the Dockerfile is as simple as:
 ## OPTION 2- Manual environment setup
 
 ### Prerequisites
-Node `11.6.0`
-Latest Exokit
+Node `11.6.0`  
+Latest Exokit  
+Ubuntu Windows Subsystem for Linux (WSL)
+
 
 ### Install Android sdkmanager
 

--- a/docs/guides/exportOculusAPK.md
+++ b/docs/guides/exportOculusAPK.md
@@ -100,6 +100,7 @@ cd exokit
 
 Build the APK
 ```sh
+# Run this inside Ubuntu WSL
 ./scripts/build-android.sh
 ```
 


### PR DESCRIPTION
This PR adds WSL requirement to the Oculus Mobile APK and Magic Leap MPK build instructions in docs.