### PR TITLE
Android debug script improvements

### DIFF
--- a/scripts/debug-android.sh
+++ b/scripts/debug-android.sh
@@ -17,4 +17,5 @@ cd "$(dirname "$0")/.."
 
 pushd ./android/app/src/main
 "$ANDROID_HOME/ndk-bundle/ndk-gdb" --adb="$ANDROID_HOME/platform-tools/adb" --launch=android.app.NativeActivity
+# "$ANDROID_HOME/ndk-bundle/ndk-gdb" --adb="$ANDROID_HOME/platform-tools/adb" --launch=android.app.NativeActivity -x <(echo set environment ARGS "'node --experimental-worker /package /package/examples/tutorial.html'")
 popd

--- a/scripts/debug-android.sh
+++ b/scripts/debug-android.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# NOTE: you need this patch in $ANDROID_HOME/ndk-bundle/prebuilt/linux-x86_64/bin/ndk-gdb.py
+#
+#   def dump_var(args, variable, abi=None):
+# +   return "arm64-v8a"
+#
+# Otherwise, you will get `ERROR: Failed to retrieve application ABI from Android.mk.`
+
 # Initialization.
 
 set -e


### PR DESCRIPTION
Adds hack documentation for making android ndk gdb attach work with the android debug script.

Also adds a potential arguments passing solution to the debug script.