### PR TITLE
Multithreaded Worker destruction

### DIFF
--- a/deps/exokit-bindings/canvascontext/include/image-context.h
+++ b/deps/exokit-bindings/canvascontext/include/image-context.h
@@ -48,7 +48,7 @@ private:
   Nan::Persistent<ArrayBuffer> arrayBuffer;
   Nan::Persistent<Function> cbFn;
   std::string error;
-  uv_async_t *threadAsyncHandle;
+  uv_async_t threadAsyncHandle;
 
   friend class CanvasRenderingContext2D;
   friend class ImageData;

--- a/deps/exokit-bindings/webaudiocontext/include/AudioContext.h
+++ b/deps/exokit-bindings/webaudiocontext/include/AudioContext.h
@@ -53,6 +53,7 @@ public:
 
   static NAN_METHOD(New);
   static NAN_METHOD(Close);
+  static NAN_METHOD(Destroy);
   static NAN_METHOD(_DecodeAudioDataSync);
   static NAN_METHOD(CreateMediaElementSource);
   static NAN_METHOD(CreateMediaStreamSource);

--- a/deps/exokit-bindings/webaudiocontext/include/AudioContext.h
+++ b/deps/exokit-bindings/webaudiocontext/include/AudioContext.h
@@ -94,6 +94,7 @@ void RunInMainThread(uv_async_t *handle);
 
 extern thread_local unique_ptr<lab::AudioContext> _defaultAudioContext;
 extern thread_local function<void()> threadFn;
+extern thread_local bool asyncInitialized;
 extern thread_local uv_async_t threadAsync;
 extern thread_local uv_sem_t threadSemaphore;
 

--- a/deps/exokit-bindings/webaudiocontext/src/AudioContext.cpp
+++ b/deps/exokit-bindings/webaudiocontext/src/AudioContext.cpp
@@ -21,6 +21,16 @@ void initializeAsync() {
     asyncInitialized = true;
   }
 }
