### PR TITLE
Move globals deletion to WindowBase

### DIFF
--- a/src/Window.js
+++ b/src/Window.js
@@ -1502,10 +1502,6 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
   window.document.xrOffset = options.xrOffsetBuffer ? new XRRigidTransform(options.xrOffsetBuffer) : new XRRigidTransform();
 })(global);
 
-if (!options.require) {
-  global.require = undefined;
-}
-global.process = undefined;
 global.onrunasync = method => {
   if (method === 'tickAnimationFrame') {
     return global.tickAnimationFrame();

--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -160,3 +160,7 @@ if (workerData.args) {
 if (workerData.initModule) {
   require(workerData.initModule);
 }
+if (!workerData.args.require) {
+  global.require = undefined;
+}
+global.process = undefined;


### PR DESCRIPTION
This moves the `global.{process,require}` exposure to a central management point in WindowBase, which covers both `window` and `Worker` contexts.

Previously only the `window` case was covered.