### PR TITLE
Add headless flag

### DIFF
--- a/docs/sdk/exokitCommandLineFlags.md
+++ b/docs/sdk/exokitCommandLineFlags.md
@@ -30,4 +30,4 @@ An example of how to use these flags:
 |`-u`|`--require`|Expose node require() on `window`|
 |`-n`|`--nogl`|Do not create GL contexts|
 |`-e`|`--headless`|Run in headless mode; do not create OS windows|
-|`-d <downloadDirectory>`|`--download`|Download site to `downloadDirectory`
+|`-d <downloadDirectory>`|`--download`|Download site to `downloadDirectory`|

--- a/docs/sdk/exokitCommandLineFlags.md
+++ b/docs/sdk/exokitCommandLineFlags.md
@@ -30,4 +30,4 @@ An example of how to use these flags:
 |`-u`|`--require`|Expose node require() on `window`|
 |`-n`|`--nogl`|Do not create GL contexts|
 |`-e`|`--headless`|Run in headless mode; do not create OS windows|
-|`-d <downloadDirectory>`|`--download`|Download site to `downloadDirectory`|
+|`-d <downloadDirectory>`|`--download`|Download site to `downloadDirectory`


### PR DESCRIPTION
Exokit already had a flag called `headless`, but it was more like `nogl` -- all it did was disable all GL context creation.

This PR changes that flag to be called `nogl`, and adds a new `headless` flag that _does_ create GL contexts while hinding the window from the windowsystem -- "headless mode".

Fixes https://github.com/exokitxr/exokit/issues/1032.