+void deinitializeAsync() {
+  std::cout << "deinitialize async 1 " << asyncInitialized << std::endl;
+  if (asyncInitialized) {
+    std::cout << "deinitialize async 2 " << std::endl;
+    uv_close((uv_handle_t *)&threadAsync, nullptr);
+    uv_sem_destroy(&threadSemaphore);
+    
+    asyncInitialized = false;
+  }
+}
 
 lab::AudioContext *getDefaultAudioContext(float sampleRate) {
   initializeAsync();
@@ -93,6 +103,7 @@ Local<Object> AudioContext::Initialize(Isolate *isolate, Local<Value> audioListe
   ctorFn->Set(JS_STR("ScriptProcessorNode"), scriptProcessorNodeCons);
   ctorFn->Set(JS_STR("MediaStreamTrack"), mediaStreamTrackCons);
   ctorFn->Set(JS_STR("MicrophoneMediaStream"), microphoneMediaStreamCons);
+  ctorFn->Set(JS_STR("Destroy"), Nan::GetFunction(Nan::New<v8::FunctionTemplate>(Destroy)).ToLocalChecked());
 
   return scope.Escape(ctorFn);
 }
@@ -478,6 +489,12 @@ NAN_METHOD(AudioContext::Close) {
 
   AudioContext *audioContext = ObjectWrap::Unwrap<AudioContext>(info.This());
   audioContext->Close();
+}
+
+NAN_METHOD(AudioContext::Destroy) {
+  // Nan::HandleScope scope;
+
+  deinitializeAsync();
 }
 
 NAN_GETTER(AudioContext::CurrentTimeGetter) {

--- a/deps/exokit-bindings/webaudiocontext/src/AudioContext.cpp
+++ b/deps/exokit-bindings/webaudiocontext/src/AudioContext.cpp
@@ -284,7 +284,7 @@ NAN_METHOD(AudioContext::New) {
 }
 
 NAN_METHOD(AudioContext::_DecodeAudioDataSync) {
-  Nan::HandleScope scope;
+  // Nan::HandleScope scope;
 
   if (info[0]->IsArrayBuffer()) {
     Local<Object> audioContextObj = info.This();
@@ -302,7 +302,7 @@ NAN_METHOD(AudioContext::_DecodeAudioDataSync) {
 }
 
 NAN_METHOD(AudioContext::CreateMediaElementSource) {
-  Nan::HandleScope scope;
+  // Nan::HandleScope scope;
 
   if (info[0]->IsObject() && JS_OBJ(JS_OBJ(info[0])->Get(JS_STR("constructor")))->Get(JS_STR("name"))->StrictEquals(JS_STR("HTMLAudioElement"))) {
     Local<Object> htmlAudioElement = Local<Object>::Cast(info[0]);
@@ -320,7 +320,7 @@ NAN_METHOD(AudioContext::CreateMediaElementSource) {
 }
 
 NAN_METHOD(AudioContext::CreateMediaStreamSource) {
-  Nan::HandleScope scope;
+  // Nan::HandleScope scope;
 
   if (info[0]->IsObject() && JS_OBJ(JS_OBJ(info[0])->Get(JS_STR("constructor")))->Get(JS_STR("name"))->StrictEquals(JS_STR("MicrophoneMediaStream"))) {
     Local<Object> microphoneMediaStream = Local<Object>::Cast(info[0]);
@@ -338,21 +338,21 @@ NAN_METHOD(AudioContext::CreateMediaStreamSource) {
 }
 
 NAN_METHOD(AudioContext::CreateMediaStreamDestination) {
-  Nan::HandleScope scope;
+  // Nan::HandleScope scope;
 
   AudioContext *audioContext = ObjectWrap::Unwrap<AudioContext>(info.This());
   audioContext->CreateMediaStreamDestination();
 }
 
 NAN_METHOD(AudioContext::CreateMediaStreamTrackSource) {
-  Nan::HandleScope scope;
+  // Nan::HandleScope scope;
 
   AudioContext *audioContext = ObjectWrap::Unwrap<AudioContext>(info.This());
   audioContext->CreateMediaStreamTrackSource();
 }
 
 NAN_METHOD(AudioContext::CreateGain) {
-  Nan::HandleScope scope;
+  // Nan::HandleScope scope;
 
   Local<Object> audioContextObj = info.This();
   AudioContext *audioContext = ObjectWrap::Unwrap<AudioContext>(audioContextObj);
@@ -364,7 +364,7 @@ NAN_METHOD(AudioContext::CreateGain) {
 }
 
 NAN_METHOD(AudioContext::CreateAnalyser) {
-  Nan::HandleScope scope;
+  // Nan::HandleScope scope;
 
   Local<Object> audioContextObj = info.This();
   AudioContext *audioContext = ObjectWrap::Unwrap<AudioContext>(audioContextObj);
@@ -376,7 +376,7 @@ NAN_METHOD(AudioContext::CreateAnalyser) {
 }
 
 NAN_METHOD(AudioContext::CreatePanner) {
-  Nan::HandleScope scope;
+  // Nan::HandleScope scope;
 
   Local<Object> audioContextObj = info.This();
   AudioContext *audioContext = ObjectWrap::Unwrap<AudioContext>(audioContextObj);
@@ -388,7 +388,7 @@ NAN_METHOD(AudioContext::CreatePanner) {
 }
 
 NAN_METHOD(AudioContext::CreateStereoPanner) {
-  Nan::HandleScope scope;
+  // Nan::HandleScope scope;
 
   Local<Object> audioContextObj = info.This();
   AudioContext *audioContext = ObjectWrap::Unwrap<AudioContext>(audioContextObj);
@@ -400,7 +400,7 @@ NAN_METHOD(AudioContext::CreateStereoPanner) {
 }
 
 NAN_METHOD(AudioContext::CreateOscillator) {
-  Nan::HandleScope scope;
+  // Nan::HandleScope scope;
 
   Local<Object> audioContextObj = info.This();
   AudioContext *audioContext = ObjectWrap::Unwrap<AudioContext>(audioContextObj);
@@ -412,7 +412,7 @@ NAN_METHOD(AudioContext::CreateOscillator) {
 }
 
 NAN_METHOD(AudioContext::CreateBuffer) {
-  Nan::HandleScope scope;
+  // Nan::HandleScope scope;
 
   if (info[0]->IsNumber() && info[1]->IsNumber() && info[2]->IsNumber()) {
     uint32_t numOfChannels = TO_UINT32(info[0]);
@@ -432,7 +432,7 @@ NAN_METHOD(AudioContext::CreateBuffer) {
 }
 
 NAN_METHOD(AudioContext::CreateBufferSource) {
-  Nan::HandleScope scope;
+  // Nan::HandleScope scope;
 
   Local<Object> audioContextObj = info.This();
   AudioContext *audioContext = ObjectWrap::Unwrap<AudioContext>(audioContextObj);
@@ -444,7 +444,7 @@ NAN_METHOD(AudioContext::CreateBufferSource) {
 }
 
 NAN_METHOD(AudioContext::CreateScriptProcessor) {
-  Nan::HandleScope scope;
+  // Nan::HandleScope scope;
 
   uint32_t bufferSize = info[0]->IsNumber() ? TO_UINT32(info[0]) : 256;
   uint32_t numberOfInputChannels = info[1]->IsNumber() ? TO_UINT32(info[1]) : 2;
@@ -460,35 +460,35 @@ NAN_METHOD(AudioContext::CreateScriptProcessor) {
 }
 
 NAN_METHOD(AudioContext::Suspend) {
-  Nan::HandleScope scope;
+  // Nan::HandleScope scope;
 
   AudioContext *audioContext = ObjectWrap::Unwrap<AudioContext>(info.This());
   audioContext->Suspend();
 }
 
 NAN_METHOD(AudioContext::Resume) {
-  Nan::HandleScope scope;
+  // Nan::HandleScope scope;
 
   AudioContext *audioContext = ObjectWrap::Unwrap<AudioContext>(info.This());
   audioContext->Resume();
 }
 
 NAN_METHOD(AudioContext::Close) {
-  Nan::HandleScope scope;
+  // Nan::HandleScope scope;
 
   AudioContext *audioContext = ObjectWrap::Unwrap<AudioContext>(info.This());
   audioContext->Close();
 }
 
 NAN_GETTER(AudioContext::CurrentTimeGetter) {
-  Nan::HandleScope scope;
+  // Nan::HandleScope scope;
 
   AudioContext *audioContext = ObjectWrap::Unwrap<AudioContext>(info.This());
   info.GetReturnValue().Set(JS_NUM(audioContext->audioContext->currentTime()));
 }
 
 NAN_GETTER(AudioContext::SampleRateGetter) {
-  Nan::HandleScope scope;
+  // Nan::HandleScope scope;
 
   AudioContext *audioContext = ObjectWrap::Unwrap<AudioContext>(info.This());
   info.GetReturnValue().Set(JS_NUM(audioContext->audioContext->sampleRate()));

--- a/deps/exokit-bindings/webaudiocontext/src/AudioContext.cpp
+++ b/deps/exokit-bindings/webaudiocontext/src/AudioContext.cpp
@@ -22,9 +22,7 @@ void initializeAsync() {
   }
 }
 void deinitializeAsync() {
-  std::cout << "deinitialize async 1 " << asyncInitialized << std::endl;
   if (asyncInitialized) {
-    std::cout << "deinitialize async 2 " << std::endl;
     uv_close((uv_handle_t *)&threadAsync, nullptr);
     uv_sem_destroy(&threadSemaphore);
     

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "mkdirp": "^0.5.1",
     "murmurhash-js": "^1.0.0",
     "nan": "^2.13.1",
-    "native-audio-deps": "0.0.59",
+    "native-audio-deps": "0.0.60",
     "native-browser-deps": "0.0.16",
     "native-browser-deps-linux": "0.0.8",
     "native-browser-deps-macos": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "mkdirp": "^0.5.1",
     "murmurhash-js": "^1.0.0",
     "nan": "^2.13.1",
-    "native-audio-deps": "0.0.62",
+    "native-audio-deps": "0.0.63",
     "native-browser-deps": "0.0.16",
     "native-browser-deps-linux": "0.0.8",
     "native-browser-deps-macos": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "mkdirp": "^0.5.1",
     "murmurhash-js": "^1.0.0",
     "nan": "^2.13.1",
-    "native-audio-deps": "0.0.60",
+    "native-audio-deps": "0.0.61",
     "native-browser-deps": "0.0.16",
     "native-browser-deps-linux": "0.0.8",
     "native-browser-deps-macos": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "mkdirp": "^0.5.1",
     "murmurhash-js": "^1.0.0",
     "nan": "^2.13.1",
-    "native-audio-deps": "0.0.61",
+    "native-audio-deps": "0.0.62",
     "native-browser-deps": "0.0.16",
     "native-browser-deps-linux": "0.0.8",
     "native-browser-deps-macos": "0.0.1",

--- a/src/Window.js
+++ b/src/Window.js
@@ -1235,7 +1235,7 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
             tex,
             depthTex,
           };
-          console.log('make new framebuffer', width, height);
+          // console.log('make new framebuffer', width, height);
         }
       }
     };

--- a/src/Window.js
+++ b/src/Window.js
@@ -1534,5 +1534,7 @@ global.onexit = () => {
   for (let i = 0; i < localContexts.length; i++) {
     localContexts[i].destroy();
   }
+  
+  AudioContext.Destroy();
 };
 // global.setImmediate = undefined; // need this for the TLS implementation

--- a/src/WindowVm.js
+++ b/src/WindowVm.js
@@ -163,14 +163,13 @@ const _makeWindow = (options = {}) => {
   window.destroy = (destroy => function() {
     GlobalContext.windows.splice(GlobalContext.windows.indexOf(window), 1);
 
-    return Promise.resolve(); // XXX
-    /* return new Promise((accept, reject) => {
-      destroy.apply(this, arguments);
-
+    return new Promise((accept, reject) => {
       window.on('exit', () => {
         accept();
       });
-    }); */
+
+      destroy.apply(this, arguments);
+    });
   })(window.destroy);
   
   GlobalContext.windows.push(window);

--- a/src/WindowVm.js
+++ b/src/WindowVm.js
@@ -163,6 +163,9 @@ const _makeWindow = (options = {}) => {
   });
   window.destroy = (destroy => function() {
     GlobalContext.windows.splice(GlobalContext.windows.indexOf(window), 1);
+    for (const k in window.queue) {
+      window.queue[k]();
+    }
 
     return new Promise((accept, reject) => {
       window.on('exit', () => {

--- a/src/WindowVm.js
+++ b/src/WindowVm.js
@@ -21,6 +21,7 @@ class WorkerVm extends EventEmitter {
 
           if (fn) {
             fn(m.error, m.result);
+            delete this.queue[m.requestKey];
           } else {
             console.warn(`unknown response request key: ${m.requestKey}`);
           }

--- a/tests/unit/timer/requestAnimationFrame.test.js
+++ b/tests/unit/timer/requestAnimationFrame.test.js
@@ -17,7 +17,7 @@ describe('requestAnimationFrame', () => {
   });
 
   afterEach(async () => {
-    return await window.destroy();
+    await window.destroy();
   });
 
   it('raf', async () => {


### PR DESCRIPTION
In the paralellization branch we weren't destroying worker resources due to dangling native handles.

This PR cleans up those references properly and unlocks worker cleanup while making sure tests pass.

Supercedes https://github.com/exokitxr/exokit/pull/1030.

[WIP]