### PR TITLE
Window URL navigation

### DIFF
--- a/deps/exokit-bindings/glfw/include/glfw.h
+++ b/deps/exokit-bindings/glfw/include/glfw.h
@@ -32,7 +32,9 @@ namespace glfw {
   public:
     EventHandler(uv_loop_t *loop, Local<Function> handlerFn);
     ~EventHandler();
-    
+
+  // protected:
+    std::mutex mutex;
     std::unique_ptr<uv_async_t> async;
     Nan::Persistent<Function> handlerFn;
     std::deque<std::function<void(std::function<void(int argc, Local<Value> *argv)>)>> fns;
@@ -42,7 +44,17 @@ namespace glfw {
   public:
     InjectionHandler();
 
+  // protected:
     std::deque<std::function<void(InjectionHandler *injectionHandler)>> fns;
+  };
+
+  class WindowState {
+  public:
+    WindowState();
+    ~WindowState();
+
+  // protected:
+    std::unique_ptr<EventHandler> handler;
   };
 
   NATIVEwindow *CreateWindowHandle(unsigned int width, unsigned int height, bool visible);

--- a/deps/exokit-bindings/glfw/src/glfw.cc
+++ b/deps/exokit-bindings/glfw/src/glfw.cc
@@ -892,15 +892,6 @@ void DestroyNativeWindow(NATIVEwindow *window) {
   glfwDestroyWindow(window);
 }
 
-/* NAN_METHOD(DestroyWindow) {
-  NATIVEwindow *window = (NATIVEwindow *)arrayToPointer(Local<Array>::Cast(info[0]));
-  glfwDestroyWindow(window);
-
-  if (currentWindow == window) {
-    currentWindow = nullptr;
-  }
-} */
-
 NAN_METHOD(SetWindowTitle) {
   NATIVEwindow *window = (NATIVEwindow *)arrayToPointer(Local<Array>::Cast(info[0]));
   Nan::Utf8String str(Local<String>::Cast(info[1]));

--- a/src/Window.js
+++ b/src/Window.js
@@ -7,6 +7,7 @@ const http = require('http');
 const https = require('https');
 const crypto = require('crypto');
 const os = require('os');
+const {parentPort} = require('worker_threads');
 const util = require('util');
 const {URL} = url;
 const {TextEncoder, TextDecoder} = util;
@@ -1161,23 +1162,14 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
   let loading = false;
   window.location.on('update', href => {
     if (!loading) {
-      core.load(href, {
-        dataPath: options.dataPath,
-      })
-        .then(newWindow => {
-          window._emit('beforeunload');
-          window._emit('unload');
-          window._emit('navigate', newWindow);
-        })
-        .catch(err => {
-          loading = false;
-
-          const e = new ErrorEvent('error', {target: this});
-          e.message = err.message;
-          e.stack = err.stack;
-          window.dispatchEvent(e);
-        });
       loading = true;
+
+      window._emit('beforeunload');
+      window._emit('unload');
+
+      window.windowEmit('navigate', {
+        href,
+      });
     }
   });
 

--- a/src/core.js
+++ b/src/core.js
@@ -80,6 +80,7 @@ exokit.load = (src, options = {}) => {
         dataPath: options.dataPath,
         args: options.args,
         replacements: options.replacements,
+        onnavigate: options.onnavigate,
       });
     });
 };


### PR DESCRIPTION
Exokit single-threaded supported location for a long time, but the multithreaded windowing model threw a wrench in URL navigation support, since that requires a dance between the parent and child context.

This PR adds `window.location` navigation support (via all of the usual `window.location` setters) to the mulithreaded `window` case.

This PR should support the usual XR navigation cases where a window chooses to navigate, as well as transparent navigation retargeting for reality tabs without losing the tab.