### PR TITLE
Clean up parallel framebuffers

### DIFF
--- a/deps/exokit-bindings/windowsystem/src/windowsystem.cc
+++ b/deps/exokit-bindings/windowsystem/src/windowsystem.cc
@@ -598,7 +598,7 @@ NAN_METHOD(CreateVrTopRenderTarget) {
   info.GetReturnValue().Set(result);
 }
 
-void CreateVrChildRenderTarget(WebGLRenderingContext *gl, int width, int height, GLuint *pFbo, GLuint *pmsFbo, GLuint *pmsColorTex, GLuint *pmsDepthStencilTex) {
+void CreateVrCompositorRenderTarget(WebGLRenderingContext *gl, int width, int height, GLuint *pFbo, GLuint *pmsFbo, GLuint *pmsColorTex, GLuint *pmsDepthStencilTex) {
   const int samples = 4;
 
   GLuint &fbo = *pFbo;
@@ -659,7 +659,7 @@ void CreateVrChildRenderTarget(WebGLRenderingContext *gl, int width, int height,
   }
 }
 
-NAN_METHOD(CreateVrChildRenderTarget) {
+NAN_METHOD(CreateVrCompositorRenderTarget) {
   WebGLRenderingContext *gl = ObjectWrap::Unwrap<WebGLRenderingContext>(Local<Object>::Cast(info[0]));
   int width = TO_INT32(info[1]);
   int height = TO_INT32(info[2]);
@@ -669,7 +669,7 @@ NAN_METHOD(CreateVrChildRenderTarget) {
   GLuint msColorTex;
   GLuint msDepthStencilTex;
 
-  CreateVrChildRenderTarget(gl, width, height, &fbo, &msFbo, &msColorTex, &msDepthStencilTex);
+  CreateVrCompositorRenderTarget(gl, width, height, &fbo, &msFbo, &msColorTex, &msDepthStencilTex);
 
   Local<Array> result = Array::New(Isolate::GetCurrent(), 4);
   result->Set(0, JS_INT(fbo));
@@ -1094,7 +1094,7 @@ void Decorate(Local<Object> target) {
   Nan::SetMethod(target, "resizeRenderTarget", ResizeRenderTarget);
   Nan::SetMethod(target, "destroyRenderTarget", DestroyRenderTarget);
   Nan::SetMethod(target, "createVrTopRenderTarget", CreateVrTopRenderTarget);
-  Nan::SetMethod(target, "createVrChildRenderTarget", CreateVrChildRenderTarget);
+  Nan::SetMethod(target, "createVrCompositorRenderTarget", CreateVrCompositorRenderTarget);
   Nan::SetMethod(target, "bindVrChildFbo", BindVrChildFbo);
   Nan::SetMethod(target, "getSync", GetSync);
   Nan::SetMethod(target, "waitSync", WaitSync);

--- a/src/VR.js
+++ b/src/VR.js
@@ -361,8 +361,6 @@ class FakeVRDisplay extends VRDisplay {
       };
       gamepad.pose._localPointerMatrix = new Float32Array(16);
     }
-    this.isPresenting = false;
-    this.stageParameters = new VRStageParameters();
 
     this.onrequestanimationframe = fn => window.requestAnimationFrame(fn);
     this.onvrdisplaypresentchange = () => {

--- a/src/VR.js
+++ b/src/VR.js
@@ -273,7 +273,7 @@ class VRDisplay extends EventEmitter {
     await this.onrequestpresent();
     
     const [{source: canvas}] = layers;
-    const {_context: context} = canvas;
+    const context = canvas._context || canvas.getContext('webgl');
     this.onmakeswapchain(context);
 
     if (this.onvrdisplaypresentchange && !this.isPresenting) {

--- a/src/Window.js
+++ b/src/Window.js
@@ -1383,8 +1383,10 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
       nativeWindow.setCurrentWindowContext(windowHandle);
 
       const window = context.canvas.ownerDocument.defaultView;
+      const width = xrState.renderWidth[0]*2;
+      const height = xrState.renderHeight[0];
       if (!window.document.hidden) {
-        const [fbo, msFbo, msTex, msDepthTex] = nativeWindow.createVrChildRenderTarget(context, xrState.renderWidth[0]*2, xrState.renderHeight[0]);
+        const [fbo, msFbo, msTex, msDepthTex] = nativeWindow.createVrCompositorRenderTarget(context, width, height);
         context.setDefaultFramebuffer(msFbo);
 
         vrPresentState.glContext = context;
@@ -1397,9 +1399,6 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
           msFbo,
         };
       } else {
-        const {canvas} = context;
-        const width = xrState.renderWidth[0]*2;
-        const height = xrState.renderHeight[0];
         const [fbo, tex, depthTex, msFbo, msTex, msDepthTex] = nativeWindow.createRenderTarget(context, width, height);
 
         context.setDefaultFramebuffer(msFbo);

--- a/src/Window.js
+++ b/src/Window.js
@@ -1260,8 +1260,6 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
             }
 
             if (vrPresentState.hmdType === 'fake' || vrPresentState.hmdType === 'oculus' || vrPresentState.hmdType === 'openvr') {
-              /* const width = context.canvas.width * (args.blit ? 0.5 : 1);
-              const height = context.canvas.height; */
               const {width: dWidth, height: dHeight} = nativeWindow.getFramebufferSize(windowHandle);
               nativeWindow.blitFrameBuffer(context, vrPresentState.fbo, 0, width, height, dWidth, dHeight, true, false, false);
             }

--- a/src/index.js
+++ b/src/index.js
@@ -419,7 +419,7 @@ const _startTopRenderLoop = () => {
           hmdType,
         }));
       } else {
-        console.warn(`no top level window to respond to for request present: ${hmdType} ${windowId}`);
+        console.warn(`no top level window to respond to for request present: ${hmdType} ${windowId} ${JSON.stringify(windows.map(window => window.id))}`);
       }
     } else if (vrRequestMethod === 2) { // exitPresent
       if (topVrPresentState.hmdType === 'fake') {

--- a/src/index.js
+++ b/src/index.js
@@ -1186,7 +1186,7 @@ const _start = () => {
     }
     u = u.replace(/^exokit:/, '');
     if (args.tab) {
-      u = u.replace(/\/?$/, '/');
+      // u = u.replace(/\/?$/, '/');
       u = `${realityTabsUrl}?t=${encodeURIComponent(u)}`
     }
     if (u && !url.parse(u).protocol) {

--- a/src/native-bindings.js
+++ b/src/native-bindings.js
@@ -241,6 +241,7 @@ const _onGl3DConstruct = (gl, canvas, attrs) => {
       gl.setDefaultFramebuffer(msFbo);
     }
     gl.framebuffer = {
+      type: 'canvas',
       msFbo,
       msTex,
       msDepthTex,
@@ -249,13 +250,12 @@ const _onGl3DConstruct = (gl, canvas, attrs) => {
       depthTex,
     };
     gl.resize = (width, height) => {
-      if (!gl.desynchronized) {
+      if (!gl.desynchronized && gl.framebuffer.type === 'canvas') {
         nativeWindow.setCurrentWindowContext(windowHandle);
         const [newFbo, newTex, newDepthTex, newMsFbo, newMsTex, newMsDepthTex] = nativeWindow.resizeRenderTarget(gl, width, height, fbo, tex, depthTex, msFbo, msTex, msDepthTex);
-        if (gl.getDefaultFramebuffer() === gl.framebuffer.msFbo) {
-          gl.setDefaultFramebuffer(newMsFbo);
-        }
+
         gl.framebuffer = {
+          type: 'canvas',
           msFbo: newMsFbo,
           msTex: newMsTex,
           msDepthTex: newMsDepthTex,

--- a/src/native-bindings.js
+++ b/src/native-bindings.js
@@ -263,10 +263,6 @@ const _onGl3DConstruct = (gl, canvas, attrs) => {
           tex: newTex,
           depthTex: newDepthTex,
         };
-        
-        if (canvas.framebuffer) {
-          canvas.framebuffer = null;
-        }
       }
     };
 


### PR DESCRIPTION
This PR adds per-context typed framebuffer tracking.

The way that Exokit's reality layers work, each context gets its own swapchain with framebuffers. There are a few kinds, depending on the role of the canvas -- is it desinged for a screen window, a reality layer, or a composition of reality layers. This also has to work with resizing, and across parallel contexts between windows.

There were a few problems in the previous logic where the framebuffer would be scribbled over in resize or due to race conditions -- this PR adds a `type` parameter to the framebuffer that can be inspected and checked to prevent these corner cases.

With this, newer versions of A-Frame/THREE.js as in https://aframe.glitch.me/ work.

This should apply to all platforms.