### PR TITLE
addEventListener double call

### DIFF
--- a/src/Event.js
+++ b/src/Event.js
@@ -15,10 +15,12 @@ class EventTarget extends EventEmitter {
 
   addEventListener(event, listener, options) {
     if (typeof listener === 'function') {
-      if (options && options.once) {
-        this.once(event, listener);
-      } else {
-        this.on(event, listener);
+      if (!this.listeners(event).includes(listener)) {
+        if (options && options.once) {
+          this.once(event, listener);
+        } else {
+          this.on(event, listener);
+        }
       }
     }
   }


### PR DESCRIPTION
I was surprised to learn the behavior of this code:

```
var newHandle = function(event) { console.log('lol'); };
document.body.addEventListener("click", newHandle, false);
document.body.addEventListener("click", newHandle, false);
```

It turns out calling `addEventListener` twice on the same event/function instance will _not_ doubly register the handler. This is _not_ how node `EventEmitter` `.on` works.

Since we were implementing `addEventListener` with `EventEmitter` `.on`, it was causing double emits where the code technically should only be getting one.

This seems a corner case and it's not trouble for many sites. However, notable A-Frame _does_ do this double registration on its `canvas` listeners.

Therefore, make `addEventListener` singly register like the browser does.