### PR TITLE
WebXR hardware extensions APIs

### DIFF
--- a/deps/exokit-bindings/magicleap/include/magicleap.h
+++ b/deps/exokit-bindings/magicleap/include/magicleap.h
@@ -16,6 +16,7 @@
 #include <cmath>
 #include <vector>
 #include <list>
+#include <set>
 #include <thread>
 #include <mutex>
 #include <condition_variable>
@@ -194,6 +195,7 @@ public:
   MLHandle meshRequestHandle;;
   MLMeshingMeshInfo meshInfo;
   MLMeshingMeshRequest meshRequest;
+  std::map<std::string, MLMeshingBlockInfo *> meshInfoMap;
   // Nan::Persistent<Function> cb;
 };
 
@@ -201,7 +203,7 @@ class MLPlaneTracker : public ObjectWrap {
 public:
   static Local<Function> Initialize(Isolate *isolate);
 
-  MLPlaneTracker();
+  MLPlaneTracker(float range);
   ~MLPlaneTracker();
 
   static NAN_METHOD(New);
@@ -209,9 +211,11 @@ public:
   static NAN_METHOD(Destroy);
 
 // protected:
+  float range;
   MLHandle tracker;
   MLHandle planesRequestHandle;
   bool planesRequestPending;
+  std::vector<std::string> planeIds;
   /* Nan::Persistent<Object> windowObj;
   uv_loop_t *loop;
   Nan::Persistent<Function> cb; */

--- a/deps/exokit-bindings/magicleap/include/ml-math.h
+++ b/deps/exokit-bindings/magicleap/include/ml-math.h
@@ -54,8 +54,8 @@ bool getFingerRayTransform(MLTransform &result, std::vector<std::vector<float *>
 bool getHandTransform(MLVec3f &center, MLVec3f &normal, float wristBones[4][1 + 3], float fingerBones[5][4][1 + 3], bool left, const MLMat4f &transform);
 bool getHandPointerTransform(MLTransform &result, float wristBones[4][1 + 3], float fingerBones[5][4][1 + 3], const MLVec3f &normal, const MLMat4f &transform);
 bool getHandGripTransform(MLTransform &result, float wristBones[4][1 + 3], float fingerBones[5][4][1 + 3], const MLVec3f &normal, const MLMat4f &transform);
-void getWristBonePosition(MLVec3f &position, float wristBones[4][1 + 3], int boneIndex, const MLMat4f &transform);
-void getFingerBonePosition(MLVec3f &position, float fingerBones[5][4][1 + 3], int fingerIndex, int boneIndex, const MLMat4f &transform);
+/* void getWristBonePosition(MLVec3f &position, float wristBones[4][1 + 3], int boneIndex, const MLMat4f &transform);
+void getFingerBonePosition(MLVec3f &position, float fingerBones[5][4][1 + 3], int fingerIndex, int boneIndex, const MLMat4f &transform); */
 
 }
 

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -451,7 +451,7 @@ NAN_METHOD(MLRaycaster::WaitGetPoses) {
       MLMat4f hitMatrix = composeMatrix(position, quaternion, scale);
 
       Local<Object> xrHitResult = Nan::New<Object>();
-      Local<Float32Array> hitMatrixArray = Float32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), (void *)hitMatrix.matrix_colmajor, 16 * sizeof(float)), 0, 16);
+      Local<Float32Array> hitMatrixArray = Float32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), (void *)hitMatrix.matrix_colmajor, sizeof(hitMatrix.matrix_colmajor)), 0, 16);
       xrHitResult->Set(JS_STR("hitMatrix"), hitMatrixArray);
       Local<Array> result = Nan::New<Array>(1);
       result->Set(0, xrHitResult);
@@ -564,8 +564,8 @@ MLMesher::MLMesher(float range, MLMeshingLOD lod) : range(range), lod(lod), mesh
 MLMesher::~MLMesher() {}
 
 NAN_METHOD(MLMesher::New) {
-  int lodValue = TO_INT32(info[0]);
-  float range = TO_FLOAT(info[1]);
+  float range = TO_FLOAT(info[0]);
+  int lodValue = TO_INT32(info[1]);
   
   MLMeshingLOD lod;
   switch (lodValue) {
@@ -650,8 +650,8 @@ NAN_METHOD(MLMesher::WaitGetPoses) {
       // std::unique_lock<std::mutex> lock(mlContext->positionMutex);
 
       meshExtents.center = mlContext->position;
-      // meshExtents.rotation =  mlContext->rotation;
-      meshExtents.rotation = {0, 0, 0, 1};
+      meshExtents.rotation =  mlContext->rotation;
+      // meshExtents.rotation = {0, 0, 0, 1};
     }
     meshExtents.extents.x = mlMesher->range;
     meshExtents.extents.y = mlMesher->range;
@@ -678,19 +678,24 @@ NAN_METHOD(MLMesher::WaitGetPoses) {
   if (mlMesher->meshInfoRequestPending) {
     MLResult result = MLMeshingGetMeshInfoResult(mlMesher->tracker, mlMesher->meshInfoRequestHandle, &mlMesher->meshInfo);
     if (result == MLResult_Ok) {
+      for (uint32_t i = 0; i < mlMesher->meshInfo.data_count; i++) {
+        MLMeshingBlockInfo &meshInfo = mlMesher->meshInfo.data[i];
+        const std::string &id = id2String(meshInfo.id);
+        mlMesher->meshInfoMap[id] = &meshInfo;
+      }
       /* uint32_t dataCount = meshInfo.data_count;
 
       meshRequestNewMap.clear();
       meshRequestRemovedMap.clear();
       meshRequestUnchangedMap.clear();
       for (uint32_t i = 0; i < dataCount; i++) {
-        const MLMeshingBlockInfo &meshBlockInfo = meshInfo.data[i];
-        const MLMeshingMeshState &state = meshBlockInfo.state;
+        const MLMeshingBlockInfo &meshInfo = meshInfo.data[i];
+        const MLMeshingMeshState &state = meshInfo.state;
         MLMeshingBlockRequest &meshBlockRequest = meshBlockRequests[i];
-        meshBlockRequest.id = meshBlockInfo.id;
+        meshBlockRequest.id = meshInfo.id;
         meshBlockRequest.level = mlMesher->lod;
 
-        const std::string &id = id2String(meshBlockInfo.id);
+        const std::string &id = id2String(meshInfo.id);
         meshRequestNewMap[id] = (state == MLMeshingMeshState_New);
         meshRequestRemovedMap[id] = (state == MLMeshingMeshState_Deleted);
         meshRequestUnchangedMap[id] = (state == MLMeshingMeshState_Unchanged);
@@ -717,13 +722,13 @@ NAN_METHOD(MLMesher::WaitGetPoses) {
 
       std::vector<MLMeshingBlockRequest> meshBlockRequests(requestsThisTime);
       for (uint32_t i = 0; i < requestsThisTime; i++) {
-        const MLMeshingBlockInfo &meshBlockInfo = mlMesher->meshInfo.data[mlMesher->meshBlockRequestIndex + i];
-        const MLMeshingMeshState &state = meshBlockInfo.state;
+        const MLMeshingBlockInfo &meshInfo = mlMesher->meshInfo.data[mlMesher->meshBlockRequestIndex + i];
+        const MLMeshingMeshState &state = meshInfo.state;
         MLMeshingBlockRequest &meshBlockRequest = meshBlockRequests[i];
-        meshBlockRequest.id = meshBlockInfo.id;
+        meshBlockRequest.id = meshInfo.id;
         meshBlockRequest.level = mlMesher->lod;
 
-        /* const std::string &id = id2String(meshBlockInfo.id);
+        /* const std::string &id = id2String(meshInfo.id);
         meshRequestNewMap[id] = (state == MLMeshingMeshState_New);
         meshRequestRemovedMap[id] = (state == MLMeshingMeshState_Deleted);
         meshRequestUnchangedMap[id] = (state == MLMeshingMeshState_Unchanged); */
@@ -742,72 +747,92 @@ NAN_METHOD(MLMesher::WaitGetPoses) {
       } else {
         ML_LOG(Error, "%s: Mesh request failed! %x", application_name, result);
 
+        mlMesher->meshInfoMap.clear();
+        MLMeshingFreeResource(mlMesher->tracker, &mlMesher->meshInfoRequestHandle);
+
         mlMesher->meshRequestsPending = false;
         mlMesher->meshRequestPending = false;
-
-        MLMeshingFreeResource(mlMesher->tracker, &mlMesher->meshInfoRequestHandle);
       }
     } else {
+      mlMesher->meshInfoMap.clear();
+      MLMeshingFreeResource(mlMesher->tracker, &mlMesher->meshInfoRequestHandle);
+      
       mlMesher->meshRequestsPending = false;
       mlMesher->meshRequestPending = false;
-
-      MLMeshingFreeResource(mlMesher->tracker, &mlMesher->meshInfoRequestHandle);
     }
   }
   if (mlMesher->meshRequestsPending && mlMesher->meshRequestPending) {
     MLMeshingMesh mesh;
     MLResult result = MLMeshingGetMeshResult(mlMesher->tracker, mlMesher->meshRequestHandle, &mesh);
     if (result == MLResult_Ok) {
-      Local<Array> result = Nan::New<Array>(mesh.data_count);
+      // std::map<std::string, MLMeshingBlockInfo*> blockMeshInfoMap();
+
+      Local<Array> result = Nan::New<Array>();
+      int index = 0;
       for (uint32_t i = 0; i < mesh.data_count; i++) {
         MLMeshingBlockMesh &blockMesh = mesh.data[i];
-        MLMeshingBlockInfo &meshBlockInfo = mlMesher->meshInfo.data[i];
-
-        if (id2String(blockMesh.id) != id2String(meshBlockInfo.id)) { // XXX
-          ML_LOG(Error, "%s: Mesh result id does not match request id %x %x %x %x", application_name, blockMesh.id, meshBlockInfo.id, mesh.data_count, mlMesher->meshInfo.data_count);
-        }
-
-        Local<Object> obj = Nan::New<Object>();
         const std::string &id = id2String(blockMesh.id);
-        obj->Set(JS_STR("id"), JS_STR(id));
-
-        const char *typeString;
-        if (meshBlockInfo.state == MLMeshingMeshState_New) {
-          typeString = "new";
-        } else if (meshBlockInfo.state == MLMeshingMeshState_Updated) {
-          typeString = "update";
-        } else if (meshBlockInfo.state == MLMeshingMeshState_Deleted) {
-          typeString = "remove";
-        } else if (meshBlockInfo.state == MLMeshingMeshState_Unchanged) {
-          typeString = "unchanged";
-        } else {
-          typeString = "";
+        auto meshInfoIter = mlMesher->meshInfoMap.find(id);
+        if (meshInfoIter == mlMesher->meshInfoMap.end()) {
+          ML_LOG(Error, "%s: Mesh result for unknown id %s", application_name, id.c_str());
         }
-        obj->Set(JS_STR("type"), JS_STR(typeString));
+        MLMeshingBlockInfo &meshInfo = *meshInfoIter->second;
 
-        if (meshBlockInfo.state == MLMeshingMeshState_New || meshBlockInfo.state == MLMeshingMeshState_Updated) {
-          /* Local<Float32Array> transformMatrixArray = Float32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), (void *)transformMatrix.matrix_colmajor, 16 * sizeof(float)), 0, 16);
-          obj->Set(JS_STR("transformMatrix"), transformMatrixArray); */
+        if (meshInfo.state == MLMeshingMeshState_New || (meshInfo.state == MLMeshingMeshState_Updated && blockMesh.index_count > 0) || MLMeshingMeshState_Deleted) {
+          Local<Object> obj = Nan::New<Object>();
+          obj->Set(JS_STR("id"), JS_STR(id));
 
-          Local<SharedArrayBuffer> positionArrayBuffer = SharedArrayBuffer::New(Isolate::GetCurrent(), blockMesh.vertex_count * 3 * sizeof(float));
-          Local<Float32Array> positionArray = Float32Array::New(positionArrayBuffer, 0, blockMesh.vertex_count * 3);
-          memcpy(positionArrayBuffer->GetContents().Data(), blockMesh.vertex->values, blockMesh.vertex_count * 3 * sizeof(float));
-          obj->Set(JS_STR("positionArray"), positionArray);
-          obj->Set(JS_STR("positionCount"), JS_INT(blockMesh.vertex_count * 3));
+          const char *typeString;
+          if (meshInfo.state == MLMeshingMeshState_New) {
+            typeString = "meshadd";
+          } else if (meshInfo.state == MLMeshingMeshState_Updated) {
+            typeString = "meshupdate";
+          } else if (meshInfo.state == MLMeshingMeshState_Deleted) {
+            typeString = "meshremove";
+          /* } else if (meshInfo.state == MLMeshingMeshState_Unchanged) {
+            typeString = "meshunchanged"; */
+          } else {
+            typeString = "";
+          }
+          obj->Set(JS_STR("type"), JS_STR(typeString));
 
-          Local<SharedArrayBuffer> normalArrayBuffer = SharedArrayBuffer::New(Isolate::GetCurrent(), blockMesh.vertex_count * 3 * sizeof(float));
-          Local<Float32Array> normalArray = Float32Array::New(normalArrayBuffer, 0, blockMesh.vertex_count * 3);
-          memcpy(normalArrayBuffer->GetContents().Data(), blockMesh.normal->values, blockMesh.vertex_count * 3 * sizeof(float));
-          obj->Set(JS_STR("normalArray"), normalArray);
-          obj->Set(JS_STR("normalCount"), JS_INT(blockMesh.vertex_count * 3));
+          if (meshInfo.state == MLMeshingMeshState_New || meshInfo.state == MLMeshingMeshState_Updated) {
+            /* Local<Float32Array> transformMatrixArray = Float32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), (void *)transformMatrix.matrix_colmajor, 16 * sizeof(float)), 0, 16);
+            obj->Set(JS_STR("transformMatrix"), transformMatrixArray); */
 
-          Local<SharedArrayBuffer> indexArrayBuffer = SharedArrayBuffer::New(Isolate::GetCurrent(), blockMesh.index_count * sizeof(uint16_t));
-          Local<Uint16Array> indexArray = Uint16Array::New(indexArrayBuffer, 0, blockMesh.index_count);
-          obj->Set(JS_STR("indexArray"), indexArray);
-          obj->Set(JS_STR("count"), JS_INT(blockMesh.index_count));
+            Local<SharedArrayBuffer> positionArrayBuffer = SharedArrayBuffer::New(Isolate::GetCurrent(), blockMesh.vertex_count * 3 * sizeof(float));
+            Local<Float32Array> positionArray = Float32Array::New(positionArrayBuffer, 0, blockMesh.vertex_count * 3);
+            memcpy(positionArrayBuffer->GetContents().Data(), blockMesh.vertex, blockMesh.vertex_count * 3 * sizeof(float));
+            obj->Set(JS_STR("positionArray"), positionArray);
+            // obj->Set(JS_STR("positionCount"), JS_INT(blockMesh.vertex_count * 3));
+
+            Local<SharedArrayBuffer> normalArrayBuffer = SharedArrayBuffer::New(Isolate::GetCurrent(), blockMesh.vertex_count * 3 * sizeof(float));
+            Local<Float32Array> normalArray = Float32Array::New(normalArrayBuffer, 0, blockMesh.vertex_count * 3);
+            memcpy(normalArrayBuffer->GetContents().Data(), blockMesh.normal, blockMesh.vertex_count * 3 * sizeof(float));
+            obj->Set(JS_STR("normalArray"), normalArray);
+            // obj->Set(JS_STR("normalCount"), JS_INT(blockMesh.vertex_count * 3));
+
+            Local<SharedArrayBuffer> indexArrayBuffer = SharedArrayBuffer::New(Isolate::GetCurrent(), blockMesh.index_count * sizeof(uint16_t));
+            Local<Uint16Array> indexArray = Uint16Array::New(indexArrayBuffer, 0, blockMesh.index_count);
+            memcpy(indexArrayBuffer->GetContents().Data(), blockMesh.index, blockMesh.index_count * sizeof(uint16_t));
+            obj->Set(JS_STR("indexArray"), indexArray);
+            // obj->Set(JS_STR("count"), JS_INT(blockMesh.index_count));
+            
+            MLVec3f position = mlContext->OffsetFloor(MLVec3f{0, 0, 0}); // {0, 0, 0};
+            MLQuaternionf rotation = {0, 0, 0, 1};
+            MLVec3f scale = {1, 1, 1};
+            MLMat4f transform = composeMatrix(position, rotation, scale);
+            
+            Local<ArrayBuffer> transformMatrixArrayBuffer = ArrayBuffer::New(Isolate::GetCurrent(), 16 * sizeof(float));
+            Local<Float32Array> transformMatrixArray = Float32Array::New(transformMatrixArrayBuffer, 0, 16);
+            float *transformMatrixData = (float *)((char *)transformMatrixArrayBuffer->GetContents().Data());
+            memcpy(transformMatrixData, transform.matrix_colmajor, sizeof(transform.matrix_colmajor));
+            obj->Set(JS_STR("transformMatrix"), transformMatrixArray);
+          }
+
+          result->Set(index, obj);
+          index++;
         }
-
-        result->Set(i, obj);
       }
 
       /* // remove outranged mesh buffers
@@ -824,11 +849,7 @@ NAN_METHOD(MLMesher::WaitGetPoses) {
       }
       for (auto iter = removedIds.begin(); iter != removedIds.end(); iter++) {
         meshBuffers.erase(*iter);
-      }
-
-      std::for_each(meshers.begin(), meshers.end(), [&](MLMesher *m) {
-        m->Update();
-      }); */
+      } */
 
       info.GetReturnValue().Set(result);
 
@@ -859,7 +880,7 @@ NAN_METHOD(MLMesher::Destroy) {
 
 // MLPlaneTracker
 
-MLPlaneTracker::MLPlaneTracker() : planesRequestPending(false) {
+MLPlaneTracker::MLPlaneTracker(float range) : range(range), planesRequestPending(false) {
   if (MLPlanesCreate(&tracker) != MLResult_Ok) {
     ML_LOG(Error, "%s: failed to create planes handle", application_name);
   }
@@ -868,7 +889,9 @@ MLPlaneTracker::MLPlaneTracker() : planesRequestPending(false) {
 MLPlaneTracker::~MLPlaneTracker() {}
 
 NAN_METHOD(MLPlaneTracker::New) {
-  MLPlaneTracker *mlPlaneTracker = new MLPlaneTracker();
+  float range = TO_FLOAT(info[0]);
+
+  MLPlaneTracker *mlPlaneTracker = new MLPlaneTracker(range);
   Local<Object> mlPlaneTrackerObj = info.This();
   mlPlaneTracker->Wrap(mlPlaneTrackerObj);
 
@@ -927,12 +950,12 @@ NAN_METHOD(MLPlaneTracker::WaitGetPoses) {
       // std::unique_lock<std::mutex> lock(mlContext->positionMutex);
 
       planesRequest.bounds_center = mlContext->position;
-      // planesRequest.bounds_rotation = mlContext->rotation;
-      planesRequest.bounds_rotation = {0, 0, 0, 1};
+      planesRequest.bounds_rotation = mlContext->rotation;
+      // planesRequest.bounds_rotation = {0, 0, 0, 1};
     }
-    planesRequest.bounds_extents.x = planeRange;
-    planesRequest.bounds_extents.y = planeRange;
-    planesRequest.bounds_extents.z = planeRange;
+    planesRequest.bounds_extents.x = mlPlaneTracker->range;
+    planesRequest.bounds_extents.y = mlPlaneTracker->range;
+    planesRequest.bounds_extents.z = mlPlaneTracker->range;
 
     planesRequest.flags = MLPlanesQueryFlag_Arbitrary | MLPlanesQueryFlag_AllOrientations | MLPlanesQueryFlag_Semantic_All | MLPlanesQueryFlag_OrientToGravity;
     // planesRequest.min_hole_length = 0.5;
@@ -952,46 +975,87 @@ NAN_METHOD(MLPlaneTracker::WaitGetPoses) {
     uint32_t numPlanesResults;
     MLResult result = MLPlanesQueryGetResults(mlPlaneTracker->tracker, mlPlaneTracker->planesRequestHandle, planeResults, &numPlanesResults);
     if (result == MLResult_Ok) {
-      mlPlaneTracker->planesRequestPending = false;
+      std::vector<std::string> currentPlaneIds(numPlanesResults);
+      for (uint32_t i = 0; i < numPlanesResults; i++) {
+        MLPlane &plane = planeResults[i];
+        uint64_t planeId = (uint64_t)plane.id;
+        currentPlaneIds[i] = id2String((uint64_t)planeId);
+      }
+
+      std::set<std::string> addedPlaneIds;
+      for (size_t i = 0; i < currentPlaneIds.size(); i++) {
+        const std::string &id = currentPlaneIds[i];
+        if (std::find(mlPlaneTracker->planeIds.begin(), mlPlaneTracker->planeIds.end(), id) == mlPlaneTracker->planeIds.end()) {
+          addedPlaneIds.insert(id);
+        }
+      }
+
+      std::set<std::string> removedPlaneIds;
+      for (size_t i = 0; i < mlPlaneTracker->planeIds.size(); i++) {
+        const std::string &id = mlPlaneTracker->planeIds[i];
+        if (std::find(currentPlaneIds.begin(), currentPlaneIds.end(), id) == currentPlaneIds.end()) {
+          removedPlaneIds.insert(id);
+        }
+      }
 
       Local<Array> result = Nan::New<Array>(numPlanesResults);
       for (uint32_t i = 0; i < numPlanesResults; i++) {
         MLPlane &plane = planeResults[i];
 
-        uint64_t planeId = (uint64_t)plane.id;
-        std::string id = id2String(planeId);
-        // uint32_t flags = plane.flags;
-        float width = plane.width;
-        float height = plane.height;
-        MLVec3f &position = plane.position;
-        MLQuaternionf &rotation = plane.rotation;
-        MLVec3f scale = {1, 1, 1};
+        const std::string &id = currentPlaneIds[i];
 
         Local<Object> obj = Nan::New<Object>();
 
         obj->Set(JS_STR("id"), JS_STR(id));
 
-        Local<ArrayBuffer> arrayBuffer = ArrayBuffer::New(Isolate::GetCurrent(), (3+4+2)*sizeof(float));
-        char *arrayBufferData = (char *)arrayBuffer->GetContents().Data();
-        size_t index = 0;
+        bool added = false;
+        bool removed = false;
+        bool updated = false;
+        
+        const char *typeString;
+        if ((added = (addedPlaneIds.find(id) != addedPlaneIds.end()))) {
+          typeString = "planeadd";
+        } else if ((removed = (removedPlaneIds.find(id) != removedPlaneIds.end()))) {
+          typeString = "planeremove";
+        } else {
+          updated = true;
+          typeString = "planeupdate";
+        }
+        obj->Set(JS_STR("type"), JS_STR(typeString));
 
-        memcpy(arrayBufferData + index, position.values, sizeof(position.values));
-        obj->Set(JS_STR("position"), Float32Array::New(arrayBuffer, index, sizeof(position.values)/sizeof(position.values[0])));
-        index += sizeof(position.values);
+        if (added || updated) {
+          // uint32_t flags = plane.flags;
+          const float &width = plane.width;
+          const float &height = plane.height;
+          const MLVec3f &position = mlContext->OffsetFloor(plane.position);
+          const MLQuaternionf &rotation = plane.rotation;
+          const MLVec3f &normal = applyVectorQuaternion(MLVec3f{0, 0, 1}, rotation);
+          
+          Local<ArrayBuffer> arrayBuffer = ArrayBuffer::New(Isolate::GetCurrent(), sizeof(position.values)+sizeof(normal.values)+sizeof(width)+sizeof(height));
+          char *arrayBufferData = (char *)arrayBuffer->GetContents().Data();
+          size_t index = 0;
 
-        memcpy(arrayBufferData + index, rotation.values, sizeof(rotation.values));
-        obj->Set(JS_STR("rotation"), Float32Array::New(arrayBuffer, index, sizeof(rotation.values)/sizeof(rotation.values[0])));
-        index += sizeof(rotation.values);
+          memcpy(arrayBufferData + index, position.values, sizeof(position.values));
+          obj->Set(JS_STR("position"), Float32Array::New(arrayBuffer, index, sizeof(position.values)/sizeof(position.values[0])));
+          index += sizeof(position.values);
 
-        ((float *)(arrayBufferData + index))[0] = width;
-        ((float *)(arrayBufferData + index))[1] = height;
-        obj->Set(JS_STR("size"), Float32Array::New(arrayBuffer, index, 2));
-        index += 2*sizeof(float);
+          memcpy(arrayBufferData + index, normal.values, sizeof(normal.values));
+          obj->Set(JS_STR("normal"), Float32Array::New(arrayBuffer, index, sizeof(normal.values)/sizeof(normal.values[0])));
+          index += sizeof(normal.values);
+
+          ((float *)(arrayBufferData + index))[0] = width;
+          ((float *)(arrayBufferData + index))[1] = height;
+          obj->Set(JS_STR("size"), Float32Array::New(arrayBuffer, index, 2));
+          index += 2*sizeof(float);
+        }
 
         result->Set(i, obj);
       }
 
       info.GetReturnValue().Set(result);
+
+      mlPlaneTracker->planeIds = std::move(currentPlaneIds);
+      mlPlaneTracker->planesRequestPending = false;
     } else if (result == MLResult_Pending) {
       info.GetReturnValue().Set(Nan::Null());
     } else {
@@ -1046,7 +1110,7 @@ void setFingerValue(const MLKeyPointState &keyPointState, MLSnapshot *snapshot, 
     MLTransform transform;
     MLResult result = MLSnapshotGetTransform(snapshot, &keyPointState.frame_id, &transform);
     if (result == MLResult_Ok) {
-      // ML_LOG(Info, "%s: ML keypoint ok", application_name);
+      // ML_LOG(Info, "%s: ML keypoint ok %f %f %f", application_name, transform.position.x, transform.position.y, transform.position.z);
 
       // uint32Data[0] = true;
       data[0] = transform.position.x;
@@ -1083,9 +1147,15 @@ MLHandTracker::MLHandTracker() {
   handTrackingConfig.keypoints_filter_level = MLKeypointFilterLevel_1;
   handTrackingConfig.pose_filter_level = MLPoseFilterLevel_1;
   for (int i = 0; i < MLHandTrackingKeyPose_Count; i++) {
+    handTrackingConfig.keypose_config[i] = true;
+  }
+  /* handTrackingConfig.keypose_config[MLHandTrackingKeyPose_Ok] = false;
+  handTrackingConfig.keypose_config[MLHandTrackingKeyPose_C] = false;
+  handTrackingConfig.keypose_config[MLHandTrackingKeyPose_L] = false; */
+  /* for (int i = 0; i < MLHandTrackingKeyPose_Count; i++) {
     handTrackingConfig.keypose_config[i] = false;
   }
-  handTrackingConfig.keypose_config[MLHandTrackingKeyPose_Pinch] = true;
+  handTrackingConfig.keypose_config[MLHandTrackingKeyPose_Pinch] = true; */
   if (MLHandTrackingSetConfiguration(tracker, &handTrackingConfig) != MLResult_Ok) {
     ML_LOG(Error, "%s: Failed to set hand tracker config.", application_name);
   }
@@ -1167,6 +1237,7 @@ NAN_METHOD(MLHandTracker::WaitGetPoses) {
 
   MLHandTracker *mlHandTracker = ObjectWrap::Unwrap<MLHandTracker>(info.This());
   Local<Array> handsArray = Local<Array>::Cast(info[0]);
+  MLContext *mlContext = application_context.mlContext;
 
   MLHandTrackingData handData;
   MLResult result = MLHandTrackingGetData(mlHandTracker->tracker, &handData);
@@ -1174,7 +1245,7 @@ NAN_METHOD(MLHandTracker::WaitGetPoses) {
     MLHandTrackingStaticData handStaticData;
     MLResult result = MLHandTrackingGetStaticData(mlHandTracker->tracker, &handStaticData);
     if (result == MLResult_Ok) {
-      MLSnapshot *snapshot;
+      MLSnapshot *snapshot = nullptr;
       if (MLPerceptionGetSnapshot(&snapshot) != MLResult_Ok) {
         ML_LOG(Error, "%s: ML failed to get hand snapshot!", application_name);
       }
@@ -1184,185 +1255,189 @@ NAN_METHOD(MLHandTracker::WaitGetPoses) {
 
         Local<Float32Array> connectedArray = Local<Float32Array>::Cast(handObj->Get(JS_STR("connected")));
         auto &handDataState = i == 0 ? handData.left_hand_state : handData.right_hand_state;
-        connectedArray->Set(0, JS_NUM(handDataState.hand_confidence >= 0.5 ? 1 : 0));
+        const bool handVisible = handDataState.hand_confidence >= 0.5;
+        connectedArray->Set(0, JS_NUM(handVisible ? 1 : 0));
 
-        Local<Float32Array> positionArray = Local<Float32Array>::Cast(handObj->Get(JS_STR("position")));
-        float *positionArrayData = (float *)((char *)positionArray->Buffer()->GetContents().Data() + positionArray->ByteOffset());
-        positionArrayData[0] = 0;
-        positionArrayData[1] = 0;
-        positionArrayData[2] = 0;
+        if (handVisible) {
+          const MLVec3f &position = mlContext->OffsetFloor(MLVec3f{0, 0, 0});
+          Local<Float32Array> positionArray = Local<Float32Array>::Cast(handObj->Get(JS_STR("position")));
+          float *positionArrayData = (float *)((char *)positionArray->Buffer()->GetContents().Data() + positionArray->ByteOffset());
+          positionArrayData[0] = position.x;
+          positionArrayData[1] = position.y;
+          positionArrayData[2] = position.z;
 
-        Local<Float32Array> orientationArray = Local<Float32Array>::Cast(handObj->Get(JS_STR("orientation")));
-        float *orientationArrayData = (float *)((char *)orientationArray->Buffer()->GetContents().Data() + orientationArray->ByteOffset());
-        orientationArrayData[0] = 0;
-        orientationArrayData[1] = 0;
-        orientationArrayData[2] = 0;
-        orientationArrayData[3] = 1;
+          Local<Float32Array> orientationArray = Local<Float32Array>::Cast(handObj->Get(JS_STR("orientation")));
+          float *orientationArrayData = (float *)((char *)orientationArray->Buffer()->GetContents().Data() + orientationArray->ByteOffset());
+          orientationArrayData[0] = 0;
+          orientationArrayData[1] = 0;
+          orientationArrayData[2] = 0;
+          orientationArrayData[3] = 1;
 
-        auto &handStaticDataSide = i == 0 ? handStaticData.left : handStaticData.right;
+          auto &handStaticDataSide = i == 0 ? handStaticData.left : handStaticData.right;
 
-        // wrist
-        {
-          auto &handStaticDataSideFinger = handStaticDataSide.wrist;
-          Local<Array> wristArray = Local<Array>::Cast(handObj->Get(JS_STR("wrist")));
+          // wrist
           {
-            Local<Float32Array> wristBoneFloat32Array = Local<Float32Array>::Cast(wristArray->Get(0));
-            float *wristBoneArrayData = (float *)((char *)wristBoneFloat32Array->Buffer()->GetContents().Data() + wristBoneFloat32Array->ByteOffset());
-            setFingerValue(handStaticDataSideFinger.radial, snapshot, wristBoneArrayData);
+            auto &handStaticDataSideFinger = handStaticDataSide.wrist;
+            Local<Array> wristArray = Local<Array>::Cast(handObj->Get(JS_STR("wrist")));
+            {
+              Local<Float32Array> wristBoneFloat32Array = Local<Float32Array>::Cast(wristArray->Get(0));
+              float *wristBoneArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(wristBoneFloat32Array->Get(JS_STR("buffer")))->GetContents().Data() + wristBoneFloat32Array->ByteOffset());
+              setFingerValue(handStaticDataSideFinger.radial, snapshot, wristBoneArrayData);
+            }
+            {
+              Local<Float32Array> wristBoneFloat32Array = Local<Float32Array>::Cast(wristArray->Get(1));
+              float *wristBoneArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(wristBoneFloat32Array->Get(JS_STR("buffer")))->GetContents().Data() + wristBoneFloat32Array->ByteOffset());
+              setFingerValue(handStaticDataSideFinger.ulnar, snapshot, wristBoneArrayData);
+            }
+            {
+              Local<Float32Array> wristBoneFloat32Array = Local<Float32Array>::Cast(wristArray->Get(2));
+              float *wristBoneArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(wristBoneFloat32Array->Get(JS_STR("buffer")))->GetContents().Data() + wristBoneFloat32Array->ByteOffset());
+              setFingerValue(handStaticDataSideFinger.center, snapshot, wristBoneArrayData);
+            }
+            {
+              Local<Float32Array> wristBoneFloat32Array = Local<Float32Array>::Cast(wristArray->Get(3));
+              float *wristBoneArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(wristBoneFloat32Array->Get(JS_STR("buffer")))->GetContents().Data() + wristBoneFloat32Array->ByteOffset());
+              setFingerValue(wristBoneArrayData);
+            }
           }
+
+          Local<Array> fingersArray = Local<Array>::Cast(handObj->Get(JS_STR("fingers")));
           {
-            Local<Float32Array> wristBoneFloat32Array = Local<Float32Array>::Cast(wristArray->Get(1));
-            float *wristBoneArrayData = (float *)((char *)wristBoneFloat32Array->Buffer()->GetContents().Data() + wristBoneFloat32Array->ByteOffset());
-            setFingerValue(handStaticDataSideFinger.ulnar, snapshot, wristBoneArrayData);
+            // thumb
+            {
+              auto &handStaticDataSideFinger = handStaticDataSide.thumb;
+              Local<Array> fingerArray = Local<Array>::Cast(fingersArray->Get(0));
+              {
+                Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(0));
+                float *fingerBoneArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(fingerBoneFloat32Array->Get(JS_STR("buffer")))->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+                setFingerValue(handStaticDataSideFinger.cmc, snapshot, fingerBoneArrayData);
+              }
+              {
+                Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(1));
+                float *fingerBoneArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(fingerBoneFloat32Array->Get(JS_STR("buffer")))->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+                setFingerValue(handStaticDataSideFinger.mcp, snapshot, fingerBoneArrayData);
+              }
+              {
+                Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(2));
+                float *fingerBoneArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(fingerBoneFloat32Array->Get(JS_STR("buffer")))->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+                setFingerValue(handStaticDataSideFinger.ip, snapshot, fingerBoneArrayData);
+              }
+              {
+                Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(3));
+                float *fingerBoneArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(fingerBoneFloat32Array->Get(JS_STR("buffer")))->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+                setFingerValue(handStaticDataSideFinger.tip, snapshot, fingerBoneArrayData);
+              }
+            }
+
+            // index
+            {
+              auto &handStaticDataSideFinger = handStaticDataSide.index;
+              Local<Array> fingerArray = Local<Array>::Cast(fingersArray->Get(1));
+              {
+                Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(0));
+                float *fingerBoneArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(fingerBoneFloat32Array->Get(JS_STR("buffer")))->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+                setFingerValue(handStaticDataSideFinger.mcp, snapshot, fingerBoneArrayData);
+              }
+              {
+                Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(1));
+                float *fingerBoneArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(fingerBoneFloat32Array->Get(JS_STR("buffer")))->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+                setFingerValue(handStaticDataSideFinger.pip, snapshot, fingerBoneArrayData);
+              }
+              {
+                Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(2));
+                float *fingerBoneArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(fingerBoneFloat32Array->Get(JS_STR("buffer")))->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+                setFingerValue(handStaticDataSideFinger.dip, snapshot, fingerBoneArrayData);
+              }
+              {
+                Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(3));
+                float *fingerBoneArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(fingerBoneFloat32Array->Get(JS_STR("buffer")))->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+                setFingerValue(handStaticDataSideFinger.tip, snapshot, fingerBoneArrayData);
+              }
+            }
+
+            // middle
+            {
+              auto &handStaticDataSideFinger = handStaticDataSide.middle;
+              Local<Array> fingerArray = Local<Array>::Cast(fingersArray->Get(2));
+              {
+                Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(0));
+                float *fingerBoneArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(fingerBoneFloat32Array->Get(JS_STR("buffer")))->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+                setFingerValue(handStaticDataSideFinger.mcp, snapshot, fingerBoneArrayData);
+              }
+              {
+                Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(1));
+                float *fingerBoneArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(fingerBoneFloat32Array->Get(JS_STR("buffer")))->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+                setFingerValue(handStaticDataSideFinger.pip, snapshot, fingerBoneArrayData);
+              }
+              {
+                Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(2));
+                float *fingerBoneArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(fingerBoneFloat32Array->Get(JS_STR("buffer")))->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+                setFingerValue(handStaticDataSideFinger.dip, snapshot, fingerBoneArrayData);
+              }
+              {
+                Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(3));
+                float *fingerBoneArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(fingerBoneFloat32Array->Get(JS_STR("buffer")))->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+                setFingerValue(handStaticDataSideFinger.tip, snapshot, fingerBoneArrayData);
+              }
+            }
+
+            // ring
+            {
+              auto &handStaticDataSideFinger = handStaticDataSide.ring;
+              Local<Array> fingerArray = Local<Array>::Cast(fingersArray->Get(3));
+              {
+                Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(0));
+                float *fingerBoneArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(fingerBoneFloat32Array->Get(JS_STR("buffer")))->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+                setFingerValue(handStaticDataSideFinger.mcp, snapshot, fingerBoneArrayData);
+              }
+              {
+                Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(1));
+                float *fingerBoneArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(fingerBoneFloat32Array->Get(JS_STR("buffer")))->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+                setFingerValue(handStaticDataSideFinger.pip, snapshot, fingerBoneArrayData);
+              }
+              {
+                Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(2));
+                float *fingerBoneArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(fingerBoneFloat32Array->Get(JS_STR("buffer")))->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+                setFingerValue(handStaticDataSideFinger.dip, snapshot, fingerBoneArrayData);
+              }
+              {
+                Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(3));
+                float *fingerBoneArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(fingerBoneFloat32Array->Get(JS_STR("buffer")))->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+                setFingerValue(handStaticDataSideFinger.tip, snapshot, fingerBoneArrayData);
+              }
+            }
+
+            // pinky
+            {
+              auto &handStaticDataSideFinger = handStaticDataSide.pinky;
+              Local<Array> fingerArray = Local<Array>::Cast(fingersArray->Get(4));
+              {
+                Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(0));
+                float *fingerBoneArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(fingerBoneFloat32Array->Get(JS_STR("buffer")))->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+                setFingerValue(handStaticDataSideFinger.mcp, snapshot, fingerBoneArrayData);
+              }
+              {
+                Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(1));
+                float *fingerBoneArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(fingerBoneFloat32Array->Get(JS_STR("buffer")))->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+                setFingerValue(handStaticDataSideFinger.pip, snapshot, fingerBoneArrayData);
+              }
+              {
+                Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(2));
+                float *fingerBoneArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(fingerBoneFloat32Array->Get(JS_STR("buffer")))->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+                setFingerValue(handStaticDataSideFinger.dip, snapshot, fingerBoneArrayData);
+              }
+              {
+                Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(3));
+                float *fingerBoneArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(fingerBoneFloat32Array->Get(JS_STR("buffer")))->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+                setFingerValue(handStaticDataSideFinger.tip, snapshot, fingerBoneArrayData);
+              }
+            }
           }
-          {
-            Local<Float32Array> wristBoneFloat32Array = Local<Float32Array>::Cast(wristArray->Get(2));
-            float *wristBoneArrayData = (float *)((char *)wristBoneFloat32Array->Buffer()->GetContents().Data() + wristBoneFloat32Array->ByteOffset());
-            setFingerValue(handStaticDataSideFinger.center, snapshot, wristBoneArrayData);
-          }
-          {
-            Local<Float32Array> wristBoneFloat32Array = Local<Float32Array>::Cast(wristArray->Get(3));
-            float *wristBoneArrayData = (float *)((char *)wristBoneFloat32Array->Buffer()->GetContents().Data() + wristBoneFloat32Array->ByteOffset());
-            setFingerValue(wristBoneArrayData);
-          }
+
+          // MLHandTrackingKeyPose &keypose = handDataState.keypose;
         }
-
-        Local<Array> fingersArray = Local<Array>::Cast(handObj->Get(JS_STR("fingers")));
-        {
-          // thumb
-          {
-            auto &handStaticDataSideFinger = handStaticDataSide.thumb;
-            Local<Array> fingerArray = Local<Array>::Cast(fingersArray->Get(0));
-            {
-              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(0));
-              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
-              setFingerValue(handStaticDataSideFinger.cmc, snapshot, fingerBoneArrayData);
-            }
-            {
-              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(1));
-              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
-              setFingerValue(handStaticDataSideFinger.mcp, snapshot, fingerBoneArrayData);
-            }
-            {
-              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(2));
-              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
-              setFingerValue(handStaticDataSideFinger.ip, snapshot, fingerBoneArrayData);
-            }
-            {
-              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(3));
-              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
-              setFingerValue(handStaticDataSideFinger.tip, snapshot, fingerBoneArrayData);
-            }
-          }
-
-          // index
-          {
-            auto &handStaticDataSideFinger = handStaticDataSide.index;
-            Local<Array> fingerArray = Local<Array>::Cast(fingersArray->Get(1));
-            {
-              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(0));
-              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
-              setFingerValue(handStaticDataSideFinger.mcp, snapshot, fingerBoneArrayData);
-            }
-            {
-              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(1));
-              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
-              setFingerValue(handStaticDataSideFinger.pip, snapshot, fingerBoneArrayData);
-            }
-            {
-              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(2));
-              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
-              setFingerValue(handStaticDataSideFinger.dip, snapshot, fingerBoneArrayData);
-            }
-            {
-              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(3));
-              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
-              setFingerValue(handStaticDataSideFinger.tip, snapshot, fingerBoneArrayData);
-            }
-          }
-
-          // middle
-          {
-            auto &handStaticDataSideFinger = handStaticDataSide.middle;
-            Local<Array> fingerArray = Local<Array>::Cast(fingersArray->Get(2));
-            {
-              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(0));
-              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
-              setFingerValue(handStaticDataSideFinger.mcp, snapshot, fingerBoneArrayData);
-            }
-            {
-              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(1));
-              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
-              setFingerValue(handStaticDataSideFinger.pip, snapshot, fingerBoneArrayData);
-            }
-            {
-              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(2));
-              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
-              setFingerValue(handStaticDataSideFinger.dip, snapshot, fingerBoneArrayData);
-            }
-            {
-              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(3));
-              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
-              setFingerValue(handStaticDataSideFinger.tip, snapshot, fingerBoneArrayData);
-            }
-          }
-
-          // ring
-          {
-            auto &handStaticDataSideFinger = handStaticDataSide.pinky;
-            Local<Array> fingerArray = Local<Array>::Cast(fingersArray->Get(3));
-            {
-              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(0));
-              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
-              setFingerValue(handStaticDataSideFinger.mcp, snapshot, fingerBoneArrayData);
-            }
-            {
-              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(1));
-              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
-              setFingerValue(handStaticDataSideFinger.pip, snapshot, fingerBoneArrayData);
-            }
-            {
-              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(2));
-              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
-              setFingerValue(handStaticDataSideFinger.dip, snapshot, fingerBoneArrayData);
-            }
-            {
-              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(3));
-              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
-              setFingerValue(handStaticDataSideFinger.tip, snapshot, fingerBoneArrayData);
-            }
-          }
-
-          // pinky
-          {
-            auto &handStaticDataSideFinger = handStaticDataSide.pinky;
-            Local<Array> fingerArray = Local<Array>::Cast(fingersArray->Get(4));
-            {
-              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(0));
-              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
-              setFingerValue(handStaticDataSideFinger.mcp, snapshot, fingerBoneArrayData);
-            }
-            {
-              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(1));
-              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
-              setFingerValue(handStaticDataSideFinger.pip, snapshot, fingerBoneArrayData);
-            }
-            {
-              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(2));
-              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
-              setFingerValue(handStaticDataSideFinger.dip, snapshot, fingerBoneArrayData);
-            }
-            {
-              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(3));
-              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
-              setFingerValue(handStaticDataSideFinger.tip, snapshot, fingerBoneArrayData);
-            }
-          }
-        }
-
-        // MLHandTrackingKeyPose &keypose = handDataState.keypose;
       }
-
+      
       if (MLPerceptionReleaseSnapshot(snapshot) != MLResult_Ok) {
         ML_LOG(Error, "%s: ML failed to release hand snapshot!", application_name);
       }
@@ -1423,15 +1498,7 @@ NAN_METHOD(MLEyeTracker::WaitGetPoses) {
 
   MLEyeTracker *mlEyeTracker = ObjectWrap::Unwrap<MLEyeTracker>(info.This());
   Local<Object> eyeObj = Local<Object>::Cast(info[0]);
-  /* Local<Float32Array> float32Array = Local<Float32Array>::Cast(info[0]);
-  Local<ArrayBuffer> arrayBuffer = float32Array->Buffer();
-  float *floatData = (float *)((char *)arrayBuffer->GetContents().Data() + float32Array->ByteOffset()); */
-  // uint32_t *uint32Data = (uint32_t *)floatData;
-
-  MLSnapshot *snapshot;
-  if (MLPerceptionGetSnapshot(&snapshot) != MLResult_Ok) {
-    ML_LOG(Error, "%s: ML failed to get eye snapshot!", application_name);
-  }
+  MLContext *mlContext = application_context.mlContext;
 
   MLEyeTrackingStaticData eyeStaticData;
   if (MLEyeTrackingGetStaticData(mlEyeTracker->tracker, &eyeStaticData) != MLResult_Ok) {
@@ -1442,40 +1509,36 @@ NAN_METHOD(MLEyeTracker::WaitGetPoses) {
   if (MLEyeTrackingGetState(mlEyeTracker->tracker, &eyeState) != MLResult_Ok) {
     ML_LOG(Error, "%s: Eye get state failed!", application_name);
   }
+  
+  MLSnapshot *snapshot;
+  if (MLPerceptionGetSnapshot(&snapshot) != MLResult_Ok) {
+    ML_LOG(Error, "%s: ML failed to get eye snapshot!", application_name);
+  }
 
   MLTransform transform;
-  if (MLSnapshotGetTransform(snapshot, &eyeStaticData.fixation, &transform) == MLResult_Ok) {
-    // nothing
-  } else {
+  if (MLSnapshotGetTransform(snapshot, &eyeStaticData.fixation, &transform) != MLResult_Ok) {
     ML_LOG(Error, "%s: ML failed to get eye fixation transform!", application_name);
   }
 
+  const MLVec3f &position = mlContext->OffsetFloor(transform.position);
   Local<Float32Array> positionArray = Local<Float32Array>::Cast(eyeObj->Get(JS_STR("position")));
-  float *positionArrayData = (float *)((char *)positionArray->Buffer()->GetContents().Data() + positionArray->ByteOffset());
-  memcpy(positionArrayData, transform.position.values, sizeof(transform.position.values));
-  /* int index = 0;
-  memcpy(floatData + index, transform.position.values, sizeof(mlEyeTracker->transform.position.values));
-  index += sizeof(mlEyeTracker->transform.position.values)/sizeof(mlEyeTracker->transform.position.values[0]); */
+  float *positionArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(positionArray->Get(JS_STR("buffer")))->GetContents().Data() + positionArray->ByteOffset());
+  memcpy(positionArrayData, position.values, sizeof(position.values));
 
   Local<Float32Array> orientationArray = Local<Float32Array>::Cast(eyeObj->Get(JS_STR("orientation")));
-  float *orientationArrayData = (float *)((char *)orientationArray->Buffer()->GetContents().Data() + orientationArray->ByteOffset());
+  float *orientationArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(orientationArray->Get(JS_STR("buffer")))->GetContents().Data() + orientationArray->ByteOffset());
   memcpy(orientationArrayData, transform.rotation.values, sizeof(transform.rotation.values));
 
-  /* memcpy(floatData + index, mlEyeTracker->transform.rotation.values, sizeof(mlEyeTracker->transform.rotation.values));
-  index += sizeof(mlEyeTracker->transform.rotation.values)/sizeof(mlEyeTracker->transform.rotation.values[0]); */
-
   Local<Float32Array> axesArray = Local<Float32Array>::Cast(eyeObj->Get(JS_STR("axes")));
-  float *axesArrayData = (float *)((char *)axesArray->Buffer()->GetContents().Data() + axesArray->ByteOffset());
+  float *axesArrayData = (float *)((char *)Local<SharedArrayBuffer>::Cast(axesArray->Get(JS_STR("buffer")))->GetContents().Data() + axesArray->ByteOffset());
   axesArrayData[0] = eyeState.left_blink ? -1 : 1;
   axesArrayData[1] = eyeState.right_blink ? -1 : 1;
-  /* floatData[index] = eyeState.left_blink ? -1 : 1;
-  index++;
-  floatData[index] = eyeState.right_blink ? -1 : 1;
-  index++; */
 
   if (MLPerceptionReleaseSnapshot(snapshot) != MLResult_Ok) {
     ML_LOG(Error, "%s: ML failed to release eye snapshot!", application_name);
   }
+  
+  ML_LOG(Error, "MLEyeTracker::WaitGetPoses 9");
 }
 
 /* void MLEyeTracker::Update(MLSnapshot *snapshot) {
@@ -2223,12 +2286,21 @@ Handle<Object> MLContext::Initialize(Isolate *isolate) {
   Local<ObjectTemplate> proto = ctor->PrototypeTemplate();
   Nan::SetMethod(proto, "Present", Present);
   Nan::SetMethod(proto, "Exit", Exit);
-  // Nan::SetMethod(proto, "WaitGetPoses", WaitGetPoses);
   Nan::SetMethod(proto, "GetSize", GetSize);
   // Nan::SetMethod(proto, "SetContentTexture", SetContentTexture);
   Nan::SetMethod(proto, "WaitGetPoses", WaitGetPoses);
   // Nan::SetMethod(proto, "PrepareFrame", PrepareFrame);
   Nan::SetMethod(proto, "SubmitFrame", SubmitFrame);
+  Nan::SetMethod(proto, "requestHitTest", RequestHitTest);
+  Nan::SetMethod(proto, "requestMeshing", RequestMeshing);
+  Nan::SetMethod(proto, "requestPlaneTracking", RequestPlaneTracking);
+  Nan::SetMethod(proto, "requestHandTracking", RequestHandTracking);
+  Nan::SetMethod(proto, "requestEyeTracking", RequestEyeTracking);
+  Nan::SetMethod(proto, "requestImageTracking", RequestImageTracking);
+  // Nan::SetMethod(proto, "RequestDepthPopulation", RequestDepthPopulation);
+  // Nan::SetMethod(proto, "RequestCamera", RequestCamera);
+  // Nan::SetMethod(proto, "CancelCamera", CancelCamera);
+  Nan::SetMethod(proto, "update", Update);
 
   Local<Function> ctorFn = ctor->GetFunction();
 
@@ -2237,16 +2309,6 @@ Handle<Object> MLContext::Initialize(Isolate *isolate) {
   Nan::SetMethod(ctorFn, "SetEventHandler", SetEventHandler);
   Nan::SetMethod(ctorFn, "IsPresent", IsPresent);
   Nan::SetMethod(ctorFn, "IsSimulated", IsSimulated);
-  Nan::SetMethod(ctorFn, "RequestHitTest", RequestHitTest);
-  Nan::SetMethod(ctorFn, "RequestMeshing", RequestMeshing);
-  Nan::SetMethod(ctorFn, "RequestPlaneTracking", RequestPlaneTracking);
-  Nan::SetMethod(ctorFn, "RequestHandTracking", RequestHandTracking);
-  Nan::SetMethod(ctorFn, "RequestEyeTracking", RequestEyeTracking);
-  Nan::SetMethod(ctorFn, "RequestImageTracking", RequestImageTracking);
-  // Nan::SetMethod(ctorFn, "RequestDepthPopulation", RequestDepthPopulation);
-  // Nan::SetMethod(ctorFn, "RequestCamera", RequestCamera);
-  // Nan::SetMethod(ctorFn, "CancelCamera", CancelCamera);
-  Nan::SetMethod(ctorFn, "Update", Update);
   // Nan::SetMethod(ctorFn, "Poll", Poll);
 
   return scope.Escape(ctorFn);
@@ -2863,60 +2925,11 @@ NAN_METHOD(MLContext::Present) {
     }
   }
 
-  /* if (MLGestureTrackingCreate(&mlContext->gestureTracker) != MLResult_Ok) {
-    ML_LOG(Error, "%s: Failed to create gesture tracker.", application_name);
-    info.GetReturnValue().Set(Nan::Null());
-    return;
-  } */
-
-  /* if (MLHandTrackingCreate(&handTracker) != MLResult_Ok) {
-    ML_LOG(Error, "%s: Failed to create hand tracker.", application_name);
-    info.GetReturnValue().Set(Nan::Null());
-    return;
-  }
-
-  MLHandTrackingConfiguration handTrackingConfig;
-  handTrackingConfig.handtracking_pipeline_enabled = true;
-  handTrackingConfig.keypoints_filter_level = MLKeypointFilterLevel_1;
-  handTrackingConfig.pose_filter_level = MLPoseFilterLevel_1;
-  for (int i = 0; i < MLHandTrackingKeyPose_Count; i++) {
-    handTrackingConfig.keypose_config[i] = true;
-  }
-  handTrackingConfig.keypose_config[MLHandTrackingKeyPose_Ok] = false;
-  handTrackingConfig.keypose_config[MLHandTrackingKeyPose_C] = false;
-  handTrackingConfig.keypose_config[MLHandTrackingKeyPose_L] = false;
-  if (MLHandTrackingSetConfiguration(handTracker, &handTrackingConfig) != MLResult_Ok) {
-    ML_LOG(Error, "%s: Failed to set hand tracker config.", application_name);
-    info.GetReturnValue().Set(Nan::Null());
-    return;
-  } */
-  
-  /* {
-    MLResult result = MLRaycastCreate(&raycastTracker);
-    if (result != MLResult_Ok) {
-      ML_LOG(Error, "%s: failed to create raycast handle %x", application_name, result);
-      Nan::ThrowError("MLContext::Present failed to create raycast handle");
-      return;
-    }
-  } */
-
   if (MLPlanesCreate(&floorTracker) != MLResult_Ok) {
     ML_LOG(Error, "%s: failed to create floor handle", application_name);
     info.GetReturnValue().Set(Nan::Null());
     return;
   }
-
-  /* if (MLPlanesCreate(&planesTracker) != MLResult_Ok) {
-    ML_LOG(Error, "%s: failed to create planes handle", application_name);
-    info.GetReturnValue().Set(Nan::Null());
-    return;
-  } */
-
-  /* if (MLEyeTrackingCreate(&eyeTracker) != MLResult_Ok) {
-    ML_LOG(Error, "%s: failed to create eye handle", application_name);
-    info.GetReturnValue().Set(Nan::Null());
-    return;
-  } */
 
   mlContext->TickFloor();
 
@@ -2966,39 +2979,11 @@ NAN_METHOD(MLContext::Exit) {
     return;
   }
 
-  /* if (MLHandTrackingDestroy(handTracker) != MLResult_Ok) {
-    ML_LOG(Error, "%s: Failed to destroy hand tracker.", application_name);
-    info.GetReturnValue().Set(Nan::Null());
-    return;
-  } */
-  
-  /* if (MLRaycastDestroy(raycastTracker) != MLResult_Ok) {
-    ML_LOG(Error, "%s: failed to destroy raycast handle", application_name);
-    return;
-  } */
-
   if (MLPlanesDestroy(floorTracker) != MLResult_Ok) {
     ML_LOG(Error, "%s: failed to destroy floor handle", application_name);
     info.GetReturnValue().Set(Nan::Null());
     return;
   }
-
-  /* if (MLMeshingDestroyClient(&meshTracker) != MLResult_Ok) {
-    ML_LOG(Error, "%s: failed to destroy mesh handle", application_name);
-    return;
-  }
-
-  if (MLPlanesDestroy(planesTracker) != MLResult_Ok) {
-    ML_LOG(Error, "%s: failed to destroy planes handle", application_name);
-    info.GetReturnValue().Set(Nan::Null());
-    return;
-  }
-
-  if (MLEyeTrackingDestroy(eyeTracker) != MLResult_Ok) {
-    ML_LOG(Error, "%s: failed to create eye handle", application_name);
-    info.GetReturnValue().Set(Nan::Null());
-    return;
-  } */
 
   if (MLPerceptionShutdown() != MLResult_Ok) {
     ML_LOG(Error, "%s: Failed to stop perception.", application_name);
@@ -3197,7 +3182,6 @@ NAN_METHOD(MLContext::WaitGetPoses) {
     Local<Float32Array> transformFloat32Array = Local<Float32Array>::Cast(info[0]);
     Local<Float32Array> projectionFloat32Array = Local<Float32Array>::Cast(info[1]);
     Local<Float32Array> controllersFloat32Array = Local<Float32Array>::Cast(info[2]);
-    Local<Function> cbFn = Local<Function>::Cast(info[3]);
 
     float *transformArray = (float *)((char *)transformFloat32Array->Buffer()->GetContents().Data() + transformFloat32Array->ByteOffset());
     float *projectionArray = (float *)((char *)projectionFloat32Array->Buffer()->GetContents().Data() + projectionFloat32Array->ByteOffset());
@@ -3260,7 +3244,7 @@ NAN_METHOD(MLContext::WaitGetPoses) {
         // std::unique_lock<std::mutex> lock(mlContext->positionMutex);
 
         const MLTransform &leftCameraTransform = mlContext->virtual_camera_array.virtual_cameras[0].transform;
-        mlContext->position = OffsetFloor(leftCameraTransform.position);
+        mlContext->position = leftCameraTransform.position;
         mlContext->rotation = leftCameraTransform.rotation;
       }
       
@@ -3432,7 +3416,7 @@ NAN_METHOD(MLContext::SubmitFrame) {
       ML_LOG(Error, "MLGraphicsEndFrame complained: %d", result);
     }
 
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    // glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
     /* if (gl->HasFramebufferBinding(GL_READ_FRAMEBUFFER)) {
       glBindFramebuffer(GL_READ_FRAMEBUFFER, gl->GetFramebufferBinding(GL_READ_FRAMEBUFFER));
@@ -3497,13 +3481,20 @@ NAN_METHOD(MLContext::RequestMeshing) {
 }
 
 NAN_METHOD(MLContext::RequestPlaneTracking) {
-  MLContext *mlContext = ObjectWrap::Unwrap<MLContext>(Local<Object>::Cast(info.This()));
-  if (mlContext->mlPlaneTrackerConstructor.IsEmpty()) {
-    mlContext->mlPlaneTrackerConstructor.Reset(MLPlaneTracker::Initialize(Isolate::GetCurrent()));
+  if (info[0]->IsNumber()) {
+    MLContext *mlContext = ObjectWrap::Unwrap<MLContext>(Local<Object>::Cast(info.This()));
+    if (mlContext->mlPlaneTrackerConstructor.IsEmpty()) {
+      mlContext->mlPlaneTrackerConstructor.Reset(MLPlaneTracker::Initialize(Isolate::GetCurrent()));
+    }
+    Local<Function> mlPlaneTrackerCons = Nan::New(mlContext->mlPlaneTrackerConstructor);
+    Local<Value> argv[] = {
+      info[0],
+    };
+    Local<Object> mlPlaneTrackerObj = mlPlaneTrackerCons->NewInstance(Isolate::GetCurrent()->GetCurrentContext(), sizeof(argv)/sizeof(argv[0]), argv).ToLocalChecked();
+    info.GetReturnValue().Set(mlPlaneTrackerObj);
+  } else {
+    Nan::ThrowError("MLContext::RequestPlaneTracking: invalid arguments");
   }
-  Local<Function> mlPlaneTrackerCons = Nan::New(mlContext->mlPlaneTrackerConstructor);
-  Local<Object> mlPlaneTrackerObj = mlPlaneTrackerCons->NewInstance(Isolate::GetCurrent()->GetCurrentContext(), 0, nullptr).ToLocalChecked();
-  info.GetReturnValue().Set(mlPlaneTrackerObj);
 }
 
 NAN_METHOD(MLContext::RequestHitTest) {
@@ -3573,6 +3564,7 @@ NAN_METHOD(MLContext::RequestEyeTracking) {
   if (mlContext->mlEyeTrackerConstructor.IsEmpty()) {
     mlContext->mlEyeTrackerConstructor.Reset(MLEyeTracker::Initialize(Isolate::GetCurrent()));
   }
+  
   Local<Function> mlEyeTrackerCons = Nan::New(mlContext->mlEyeTrackerConstructor);
   /* Local<Value> argv[] = {
     info[0],
@@ -3679,7 +3671,7 @@ NAN_METHOD(MLContext::CancelCamera) {
 } */
 
 NAN_METHOD(MLContext::Update) {
-  MLContext *mlContext = ObjectWrap::Unwrap<MLContext>(Local<Object>::Cast(info[0]));
+  MLContext *mlContext = ObjectWrap::Unwrap<MLContext>(info.This());
 
   MLSnapshot *snapshot = nullptr;
 
@@ -3744,8 +3736,8 @@ void MLContext::TickFloor() {
       // std::unique_lock<std::mutex> lock(mlContext->positionMutex);
 
       floorRequest.bounds_center = this->position;
-      // floorRequest.bounds_rotation = mlContext->rotation;
-      floorRequest.bounds_rotation = {0, 0, 0, 1};
+      floorRequest.bounds_rotation = this->rotation;
+      // floorRequest.bounds_rotation = {0, 0, 0, 1};
     }
     floorRequest.bounds_extents.x = planeRange;
     floorRequest.bounds_extents.y = planeRange;

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -374,6 +374,7 @@ MLMat4f getWindowTransformMatrix(Local<Object> windowObj, bool inverse = true) {
 
 // MLRaycaster
 
+MLHandle MLRaycaster::tracker;
 bool MLRaycaster::hasTracker = false;
 MLRaycaster::MLRaycaster(const MLVec3f &position, const MLVec3f &direction) {
   if (!hasTracker) {

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -49,9 +49,10 @@ void QueueEvent(std::function<void(std::function<void(int, Local<Value> *)>)> fn
 }
 
 void QueueCallback(uv_loop_t *loop, std::function<void()> fn) {
-  MLCallback *mlCallback = new MLCallback(loop, fn);
+  // XXX
+  /* MLCallback *mlCallback = new MLCallback(loop, fn);
 
-  uv_async_send(mlCallback->async.get());
+  uv_async_send(mlCallback->async.get()); */
 }
 
 // std::list<MLPoll *> polls;
@@ -70,7 +71,7 @@ MLHandle imageTrackerHandle;
 MLImageTrackerSettings imageTrackerSettings;
 std::vector<MLImageTracker *> imageTrackers;
 
-MLHandle handTracker;
+/* MLHandle handTracker;
 MLHandTrackingData handData;
 MLHandTrackingKeyPose lastKeyposeLeft = MLHandTrackingKeyPose_NoHand;
 MLHandTrackingKeyPose lastKeyposeRight = MLHandTrackingKeyPose_NoHand;
@@ -78,11 +79,7 @@ MLHandTrackingStaticData handStaticData;
 std::vector<MLHandTracker *> handTrackers;
 bool handPresents[2];
 float wristBones[2][4][1 + 3];
-float fingerBones[2][5][4][1 + 3];
-
-MLHandle raycastTracker;
-MLRaycastQuery raycastQuery;
-std::vector<MLRaycaster *> raycasters;
+float fingerBones[2][5][4][1 + 3]; */
 
 MLHandle floorTracker;
 MLPlanesQuery floorRequest;
@@ -93,7 +90,7 @@ bool floorRequestPending = false;
 float largestFloorY = 0;
 float largestFloorSizeSq = 0;
 
-MLHandle meshTracker;
+/* MLHandle meshTracker;
 std::vector<MLMesher *> meshers;
 MLMeshingExtents meshExtents;
 MLHandle meshInfoRequestHandle;
@@ -111,20 +108,15 @@ MLMeshingMesh mesh;
 bool meshRequestsPending = false;
 bool meshRequestPending = false;
 
-std::map<std::string, MeshBuffer> meshBuffers;
+std::map<std::string, MeshBuffer> meshBuffers; */
 
-MLHandle planesTracker;
+/* MLHandle planesTracker;
 std::vector<MLPlaneTracker *> planeTrackers;
 MLPlanesQuery planesRequest;
 MLHandle planesRequestHandle;
 MLPlane planeResults[MAX_NUM_PLANES];
 uint32_t numPlanesResults;
-bool planesRequestPending = false;
-
-MLHandle eyeTracker;
-std::vector<MLEyeTracker *> eyeTrackers;
-MLEyeTrackingState eyeState;
-MLEyeTrackingStaticData eyeStaticData;
+bool planesRequestPending = false; */
 
 bool depthEnabled = false;
 
@@ -382,98 +374,104 @@ MLMat4f getWindowTransformMatrix(Local<Object> windowObj, bool inverse = true) {
 
 // MLRaycaster
 
-MLRaycaster::MLRaycaster(Local<Object> windowObj, MLHandle requestHandle, uv_loop_t *loop, Local<Function> cb) : windowObj(windowObj), requestHandle(requestHandle), loop(loop), cb(cb) {}
+bool MLRaycaster::hasTracker = false;
+MLRaycaster::MLRaycaster(const MLVec3f &position, const MLVec3f &direction) {
+  if (!hasTracker) {
+    MLResult result = MLRaycastCreate(&tracker);
+    if (result == MLResult_Ok) {
+      hasTracker = true;
+    } else {
+      ML_LOG(Error, "%s: failed to create raycast handle %x", application_name, result);
+    }
+  }
+
+  raycastQuery.position = position;
+  raycastQuery.direction = direction;
+  raycastQuery.up_vector = MLVec3f{0, 1, 0};
+  raycastQuery.horizontal_fov_degrees = 30;
+  raycastQuery.width = 1;
+  raycastQuery.height = 1;
+  raycastQuery.collide_with_unobserved = false;
+
+  MLResult result = MLRaycastRequest(tracker, &raycastQuery, &requestHandle);
+  if (result != MLResult_Ok) {
+    ML_LOG(Error, "%s: Failed to request raycast: %x %x", application_name, result);
+    Nan::ThrowError("failed to request raycast");
+  }
+}
 
 MLRaycaster::~MLRaycaster() {}
 
-bool MLRaycaster::Update() {
+Local<Function> MLRaycaster::Initialize(Isolate *isolate) {
+  Nan::EscapableHandleScope scope;
+
+  // constructor
+  Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(New);
+  ctor->InstanceTemplate()->SetInternalFieldCount(1);
+  ctor->SetClassName(JS_STR("MLRaycaster"));
+
+  // prototype
+  Local<ObjectTemplate> proto = ctor->PrototypeTemplate();
+  Nan::SetMethod(proto, "waitGetPoses", WaitGetPoses);
+  // Nan::SetMethod(proto, "destroy", Destroy);
+
+  Local<Function> ctorFn = Nan::GetFunction(ctor).ToLocalChecked();
+
+  return scope.Escape(ctorFn);
+}
+
+NAN_METHOD(MLRaycaster::New) {
+  Local<Float32Array> originFloat32Array = Local<Float32Array>::Cast(info[0]);
+  Local<Float32Array> directionFloat32Array = Local<Float32Array>::Cast(info[1]);
+
+  MLVec3f position;
+  memcpy(position.values, (char *)originFloat32Array->Buffer()->GetContents().Data() + originFloat32Array->ByteOffset(), sizeof(raycastQuery.position.values));
+  
+  MLVec3f direction;
+  memcpy(direction.values, (char *)directionFloat32Array->Buffer()->GetContents().Data() + directionFloat32Array->ByteOffset(), sizeof(raycastQuery.direction.values));
+
+  MLRaycaster *mlRaycaster = new MLRaycaster(position, direction);
+  Local<Object> mlRaycasterObj = info.This();
+  mlRaycaster->Wrap(mlRaycasterObj);
+  info.GetReturnValue().Set(mlRaycasterObj);
+}
+
+NAN_METHOD(MLRaycaster::WaitGetPoses) {
+  MLRaycaster *mlRaycaster = ObjectWrap::Unwrap<MLRaycaster>(info.This());
+  
   MLRaycastResult raycastResult;
-  MLResult result = MLRaycastGetResult(raycastTracker, this->requestHandle, &raycastResult);
+  MLResult result = MLRaycastGetResult(mlRaycaster->tracker, mlRaycaster->requestHandle, &raycastResult);
   if (result == MLResult_Ok) {
     if (raycastResult.state == MLRaycastResultState_HitObserved) {
       const MLVec3f position = raycastResult.hitpoint;
       const MLQuaternionf quaternion = getQuaternionFromUnitVectors(MLVec3f{0, 1, 0}, raycastResult.normal);
       const MLVec3f scale = {1, 1, 1};
 
-      QueueCallback(loop, [this, position, quaternion, scale]() -> void {
-        if (!this->cb.IsEmpty()) {
-          MLMat4f hitMatrix = composeMatrix(position, quaternion, scale);
+      MLMat4f hitMatrix = composeMatrix(position, quaternion, scale);
 
-          Local<Object> localWindowObj = Nan::New(this->windowObj);
-          MLMat4f transformMatrix = getWindowTransformMatrix(localWindowObj);
-          if (!isIdentityMatrix(transformMatrix)) {
-            hitMatrix = multiplyMatrices(transformMatrix, hitMatrix);
-          }
-
-          Local<Object> asyncObject = Nan::New<Object>();
-          AsyncResource asyncResource(Isolate::GetCurrent(), asyncObject, "MLRaycaster::Update");
-
-          Local<Function> cb = Nan::New(this->cb);
-
-          Local<Object> xrHitResult = Nan::New<Object>();
-          Local<Float32Array> hitMatrixArray = Float32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), (void *)hitMatrix.matrix_colmajor, 16 * sizeof(float)), 0, 16);
-          xrHitResult->Set(JS_STR("hitMatrix"), hitMatrixArray);
-          Local<Array> array = Nan::New<Array>(1);
-          array->Set(0, xrHitResult);
-          Local<Value> argv[] = {
-            array,
-          };
-          asyncResource.MakeCallback(cb, sizeof(argv)/sizeof(argv[0]), argv);
-        }
-
-        delete this;
-      });
+      Local<Object> xrHitResult = Nan::New<Object>();
+      Local<Float32Array> hitMatrixArray = Float32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), (void *)hitMatrix.matrix_colmajor, 16 * sizeof(float)), 0, 16);
+      xrHitResult->Set(JS_STR("hitMatrix"), hitMatrixArray);
+      Local<Array> result = Nan::New<Array>(1);
+      result->Set(0, xrHitResult);
+      info.GetReturnValue().Set(result);
     } else {
-      // Local<Object> localWindowObj = Nan::New(this->windowObj);
-
-      QueueCallback(loop, [this]() -> void {
-        if (!this->cb.IsEmpty()) {
-          Local<Object> asyncObject = Nan::New<Object>();
-          AsyncResource asyncResource(Isolate::GetCurrent(), asyncObject, "MLRaycaster::Update");
-
-          Local<Function> cb = Nan::New(this->cb);
-          
-          Local<Value> argv[] = {
-            Nan::New<Array>(0),
-          };
-          asyncResource.MakeCallback(cb, sizeof(argv)/sizeof(argv[0]), argv);
-        }
-        
-        delete this;
-      });
+      Local<Array> result = Nan::New<Array>(0);
+      info.GetReturnValue().Set(result);
     }
-    
-    return true;
   } else if (result == MLResult_Pending) {
-    return false;
+    info.GetReturnValue().Set(Nan::Null());
   } else {
     ML_LOG(Error, "%s: Raycast request failed! %x", application_name, result);
     
-    // Local<Object> localWindowObj = Nan::New(this->windowObj);
-
-    QueueCallback(loop, [this]() -> void {
-      if (!this->cb.IsEmpty()) {
-        Local<Object> asyncObject = Nan::New<Object>();
-        AsyncResource asyncResource(Isolate::GetCurrent(), asyncObject, "MLRaycaster::Update");
-
-        Local<Function> cb = Nan::New(this->cb);
-        
-        Local<Value> argv[] = {
-          Nan::New<Array>(0),
-        };
-        asyncResource.MakeCallback(cb, sizeof(argv)/sizeof(argv[0]), argv);
-      }
-      
-      delete this;
-    });
-
-    return true;
+    Local<Array> result = Nan::New<Array>(0);
+    info.GetReturnValue().Set(result);
   }
 }
 
 // MLCallback
 
-MLCallback::MLCallback(uv_loop_t *loop, std::function<void()> fn) : async(new uv_async_t()), fn(fn) {
+/* MLCallback::MLCallback(uv_loop_t *loop, std::function<void()> fn) : async(new uv_async_t()), fn(fn) {
   async->data = this;
   uv_async_init(loop, async.get(), RunInAsyncThread);
 }
@@ -491,7 +489,7 @@ void MLCallback::RunInAsyncThread(uv_async_t *handle) {
   mlCallback->fn();
 
   delete mlCallback;
-}
+} */
 
 /* // MLPoll
 
@@ -501,7 +499,7 @@ MLPoll::~MLPoll() {} */
 
 // MeshBuffer
 
-MeshBuffer::MeshBuffer() :
+/* MeshBuffer::MeshBuffer() :
   positions(nullptr),
   numPositions(0),
   normals(nullptr),
@@ -515,7 +513,7 @@ MeshBuffer::MeshBuffer(MLTransform transform, float *positions, uint32_t numPosi
   normals(normals),
   indices(indices),
   numIndices(numIndices)
-  {}
+  {} */
 /* MeshBuffer::MeshBuffer(const MeshBuffer &meshBuffer) {
   positionBuffer = meshBuffer.positionBuffer;
   normalBuffer = meshBuffer.normalBuffer;
@@ -527,7 +525,7 @@ MeshBuffer::MeshBuffer(MLTransform transform, float *positions, uint32_t numPosi
   numIndices = meshBuffer.numIndices;
 } */
 
-float getMaxRange() {
+/* float getMaxRange() {
   float range = 1.0f;
   for (auto iter = meshers.begin(); iter != meshers.end(); iter++) {
     MLMesher *mesher = *iter;
@@ -541,19 +539,32 @@ MLMeshingLOD getMaxLod() {
     MLMesher *mesher = *iter;
     lod = std::max(lod, mesher->lod);
   }
-}
+} */
 
 // MLMesher
 
-MLMesher::MLMesher(Local<Object> windowObj, uv_loop_t *loop, float range, MLMeshingLOD lod) : windowObj(windowObj), loop(loop), range(range), lod(lod) {}
+MLMesher::MLMesher(float range, MLMeshingLOD lod) : range(range), lod(lod), meshInfoRequestPending(false), meshRequestsPending(false), meshRequestPending(false) {
+  MLMeshingSettings meshingSettings;
+  if (MLMeshingInitSettings(&meshingSettings) != MLResult_Ok) {
+    ML_LOG(Error, "%s: failed to initialize meshing settings", application_name);
+  }
+  meshingSettings.flags |= MLMeshingFlags_ComputeNormals;
+  // meshingSettings.flags |= MLMeshingFlags_Planarize;
+  {
+    MLResult result = MLMeshingCreateClient(&tracker, &meshingSettings);
+    if (result != MLResult_Ok) {
+      ML_LOG(Error, "%s: failed to create mesh handle %x", application_name, result);
+      Nan::ThrowError("MLContext::Present failed to create mesh handle");
+      return;
+    }
+  }
+}
 
 MLMesher::~MLMesher() {}
 
 NAN_METHOD(MLMesher::New) {
-  Local<Object> windowObj = Local<Object>::Cast(info[0]);
-  int lodValue = TO_INT32(info[1]);
-  float range = TO_FLOAT(info[2]);
-  uv_loop_t *loop = windowsystembase::GetEventLoop();
+  int lodValue = TO_INT32(info[0]);
+  float range = TO_FLOAT(info[1]);
   
   MLMeshingLOD lod;
   switch (lodValue) {
@@ -575,15 +586,15 @@ NAN_METHOD(MLMesher::New) {
     }
   }
   
-  MLMesher *mlMesher = new MLMesher(windowObj, loop, range, lod);
+  MLMesher *mlMesher = new MLMesher(range, lod);
   Local<Object> mlMesherObj = info.This();
   mlMesher->Wrap(mlMesherObj);
 
-  Nan::SetAccessor(mlMesherObj, JS_STR("onmesh"), OnMeshGetter, OnMeshSetter);
+  // Nan::SetAccessor(mlMesherObj, JS_STR("onmesh"), OnMeshGetter, OnMeshSetter);
 
   info.GetReturnValue().Set(mlMesherObj);
 
-  meshers.push_back(mlMesher);
+  // meshers.push_back(mlMesher);
 }
 
 Local<Function> MLMesher::Initialize(Isolate *isolate) {
@@ -596,6 +607,7 @@ Local<Function> MLMesher::Initialize(Isolate *isolate) {
 
   // prototype
   Local<ObjectTemplate> proto = ctor->PrototypeTemplate();
+  Nan::SetMethod(proto, "waitGetPoses", WaitGetPoses);
   Nan::SetMethod(proto, "destroy", Destroy);
 
   Local<Function> ctorFn = Nan::GetFunction(ctor).ToLocalChecked();
@@ -603,7 +615,7 @@ Local<Function> MLMesher::Initialize(Isolate *isolate) {
   return scope.Escape(ctorFn);
 }
 
-NAN_GETTER(MLMesher::OnMeshGetter) {
+/* NAN_GETTER(MLMesher::OnMeshGetter) {
   // Nan::HandleScope scope;
   MLMesher *mlMesher = ObjectWrap::Unwrap<MLMesher>(info.This());
 
@@ -621,192 +633,247 @@ NAN_SETTER(MLMesher::OnMeshSetter) {
   } else {
     Nan::ThrowError("MLMesher::OnMeshSetter: invalid arguments");
   }
-}
+} */
 
-void MLMesher::Update() {
-  MLMat4f transformMatrix = getWindowTransformMatrix(Nan::New(this->windowObj));
+NAN_METHOD(MLMesher::WaitGetPoses) {
+  MLMesher *mlMesher = ObjectWrap::Unwrap<MLMesher>(info.This());
+  MLContext *mlContext = application_context.mlContext;
 
-  MLMeshingBlockMesh *blockMeshes = mesh.data;
-  uint32_t dataCount = mesh.data_count;
+  // MLMat4f transformMatrix = getWindowTransformMatrix(Nan::New(this->windowObj));
 
-  std::vector<MLUpdateType> types;
-  types.reserve(dataCount);
-  std::vector<std::string> ids;
-  ids.reserve(dataCount);
-  std::vector<float *> positionArrays;
-  positionArrays.reserve(dataCount);
-  std::vector<int> positionCounts;
-  positionCounts.reserve(dataCount);
-  std::vector<float *> normalArrays;
-  normalArrays.reserve(dataCount);
-  std::vector<int> normalCounts;
-  normalCounts.reserve(dataCount);
-  std::vector<uint16_t *> indexArrays;
-  indexArrays.reserve(dataCount);
-  std::vector<int> counts;
-  counts.reserve(dataCount);
-  uint32_t numResults = 0;
+  // request
 
-  for (uint32_t i = 0; i < dataCount; i++) {
-    MLMeshingBlockMesh &blockMesh = blockMeshes[i];
-    std::string id = id2String(blockMesh.id);
+  if (!mlMesher->meshInfoRequestPending && !mlMesher->meshRequestsPending) {
+    MLMeshingExtents meshExtents;
+    {
+      // std::unique_lock<std::mutex> lock(mlContext->positionMutex);
 
-    if (!meshRequestRemovedMap[id]) {
-      auto iter = meshBuffers.find(id);
+      meshExtents.center = mlContext->position;
+      // meshExtents.rotation =  mlContext->rotation;
+      meshExtents.rotation = {0, 0, 0, 1};
+    }
+    meshExtents.extents.x = mlMesher->range;
+    meshExtents.extents.y = mlMesher->range;
+    meshExtents.extents.z = mlMesher->range;
 
-      if (iter != meshBuffers.end()) {
-        const MeshBuffer &meshBuffer = iter->second;
-
-        MLUpdateType type;
-        if (meshRequestNewMap[id]) {
-          type = MLUpdateType::NEW;
-        } else if (meshRequestUnchangedMap[id]) {
-          type = MLUpdateType::UNCHANGED;
-        } else {
-          type = MLUpdateType::UPDATE;
-        }
-        types.push_back(type);
-        ids.push_back(std::move(id));
-        positionArrays.push_back(meshBuffer.positions);
-        positionCounts.push_back(meshBuffer.numPositions);
-        normalArrays.push_back(meshBuffer.normals);
-        normalCounts.push_back(meshBuffer.numPositions);
-        indexArrays.push_back(meshBuffer.indices);
-        counts.push_back(meshBuffer.numIndices);
-        
-        numResults++;
-      } else {
-        ML_LOG(Error, "%s: ML mesh poll failed to find mesh: %s", application_name, id.c_str());
-      }
+    MLResult result = MLMeshingRequestMeshInfo(mlMesher->tracker, &meshExtents, &mlMesher->meshInfoRequestHandle);
+    if (result == MLResult_Ok) {
+      mlMesher->meshInfoRequestPending = true;
     } else {
-      types.push_back(MLUpdateType::REMOVE);
-      ids.push_back(std::move(id));
-      positionArrays.push_back(nullptr);
-      positionCounts.push_back(0);
-      normalArrays.push_back(nullptr);
-      normalCounts.push_back(0);
-      indexArrays.push_back(nullptr);
-      counts.push_back(0);
-      
-      numResults++;
+      ML_LOG(Error, "%s: Mesh info request failed! %x", application_name, result);
     }
   }
 
-  // Local<Object> localWindowObj = Nan::New(this->windowObj);
+  /* {
+    // std::unique_lock<std::mutex> lock(cameraRequestsMutex);
 
-  QueueCallback(loop, [
-    this,
-    transformMatrix,
-    types{std::move(types)},
-    ids{std::move(ids)},
-    positionArrays{std::move(positionArrays)},
-    positionCounts{std::move(positionCounts)},
-    normalArrays{std::move(normalArrays)},
-    normalCounts{std::move(normalCounts)},
-    indexArrays{std::move(indexArrays)},
-    counts{std::move(counts)},
-    numResults
-  ]() -> void {
-    if (!this->cb.IsEmpty()) {
-      Local<Object> asyncObject = Nan::New<Object>();
-      AsyncResource asyncResource(Isolate::GetCurrent(), asyncObject, "MLMesher::Update");
+    if (cameraRequests.size() > 0) {
+      cameraRequestConditionVariable.notify_one();
+    }
+  } */
 
-      Local<Array> array = Nan::New<Array>(numResults);
-      for (uint32_t i = 0; i < numResults; i++) {
-        const string &id = ids[i];
+  // responses
+
+  if (mlMesher->meshInfoRequestPending) {
+    MLResult result = MLMeshingGetMeshInfoResult(mlMesher->tracker, mlMesher->meshInfoRequestHandle, &mlMesher->meshInfo);
+    if (result == MLResult_Ok) {
+      /* uint32_t dataCount = meshInfo.data_count;
+
+      meshRequestNewMap.clear();
+      meshRequestRemovedMap.clear();
+      meshRequestUnchangedMap.clear();
+      for (uint32_t i = 0; i < dataCount; i++) {
+        const MLMeshingBlockInfo &meshBlockInfo = meshInfo.data[i];
+        const MLMeshingMeshState &state = meshBlockInfo.state;
+        MLMeshingBlockRequest &meshBlockRequest = meshBlockRequests[i];
+        meshBlockRequest.id = meshBlockInfo.id;
+        meshBlockRequest.level = mlMesher->lod;
+
+        const std::string &id = id2String(meshBlockInfo.id);
+        meshRequestNewMap[id] = (state == MLMeshingMeshState_New);
+        meshRequestRemovedMap[id] = (state == MLMeshingMeshState_Deleted);
+        meshRequestUnchangedMap[id] = (state == MLMeshingMeshState_Unchanged);
+      }
+      numMeshBlockRequests = dataCount; */
+
+      mlMesher->meshInfoRequestPending = false;
+      mlMesher->meshRequestsPending = true;
+      mlMesher->meshRequestPending = false;
+      mlMesher->meshBlockRequestIndex = 0;
+    } else if (result == MLResult_Pending) {
+      // nothing
+    } else {
+      ML_LOG(Error, "%s: Mesh info get failed! %x", application_name, result);
+
+      mlMesher->meshInfoRequestPending = false;
+    }
+  }
+
+  if (mlMesher->meshRequestsPending && !mlMesher->meshRequestPending) {
+    if (mlMesher->meshBlockRequestIndex < mlMesher->meshInfo.data_count) {
+      uint32_t requestsRemaining = mlMesher->meshInfo.data_count - mlMesher->meshBlockRequestIndex;
+      uint32_t requestsThisTime = std::min<uint32_t>(requestsRemaining, 16);
+
+      std::vector<MLMeshingBlockRequest> meshBlockRequests(requestsThisTime);
+      for (uint32_t i = 0; i < requestsThisTime; i++) {
+        const MLMeshingBlockInfo &meshBlockInfo = mlMesher->meshInfo.data[mlMesher->meshBlockRequestIndex + i];
+        const MLMeshingMeshState &state = meshBlockInfo.state;
+        MLMeshingBlockRequest &meshBlockRequest = meshBlockRequests[i];
+        meshBlockRequest.id = meshBlockInfo.id;
+        meshBlockRequest.level = mlMesher->lod;
+
+        /* const std::string &id = id2String(meshBlockInfo.id);
+        meshRequestNewMap[id] = (state == MLMeshingMeshState_New);
+        meshRequestRemovedMap[id] = (state == MLMeshingMeshState_Deleted);
+        meshRequestUnchangedMap[id] = (state == MLMeshingMeshState_Unchanged); */
+      }
+
+      MLMeshingMeshRequest meshRequest;
+      meshRequest.data = meshBlockRequests.data();
+      meshRequest.request_count = requestsThisTime;
+
+      mlMesher->meshBlockRequestIndex += requestsThisTime;
+
+      MLResult result = MLMeshingRequestMesh(mlMesher->tracker, &meshRequest, &mlMesher->meshRequestHandle);
+      if (result == MLResult_Ok) {
+        mlMesher->meshRequestsPending = true;
+        mlMesher->meshRequestPending = true;
+      } else {
+        ML_LOG(Error, "%s: Mesh request failed! %x", application_name, result);
+
+        mlMesher->meshRequestsPending = false;
+        mlMesher->meshRequestPending = false;
+
+        MLMeshingFreeResource(mlMesher->tracker, &mlMesher->meshInfoRequestHandle);
+      }
+    } else {
+      mlMesher->meshRequestsPending = false;
+      mlMesher->meshRequestPending = false;
+
+      MLMeshingFreeResource(mlMesher->tracker, &mlMesher->meshInfoRequestHandle);
+    }
+  }
+  if (mlMesher->meshRequestsPending && mlMesher->meshRequestPending) {
+    MLMeshingMesh mesh;
+    MLResult result = MLMeshingGetMeshResult(mlMesher->tracker, mlMesher->meshRequestHandle, &mesh);
+    if (result == MLResult_Ok) {
+      Local<Array> result = Nan::New<Array>(mesh.data_count);
+      for (uint32_t i = 0; i < mesh.data_count; i++) {
+        MLMeshingBlockMesh &blockMesh = mesh.data[i];
+        MLMeshingBlockInfo &meshBlockInfo = mlMesher->meshInfo.data[i];
+
+        if (id2String(blockMesh.id) != id2String(meshBlockInfo.id)) { // XXX
+          ML_LOG(Error, "%s: Mesh result id does not match request id %x %x %x %x", application_name, blockMesh.id, meshBlockInfo.id, mesh.data_count, mlMesher->meshInfo.data_count);
+        }
 
         Local<Object> obj = Nan::New<Object>();
+        const std::string &id = id2String(blockMesh.id);
         obj->Set(JS_STR("id"), JS_STR(id));
 
-        const MLUpdateType &type = types[i];
         const char *typeString;
-        switch (type) {
-          case MLUpdateType::NEW: {
-            typeString = "new";
-            break;
-          }
-          case MLUpdateType::UNCHANGED: {
-            typeString = "unchanged";
-            break;
-          }
-          case MLUpdateType::UPDATE: {
-            typeString = "update";
-            break;
-          }
-          case MLUpdateType::REMOVE: {
-            typeString = "remove";
-            break;
-          }
-          default: {
-            typeString = "";
-            break;
-          }
+        if (meshBlockInfo.state == MLMeshingMeshState_New) {
+          typeString = "new";
+        } else if (meshBlockInfo.state == MLMeshingMeshState_Updated) {
+          typeString = "update";
+        } else if (meshBlockInfo.state == MLMeshingMeshState_Deleted) {
+          typeString = "remove";
+        } else if (meshBlockInfo.state == MLMeshingMeshState_Unchanged) {
+          typeString = "unchanged";
+        } else {
+          typeString = "";
         }
         obj->Set(JS_STR("type"), JS_STR(typeString));
 
-        if (type != MLUpdateType::REMOVE) {
-          Local<Float32Array> transformMatrixArray = Float32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), (void *)transformMatrix.matrix_colmajor, 16 * sizeof(float)), 0, 16);
-          obj->Set(JS_STR("transformMatrix"), transformMatrixArray);
+        if (meshBlockInfo.state == MLMeshingMeshState_New || meshBlockInfo.state == MLMeshingMeshState_Updated) {
+          /* Local<Float32Array> transformMatrixArray = Float32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), (void *)transformMatrix.matrix_colmajor, 16 * sizeof(float)), 0, 16);
+          obj->Set(JS_STR("transformMatrix"), transformMatrixArray); */
 
-          Local<Float32Array> positionArray = Float32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), positionArrays[i], positionCounts[i] * sizeof(float)), 0, positionCounts[i]);
+          Local<SharedArrayBuffer> positionArrayBuffer = SharedArrayBuffer::New(Isolate::GetCurrent(), blockMesh.vertex_count * 3 * sizeof(float));
+          Local<Float32Array> positionArray = Float32Array::New(positionArrayBuffer, 0, blockMesh.vertex_count * 3);
+          memcpy(positionArrayBuffer->GetContents().Data(), blockMesh.vertex->values, blockMesh.vertex_count * 3 * sizeof(float));
           obj->Set(JS_STR("positionArray"), positionArray);
-          obj->Set(JS_STR("positionCount"), JS_INT(positionCounts[i]));
+          obj->Set(JS_STR("positionCount"), JS_INT(blockMesh.vertex_count * 3));
 
-          Local<Float32Array> normalArray = Float32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), normalArrays[i], normalCounts[i] * sizeof(float)), 0, normalCounts[i]);
+          Local<SharedArrayBuffer> normalArrayBuffer = SharedArrayBuffer::New(Isolate::GetCurrent(), blockMesh.vertex_count * 3 * sizeof(float));
+          Local<Float32Array> normalArray = Float32Array::New(normalArrayBuffer, 0, blockMesh.vertex_count * 3);
+          memcpy(normalArrayBuffer->GetContents().Data(), blockMesh.normal->values, blockMesh.vertex_count * 3 * sizeof(float));
           obj->Set(JS_STR("normalArray"), normalArray);
-          obj->Set(JS_STR("normalCount"), JS_INT(positionCounts[i]));
+          obj->Set(JS_STR("normalCount"), JS_INT(blockMesh.vertex_count * 3));
 
-          Local<Uint16Array> indexArray = Uint16Array::New(ArrayBuffer::New(Isolate::GetCurrent(), indexArrays[i], counts[i] * sizeof(uint16_t)), 0, counts[i]);
+          Local<SharedArrayBuffer> indexArrayBuffer = SharedArrayBuffer::New(Isolate::GetCurrent(), blockMesh.index_count * sizeof(uint16_t));
+          Local<Uint16Array> indexArray = Uint16Array::New(indexArrayBuffer, 0, blockMesh.index_count);
           obj->Set(JS_STR("indexArray"), indexArray);
-          obj->Set(JS_STR("count"), JS_INT(counts[i]));
-        } else {
-          Local<Object> obj = Nan::New<Object>();
-          obj->Set(JS_STR("id"), JS_STR(id));
-          obj->Set(JS_STR("type"), JS_STR("remove"));
+          obj->Set(JS_STR("count"), JS_INT(blockMesh.index_count));
         }
 
-        array->Set(i, obj);
+        result->Set(i, obj);
       }
 
-      Local<Function> cbFn = Nan::New(this->cb);
-      Local<Value> argv[] = {
-        array,
-      };
-      asyncResource.MakeCallback(cbFn, sizeof(argv)/sizeof(argv[0]), argv);
+      /* // remove outranged mesh buffers
+      float range = getMaxRange();
+      std::vector<std::string> removedIds;
+      for (auto iter = meshBuffers.begin(); iter != meshBuffers.end(); iter++) {
+        const std::string &id = iter->first;
+        MeshBuffer &meshBuffer = iter->second;
+        float distance = distanceTo(mlContext->position, meshBuffer.transform.position);
+        if (distance > range) {
+          meshRequestRemovedMap[id] = true;
+          removedIds.push_back(id);
+        }
+      }
+      for (auto iter = removedIds.begin(); iter != removedIds.end(); iter++) {
+        meshBuffers.erase(*iter);
+      }
+
+      std::for_each(meshers.begin(), meshers.end(), [&](MLMesher *m) {
+        m->Update();
+      }); */
+
+      info.GetReturnValue().Set(result);
+
+      mlMesher->meshRequestsPending = true;
+      mlMesher->meshRequestPending = false;
+
+      MLMeshingFreeResource(mlMesher->tracker, &mlMesher->meshRequestHandle);
+    } else if (result == MLResult_Pending) {
+      info.GetReturnValue().Set(Nan::Null());
+    } else {
+      ML_LOG(Error, "%s: Mesh get failed! %x", application_name, result);
+
+      mlMesher->meshRequestsPending = true;
+      mlMesher->meshRequestPending = false;
+
+      info.GetReturnValue().Set(Nan::Null());
     }
-  });
+  }
 }
 
 NAN_METHOD(MLMesher::Destroy) {
   MLMesher *mlMesher = ObjectWrap::Unwrap<MLMesher>(info.This());
 
-  meshers.erase(std::remove_if(meshers.begin(), meshers.end(), [&](MLMesher *m) -> bool {
-    if (m == mlMesher) {
-      delete m;
-      return true;
-    } else {
-      return false;
-    }
-  }), meshers.end());
+  if (MLMeshingDestroyClient(&mlMesher->tracker) != MLResult_Ok) {
+    ML_LOG(Error, "%s: failed to destroy mesh handle", application_name);
+  }
 }
 
 // MLPlaneTracker
 
-MLPlaneTracker::MLPlaneTracker(Local<Object> windowObj, uv_loop_t *loop) : windowObj(windowObj), loop(loop) {}
+MLPlaneTracker::MLPlaneTracker() : planesRequestPending(false) {
+  if (MLPlanesCreate(&tracker) != MLResult_Ok) {
+    ML_LOG(Error, "%s: failed to create planes handle", application_name);
+  }
+}
 
 MLPlaneTracker::~MLPlaneTracker() {}
 
 NAN_METHOD(MLPlaneTracker::New) {
-  uv_loop_t *loop = windowsystembase::GetEventLoop();
-  MLPlaneTracker *mlPlaneTracker = new MLPlaneTracker(Local<Object>::Cast(info[0]), loop);
+  MLPlaneTracker *mlPlaneTracker = new MLPlaneTracker();
   Local<Object> mlPlaneTrackerObj = info.This();
   mlPlaneTracker->Wrap(mlPlaneTrackerObj);
 
-  Nan::SetAccessor(mlPlaneTrackerObj, JS_STR("onplanes"), OnPlanesGetter, OnPlanesSetter);
+  // Nan::SetAccessor(mlPlaneTrackerObj, JS_STR("onplanes"), OnPlanesGetter, OnPlanesSetter);
 
   info.GetReturnValue().Set(mlPlaneTrackerObj);
-
-  planeTrackers.push_back(mlPlaneTracker);
 }
 
 Local<Function> MLPlaneTracker::Initialize(Isolate *isolate) {
@@ -819,6 +886,7 @@ Local<Function> MLPlaneTracker::Initialize(Isolate *isolate) {
 
   // prototype
   Local<ObjectTemplate> proto = ctor->PrototypeTemplate();
+  Nan::SetMethod(proto, "waitGetPoses", WaitGetPoses);
   Nan::SetMethod(proto, "destroy", Destroy);
 
   Local<Function> ctorFn = Nan::GetFunction(ctor).ToLocalChecked();
@@ -826,7 +894,7 @@ Local<Function> MLPlaneTracker::Initialize(Isolate *isolate) {
   return scope.Escape(ctorFn);
 }
 
-NAN_GETTER(MLPlaneTracker::OnPlanesGetter) {
+/* NAN_GETTER(MLPlaneTracker::OnPlanesGetter) {
   // Nan::HandleScope scope;
   MLPlaneTracker *mlPlaneTracker = ObjectWrap::Unwrap<MLPlaneTracker>(info.This());
 
@@ -844,134 +912,195 @@ NAN_SETTER(MLPlaneTracker::OnPlanesSetter) {
   } else {
     Nan::ThrowError("MLPlaneTracker::OnPlaneSetter: invalid arguments");
   }
-}
+} */
 
-void MLPlaneTracker::Update() {
-  MLMat4f transformMatrix = getWindowTransformMatrix(Nan::New(this->windowObj));
+NAN_METHOD(MLPlaneTracker::WaitGetPoses) {
+  MLPlaneTracker *mlPlaneTracker = ObjectWrap::Unwrap<MLPlaneTracker>(info.This());
+  MLContext *mlContext = application_context.mlContext;
 
-  uint32_t numPlanes = numPlanesResults;
-  
-  std::vector<std::string> ids;
-  ids.reserve(numPlanes);
-  std::vector<float> widths;
-  widths.reserve(numPlanes);
-  std::vector<float> heights;
-  heights.reserve(numPlanes);
-  std::vector<MLVec3f> positions;
-  positions.reserve(numPlanes);
-  std::vector<MLQuaternionf> rotations;
-  rotations.reserve(numPlanes);
+  // MLMat4f transformMatrix = getWindowTransformMatrix(Nan::New(this->windowObj));
 
-  for (uint32_t i = 0; i < numPlanes; i++) {
-    MLPlane &plane = planeResults[i];
+  if (!mlPlaneTracker->planesRequestPending) {
+    MLPlanesQuery planesRequest;
+    {
+      // std::unique_lock<std::mutex> lock(mlContext->positionMutex);
 
-    uint64_t planeId = (uint64_t)plane.id;
-    // uint32_t flags = plane.flags;
-    float width = plane.width;
-    float height = plane.height;
-    MLVec3f position = plane.position;
-    MLQuaternionf rotation = plane.rotation;
-    MLVec3f scale = {1, 1, 1};
-
-    std::string id = id2String(planeId);
-    ids.push_back(std::move(id));
-
-    if (!isIdentityMatrix(transformMatrix)) {
-      MLMat4f transform = multiplyMatrices(transformMatrix, composeMatrix(position, rotation, scale));
-      decomposeMatrix(transform, position, rotation, scale);
+      planesRequest.bounds_center = mlContext->position;
+      // planesRequest.bounds_rotation = mlContext->rotation;
+      planesRequest.bounds_rotation = {0, 0, 0, 1};
     }
+    planesRequest.bounds_extents.x = planeRange;
+    planesRequest.bounds_extents.y = planeRange;
+    planesRequest.bounds_extents.z = planeRange;
 
-    positions.push_back(position);
-    rotations.push_back(rotation);
-    widths.push_back(width);
-    heights.push_back(height);
+    planesRequest.flags = MLPlanesQueryFlag_Arbitrary | MLPlanesQueryFlag_AllOrientations | MLPlanesQueryFlag_Semantic_All | MLPlanesQueryFlag_OrientToGravity;
+    // planesRequest.min_hole_length = 0.5;
+    planesRequest.min_plane_area = 0.25;
+    planesRequest.max_results = MAX_NUM_PLANES;
+
+    MLResult result = MLPlanesQueryBegin(mlPlaneTracker->tracker, &planesRequest, &mlPlaneTracker->planesRequestHandle);
+    if (result == MLResult_Ok) {
+      mlPlaneTracker->planesRequestPending = true;
+    } else {
+      ML_LOG(Error, "%s: Planes request failed! %x", application_name, result);
+    }
   }
 
-  // Local<Object> localWindowObj = Nan::New(this->windowObj);
+  if (mlPlaneTracker->planesRequestPending) {
+    MLPlane planeResults[MAX_NUM_PLANES];
+    uint32_t numPlanesResults;
+    MLResult result = MLPlanesQueryGetResults(mlPlaneTracker->tracker, mlPlaneTracker->planesRequestHandle, planeResults, &numPlanesResults);
+    if (result == MLResult_Ok) {
+      mlPlaneTracker->planesRequestPending = false;
 
-  QueueCallback(loop, [
-    this,
-    numPlanes,
-    ids{std::move(ids)},
-    positions{std::move(positions)},
-    rotations{std::move(rotations)},
-    widths{std::move(widths)},
-    heights{std::move(heights)}
-  ]() -> void {
-    if (!this->cb.IsEmpty()) {
-      Local<Object> asyncObject = Nan::New<Object>();
-      AsyncResource asyncResource(Isolate::GetCurrent(), asyncObject, "MLPlaneTracker::Update");
+      Local<Array> result = Nan::New<Array>(numPlanesResults);
+      for (uint32_t i = 0; i < numPlanesResults; i++) {
+        MLPlane &plane = planeResults[i];
 
-      Local<Array> array = Nan::New<Array>();
-      
-      for (uint32_t i = 0; i < numPlanes; i++) {
+        uint64_t planeId = (uint64_t)plane.id;
+        std::string id = id2String(planeId);
+        // uint32_t flags = plane.flags;
+        float width = plane.width;
+        float height = plane.height;
+        MLVec3f &position = plane.position;
+        MLQuaternionf &rotation = plane.rotation;
+        MLVec3f scale = {1, 1, 1};
+
         Local<Object> obj = Nan::New<Object>();
-        
-        const std::string &id = ids[i];
+
         obj->Set(JS_STR("id"), JS_STR(id));
 
         Local<ArrayBuffer> arrayBuffer = ArrayBuffer::New(Isolate::GetCurrent(), (3+4+2)*sizeof(float));
         char *arrayBufferData = (char *)arrayBuffer->GetContents().Data();
         size_t index = 0;
 
-        const MLVec3f &position = positions[i];
         memcpy(arrayBufferData + index, position.values, sizeof(position.values));
         obj->Set(JS_STR("position"), Float32Array::New(arrayBuffer, index, sizeof(position.values)/sizeof(position.values[0])));
         index += sizeof(position.values);
 
-        const MLQuaternionf &rotation = rotations[i];
         memcpy(arrayBufferData + index, rotation.values, sizeof(rotation.values));
         obj->Set(JS_STR("rotation"), Float32Array::New(arrayBuffer, index, sizeof(rotation.values)/sizeof(rotation.values[0])));
         index += sizeof(rotation.values);
 
-        ((float *)(arrayBufferData + index))[0] = widths[i];
-        ((float *)(arrayBufferData + index))[1] = heights[i];
+        ((float *)(arrayBufferData + index))[0] = width;
+        ((float *)(arrayBufferData + index))[1] = height;
         obj->Set(JS_STR("size"), Float32Array::New(arrayBuffer, index, 2));
         index += 2*sizeof(float);
 
-        array->Set(i, obj);
+        result->Set(i, obj);
       }
 
-      Local<Function> cb = Nan::New(this->cb);
-      Local<Value> argv[] = {
-        array,
-      };
-      asyncResource.MakeCallback(cb, sizeof(argv)/sizeof(argv[0]), argv);
+      info.GetReturnValue().Set(result);
+    } else if (result == MLResult_Pending) {
+      info.GetReturnValue().Set(Nan::Null());
+    } else {
+      ML_LOG(Error, "%s: Planes request failed! %x", application_name, result);
+
+      mlPlaneTracker->planesRequestPending = false;
+
+      info.GetReturnValue().Set(Nan::Null());
     }
-  });
+  }
 }
 
 NAN_METHOD(MLPlaneTracker::Destroy) {
   MLPlaneTracker *mlPlaneTracker = ObjectWrap::Unwrap<MLPlaneTracker>(info.This());
 
-  planeTrackers.erase(std::remove_if(planeTrackers.begin(), planeTrackers.end(), [&](MLPlaneTracker *p) -> bool {
-    if (p == mlPlaneTracker) {
-      delete p;
-      return true;
-    } else {
-      return false;
-    }
-  }), planeTrackers.end());
+  if (MLPlanesDestroy(mlPlaneTracker->tracker) != MLResult_Ok) {
+    ML_LOG(Error, "%s: failed to destroy planes handle", application_name);
+  }
 }
 
 // MLHandTracker
 
-MLHandTracker::MLHandTracker(Local<Object> windowObj, uv_loop_t *loop) : windowObj(windowObj), loop(loop) {}
+/* void setFingerValue(const MLWristState &wristState, MLSnapshot *snapshot, float data[4][1 + 3]);
+void setFingerValue(const MLThumbState &thumbState, MLSnapshot *snapshot, float data[4][1 + 3]);
+void setFingerValue(const MLFingerState &fingerState, MLSnapshot *snapshot, float data[4][1 + 3]); */
+void setFingerValue(const MLKeyPointState &keyPointState, MLSnapshot *snapshot, float *data);
+void setFingerValue(float *data);
+
+/* void setFingerValue(const MLWristState &wristState, MLSnapshot *snapshot, float data[4][1 + 3]) {
+  setFingerValue(wristState.radial, snapshot, data[0]);
+  setFingerValue(wristState.ulnar, snapshot, data[1]);
+  setFingerValue(wristState.center, snapshot, data[2]);
+  setFingerValue(data[3]);
+}
+void setFingerValue(const MLThumbState &thumbState, MLSnapshot *snapshot, float data[4][1 + 3]) {
+  setFingerValue(thumbState.cmc, snapshot, data[0]);
+  setFingerValue(thumbState.mcp, snapshot, data[1]);
+  setFingerValue(thumbState.ip, snapshot, data[2]);
+  setFingerValue(thumbState.tip, snapshot, data[3]);
+}
+void setFingerValue(const MLFingerState &fingerState, MLSnapshot *snapshot, float data[4][1 + 3]) {
+  setFingerValue(fingerState.mcp, snapshot, data[0]);
+  setFingerValue(fingerState.pip, snapshot, data[1]);
+  setFingerValue(fingerState.dip, snapshot, data[2]);
+  setFingerValue(fingerState.tip, snapshot, data[3]);
+} */
+void setFingerValue(const MLKeyPointState &keyPointState, MLSnapshot *snapshot, float *data) {
+  // uint32_t *uint32Data = (uint32_t *)data;
+  // float *floatData = (float *)data;
+
+  if (keyPointState.is_valid) {
+    MLTransform transform;
+    MLResult result = MLSnapshotGetTransform(snapshot, &keyPointState.frame_id, &transform);
+    if (result == MLResult_Ok) {
+      // ML_LOG(Info, "%s: ML keypoint ok", application_name);
+
+      // uint32Data[0] = true;
+      data[0] = transform.position.x;
+      data[1] = transform.position.y;
+      data[2] = transform.position.z;
+    } else {
+      // ML_LOG(Error, "%s: ML failed to get finger transform: %s", application_name, MLSnapshotGetResultString(result));
+
+      setFingerValue(data);
+    }
+  } else {
+    setFingerValue(data);
+  }
+}
+void setFingerValue(float *data) {
+  // uint32_t *uint32Data = (uint32_t *)data;
+  // float *floatData = (float *)data;
+
+  // uint32Data[0] = false;
+  // const MLVec3f &position = MLVec3f{0, 0, 0};
+  auto nan = std::numeric_limits<float>::quiet_NaN();
+  data[0] = nan;
+  data[1] = nan;
+  data[2] = nan;
+}
+
+MLHandTracker::MLHandTracker() {
+  if (MLHandTrackingCreate(&tracker) != MLResult_Ok) {
+    ML_LOG(Error, "%s: Failed to create hand tracker.", application_name);
+  }
+
+  MLHandTrackingConfiguration handTrackingConfig;
+  handTrackingConfig.handtracking_pipeline_enabled = true;
+  handTrackingConfig.keypoints_filter_level = MLKeypointFilterLevel_1;
+  handTrackingConfig.pose_filter_level = MLPoseFilterLevel_1;
+  for (int i = 0; i < MLHandTrackingKeyPose_Count; i++) {
+    handTrackingConfig.keypose_config[i] = false;
+  }
+  handTrackingConfig.keypose_config[MLHandTrackingKeyPose_Pinch] = true;
+  if (MLHandTrackingSetConfiguration(tracker, &handTrackingConfig) != MLResult_Ok) {
+    ML_LOG(Error, "%s: Failed to set hand tracker config.", application_name);
+  }
+}
 
 MLHandTracker::~MLHandTracker() {}
 
 NAN_METHOD(MLHandTracker::New) {
-  uv_loop_t *loop = windowsystembase::GetEventLoop();
-  MLHandTracker *mlHandTracker = new MLHandTracker(Local<Object>::Cast(info[0]), loop);
+  MLHandTracker *mlHandTracker = new MLHandTracker();
   Local<Object> mlHandTrackerObj = info.This();
   mlHandTracker->Wrap(mlHandTrackerObj);
 
-  Nan::SetAccessor(mlHandTrackerObj, JS_STR("onhands"), OnHandsGetter, OnHandsSetter);
-  Nan::SetAccessor(mlHandTrackerObj, JS_STR("ongesture"), OnGestureGetter, OnGestureSetter);
+  // Nan::SetAccessor(mlHandTrackerObj, JS_STR("onhands"), OnHandsGetter, OnHandsSetter);
+  // Nan::SetAccessor(mlHandTrackerObj, JS_STR("ongesture"), OnGestureGetter, OnGestureSetter);
 
   info.GetReturnValue().Set(mlHandTrackerObj);
-
-  handTrackers.push_back(mlHandTracker);
 }
 
 Local<Function> MLHandTracker::Initialize(Isolate *isolate) {
@@ -984,6 +1113,7 @@ Local<Function> MLHandTracker::Initialize(Isolate *isolate) {
 
   // prototype
   Local<ObjectTemplate> proto = ctor->PrototypeTemplate();
+  Nan::SetMethod(proto, "waitGetPoses", WaitGetPoses);
   Nan::SetMethod(proto, "destroy", Destroy);
 
   Local<Function> ctorFn = Nan::GetFunction(ctor).ToLocalChecked();
@@ -991,7 +1121,7 @@ Local<Function> MLHandTracker::Initialize(Isolate *isolate) {
   return scope.Escape(ctorFn);
 }
 
-NAN_GETTER(MLHandTracker::OnHandsGetter) {
+/* NAN_GETTER(MLHandTracker::OnHandsGetter) {
   // Nan::HandleScope scope;
   MLHandTracker *mlHandTracker = ObjectWrap::Unwrap<MLHandTracker>(info.This());
 
@@ -1029,471 +1159,244 @@ NAN_SETTER(MLHandTracker::OnGestureSetter) {
   } else {
     Nan::ThrowError("MLHandTracker::OnGestureSetter: invalid arguments");
   }
-}
+} */
 
-void MLHandTracker::Update() {
-  MLMat4f transformMatrix = getWindowTransformMatrix(Nan::New(this->windowObj));
+NAN_METHOD(MLHandTracker::WaitGetPoses) {
+  // MLMat4f transformMatrix = getWindowTransformMatrix(Nan::New(this->windowObj));
 
-  bool leftHandBoneValid;
-  MLVec3f leftHandCenter;
-  MLVec3f leftHandNormal;
-  bool leftHandTransformValid;
-  MLTransform leftPointerTransform;
-  bool leftPointerTransformValid;
-  MLTransform leftGripTransform;
-  bool leftGripTransformValid;
-  std::vector<MLVec3f> leftWristPositions(4);
-  std::vector<bool> leftWristPositionsValid(4);
-  std::vector<MLVec3f> leftFingerPositions(5*4);
-  std::vector<bool> leftFingerPositionsValid(5*4);
-  MLHandTrackingKeyPose keyposeLeft;
-  bool keyposeLeftNew;
+  MLHandTracker *mlHandTracker = ObjectWrap::Unwrap<MLHandTracker>(info.This());
+  Local<Array> handsArray = Local<Array>::Cast(info[0]);
 
-  bool rightHandBoneValid;
-  MLVec3f rightHandCenter;
-  MLVec3f rightHandNormal;
-  bool rightHandTransformValid;
-  MLTransform rightPointerTransform;
-  bool rightPointerTransformValid;
-  MLTransform rightGripTransform;
-  bool rightGripTransformValid;
-  std::vector<MLVec3f> rightWristPositions(4);
-  std::vector<bool> rightWristPositionsValid(4);
-  std::vector<MLVec3f> rightFingerPositions(5*4);
-  std::vector<bool> rightFingerPositionsValid(5*4);
-  MLHandTrackingKeyPose keyposeRight;
-  bool keyposeRightNew;
-
-  leftHandBoneValid = handPresents[0] && getHandBone(wristBones[0], fingerBones[0]);
-  if (leftHandBoneValid) {
-    leftHandTransformValid = getHandTransform(leftHandCenter, leftHandNormal, wristBones[0], fingerBones[0], true, transformMatrix);
-    leftPointerTransformValid = getHandPointerTransform(leftPointerTransform, wristBones[0], fingerBones[0], leftHandNormal, transformMatrix);
-    leftGripTransformValid = getHandGripTransform(leftGripTransform, wristBones[0], fingerBones[0], leftHandNormal, transformMatrix);
-
-    for (size_t i = 0; i < 4; i++) {
-      if (*(uint32_t *)&wristBones[0][i][0]) {
-        MLVec3f position;
-        getWristBonePosition(position, wristBones[0], i, transformMatrix);
-
-        leftWristPositions[i] = position;
-        leftWristPositionsValid[i] = true;
-      } else {
-        leftWristPositionsValid[i] = false;
-      }
-    }
-
-    for (size_t i = 0; i < 5; i++) {
-      for (size_t j = 0; j < 4; j++) {
-        uint32_t k = i*4 + j;
-
-        if (*(uint32_t *)&fingerBones[0][i][j][0]) {
-          MLVec3f position;
-          getFingerBonePosition(position, fingerBones[0], i, j, transformMatrix);
-
-          leftFingerPositions[k] = position;
-          leftFingerPositionsValid[k] = true;
-        } else {
-          leftFingerPositionsValid[k] = false;
-        }
-      }
-    }
-
-    keyposeLeft = handData.left_hand_state.keypose;
-    keyposeLeftNew = keyposeLeft != lastKeyposeLeft;
-    lastKeyposeLeft = handData.left_hand_state.keypose;
-  }
-
-  rightHandBoneValid = handPresents[1] && getHandBone(wristBones[1], fingerBones[1]);
-  if (rightHandBoneValid) {
-    rightHandTransformValid = getHandTransform(rightHandCenter, rightHandNormal, wristBones[1], fingerBones[1], false, transformMatrix);
-    rightPointerTransformValid = getHandPointerTransform(rightPointerTransform, wristBones[1], fingerBones[1], rightHandNormal, transformMatrix);
-    rightGripTransformValid = getHandGripTransform(rightGripTransform, wristBones[1], fingerBones[1], rightHandNormal, transformMatrix);
-
-    for (size_t i = 0; i < 4; i++) {
-      if (*(uint32_t *)&wristBones[1][i][0]) {
-        MLVec3f position;
-        getWristBonePosition(position, wristBones[1], i, transformMatrix);
-
-        rightWristPositions[i] = position;
-        rightWristPositionsValid[i] = true;
-      } else {
-        rightWristPositionsValid[i] = false;
-      }
-    }
-
-    for (size_t i = 0; i < 5; i++) {
-      for (size_t j = 0; j < 4; j++) {
-        uint32_t k = i*4 + j;
-
-        if (*(uint32_t *)&fingerBones[1][i][j][0]) {
-          MLVec3f position;
-          getFingerBonePosition(position, fingerBones[1], i, j, transformMatrix);
-
-          rightFingerPositions[k] = position;
-          rightFingerPositionsValid[k] = true;
-        } else {
-          rightFingerPositionsValid[k] = false;
-        }
-      }
-    }
-
-    keyposeRight = handData.right_hand_state.keypose;
-    keyposeRightNew = keyposeRight != lastKeyposeRight;
-    lastKeyposeRight = handData.right_hand_state.keypose;
-  }
-
-  // Local<Object> localWindowObj = Nan::New(this->windowObj);
-
-  QueueCallback(loop, [
-    this,
-    transformMatrix,
-    leftHandBoneValid,
-    leftHandCenter,
-    leftHandNormal,
-    leftHandTransformValid,
-    leftPointerTransform,
-    leftPointerTransformValid,
-    leftGripTransform,
-    leftGripTransformValid,
-    leftWristPositions{std::move(leftWristPositions)},
-    leftWristPositionsValid{std::move(leftWristPositionsValid)},
-    leftFingerPositions{std::move(leftFingerPositions)},
-    leftFingerPositionsValid{std::move(leftFingerPositionsValid)},
-    keyposeLeft,
-    keyposeLeftNew,
-    rightHandBoneValid,
-    rightHandCenter,
-    rightHandNormal,
-    rightHandTransformValid,
-    rightPointerTransform,
-    rightPointerTransformValid,
-    rightGripTransform,
-    rightGripTransformValid,
-    rightWristPositions{std::move(rightWristPositions)},
-    rightWristPositionsValid{std::move(rightWristPositionsValid)},
-    rightFingerPositions{std::move(rightFingerPositions)},
-    rightFingerPositionsValid{std::move(rightFingerPositionsValid)},
-    keyposeRight,
-    keyposeRightNew
-  ]() -> void {
-    Local<Object> asyncObject = Nan::New<Object>();
-    AsyncResource asyncResource(Isolate::GetCurrent(), asyncObject, "MLHandTracker::Update");
-
-    Local<Array> array = Nan::New<Array>();
-    uint32_t numResults = 0;
-    
-    Local<ArrayBuffer> arrayBuffer = ArrayBuffer::New(Isolate::GetCurrent(), (3+3 + 3+4 + 3+4 + 4*3 + 5*4*3 + 3+4)*2*sizeof(float));
-    char *arrayBufferData = (char *)arrayBuffer->GetContents().Data();
-    size_t index = 0;
-
-    if (leftHandBoneValid) {
-      Local<Object> obj = Nan::New<Object>();
-
-      obj->Set(JS_STR("hand"), JS_STR("left"));
-
-      if (leftHandTransformValid) {
-        memcpy(arrayBufferData + index, leftHandCenter.values, sizeof(leftHandCenter.values));
-        obj->Set(JS_STR("center"), Float32Array::New(arrayBuffer, index, sizeof(leftHandCenter.values)/sizeof(leftHandCenter.values[0])));
-        index += sizeof(leftHandCenter.values);
-        
-        memcpy(arrayBufferData + index, leftHandNormal.values, sizeof(leftHandNormal.values));
-        obj->Set(JS_STR("normal"), Float32Array::New(arrayBuffer, index, sizeof(leftHandNormal.values)/sizeof(leftHandNormal.values[0])));
-        index += sizeof(leftHandNormal.values);
+  MLHandTrackingData handData;
+  MLResult result = MLHandTrackingGetData(mlHandTracker->tracker, &handData);
+  if (result == MLResult_Ok) {
+    MLHandTrackingStaticData handStaticData;
+    MLResult result = MLHandTrackingGetStaticData(mlHandTracker->tracker, &handStaticData);
+    if (result == MLResult_Ok) {
+      MLSnapshot *snapshot;
+      if (MLPerceptionGetSnapshot(&snapshot) != MLResult_Ok) {
+        ML_LOG(Error, "%s: ML failed to get hand snapshot!", application_name);
       }
 
-      if (leftPointerTransformValid) {
-        Local<Object> pointerObj = Nan::New<Object>();
+      for (int i = 0; i < 2; i++) {
+        Local<Object> handObj = Local<Object>::Cast(handsArray->Get(i));
 
-        memcpy(arrayBufferData + index, leftPointerTransform.position.values, sizeof(leftPointerTransform.position.values));
-        pointerObj->Set(JS_STR("position"), Float32Array::New(arrayBuffer, index, sizeof(leftPointerTransform.position.values)/sizeof(leftPointerTransform.position.values[0])));
-        index += sizeof(leftPointerTransform.position.values);
-        
-        memcpy(arrayBufferData + index, leftPointerTransform.rotation.values, sizeof(leftPointerTransform.rotation.values));
-        pointerObj->Set(JS_STR("rotation"), Float32Array::New(arrayBuffer, index, sizeof(leftPointerTransform.rotation.values)/sizeof(leftPointerTransform.rotation.values[0])));
-        index += sizeof(leftPointerTransform.rotation.values);
+        Local<Float32Array> connectedArray = Local<Float32Array>::Cast(handObj->Get(JS_STR("connected")));
+        auto &handDataState = i == 0 ? handData.left_hand_state : handData.right_hand_state;
+        connectedArray->Set(0, JS_NUM(handDataState.hand_confidence >= 0.5 ? 1 : 0));
 
-        obj->Set(JS_STR("pointer"), pointerObj);
-      } else {
-        obj->Set(JS_STR("pointer"), Nan::Null());
-      }
-      
-      if (leftGripTransformValid) {
-        Local<Object> gripObj = Nan::New<Object>();
+        Local<Float32Array> positionArray = Local<Float32Array>::Cast(handObj->Get(JS_STR("position")));
+        float *positionArrayData = (float *)((char *)positionArray->Buffer()->GetContents().Data() + positionArray->ByteOffset());
+        positionArrayData[0] = 0;
+        positionArrayData[1] = 0;
+        positionArrayData[2] = 0;
 
-        memcpy(arrayBufferData + index, leftGripTransform.position.values, sizeof(leftGripTransform.position.values));
-        gripObj->Set(JS_STR("position"), Float32Array::New(arrayBuffer, index, sizeof(leftGripTransform.position.values)/sizeof(leftPointerTransform.position.values[0])));
-        index += sizeof(leftGripTransform.position.values);
-        
-        memcpy(arrayBufferData + index, leftGripTransform.rotation.values, sizeof(leftGripTransform.rotation.values));
-        gripObj->Set(JS_STR("rotation"), Float32Array::New(arrayBuffer, index, sizeof(leftGripTransform.rotation.values)/sizeof(leftGripTransform.rotation.values[0])));
-        index += sizeof(leftGripTransform.rotation.values);
+        Local<Float32Array> orientationArray = Local<Float32Array>::Cast(handObj->Get(JS_STR("orientation")));
+        float *orientationArrayData = (float *)((char *)orientationArray->Buffer()->GetContents().Data() + orientationArray->ByteOffset());
+        orientationArrayData[0] = 0;
+        orientationArrayData[1] = 0;
+        orientationArrayData[2] = 0;
+        orientationArrayData[3] = 1;
 
-        obj->Set(JS_STR("grip"), gripObj);
-      } else {
-        obj->Set(JS_STR("grip"), Nan::Null());
-      }
+        auto &handStaticDataSide = i == 0 ? handStaticData.left : handStaticData.right;
 
-      Local<Array> wristArray = Nan::New<Array>(4);
-      for (size_t i = 0; i < 4; i++) {
-        Local<Value> boneVal;
-
-        if (leftWristPositionsValid[i]) {
-          const MLVec3f &position = leftWristPositions[i];
-          
-          memcpy(arrayBufferData + index, position.values, sizeof(position.values));
-          boneVal = Float32Array::New(arrayBuffer, index, sizeof(position.values)/sizeof(position.values[0]));
-          index += sizeof(position.values);
-        } else {
-          boneVal = Nan::Null();
+        // wrist
+        {
+          auto &handStaticDataSideFinger = handStaticDataSide.wrist;
+          Local<Array> wristArray = Local<Array>::Cast(handObj->Get(JS_STR("wrist")));
+          {
+            Local<Float32Array> wristBoneFloat32Array = Local<Float32Array>::Cast(wristArray->Get(0));
+            float *wristBoneArrayData = (float *)((char *)wristBoneFloat32Array->Buffer()->GetContents().Data() + wristBoneFloat32Array->ByteOffset());
+            setFingerValue(handStaticDataSideFinger.radial, snapshot, wristBoneArrayData);
+          }
+          {
+            Local<Float32Array> wristBoneFloat32Array = Local<Float32Array>::Cast(wristArray->Get(1));
+            float *wristBoneArrayData = (float *)((char *)wristBoneFloat32Array->Buffer()->GetContents().Data() + wristBoneFloat32Array->ByteOffset());
+            setFingerValue(handStaticDataSideFinger.ulnar, snapshot, wristBoneArrayData);
+          }
+          {
+            Local<Float32Array> wristBoneFloat32Array = Local<Float32Array>::Cast(wristArray->Get(2));
+            float *wristBoneArrayData = (float *)((char *)wristBoneFloat32Array->Buffer()->GetContents().Data() + wristBoneFloat32Array->ByteOffset());
+            setFingerValue(handStaticDataSideFinger.center, snapshot, wristBoneArrayData);
+          }
+          {
+            Local<Float32Array> wristBoneFloat32Array = Local<Float32Array>::Cast(wristArray->Get(3));
+            float *wristBoneArrayData = (float *)((char *)wristBoneFloat32Array->Buffer()->GetContents().Data() + wristBoneFloat32Array->ByteOffset());
+            setFingerValue(wristBoneArrayData);
+          }
         }
 
-        wristArray->Set(i, boneVal);
-      }
-      obj->Set(JS_STR("wrist"), wristArray);
-
-      Local<Array> fingersArray = Nan::New<Array>(5);
-      for (size_t i = 0; i < 5; i++) {
-        Local<Array> bonesArray = Nan::New<Array>(4);
-
-        for (size_t j = 0; j < 4; j++) {
-          Local<Value> boneVal;
-
-          uint32_t k = j*4 + i;
-          if (leftFingerPositionsValid[k]) {
-            const MLVec3f &position = leftFingerPositions[k];
-
-            memcpy(arrayBufferData + index, position.values, sizeof(position.values));
-            boneVal = Float32Array::New(arrayBuffer, index, sizeof(position.values)/sizeof(position.values[0]));
-            index += sizeof(position.values); 
-          } else {
-            boneVal = Nan::Null();
+        Local<Array> fingersArray = Local<Array>::Cast(handObj->Get(JS_STR("fingers")));
+        {
+          // thumb
+          {
+            auto &handStaticDataSideFinger = handStaticDataSide.thumb;
+            Local<Array> fingerArray = Local<Array>::Cast(fingersArray->Get(0));
+            {
+              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(0));
+              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+              setFingerValue(handStaticDataSideFinger.cmc, snapshot, fingerBoneArrayData);
+            }
+            {
+              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(1));
+              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+              setFingerValue(handStaticDataSideFinger.mcp, snapshot, fingerBoneArrayData);
+            }
+            {
+              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(2));
+              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+              setFingerValue(handStaticDataSideFinger.ip, snapshot, fingerBoneArrayData);
+            }
+            {
+              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(3));
+              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+              setFingerValue(handStaticDataSideFinger.tip, snapshot, fingerBoneArrayData);
+            }
           }
 
-          bonesArray->Set(j, boneVal);
-        }
-
-        fingersArray->Set(i, bonesArray);
-      }
-      obj->Set(JS_STR("fingers"), fingersArray);
-
-      Local<Value> gestureVal = gestureCategoryToJsValue(keyposeLeft);
-      obj->Set(JS_STR("gesture"), gestureVal);
-
-      if (keyposeLeftNew && !this->ongesture.IsEmpty()) {
-        Local<Object> gestureObj = Nan::New<Object>();
-
-        gestureObj->Set(JS_STR("hand"), JS_STR("left"));
-
-        Local<Value> gesturePositionObj;
-        Local<Value> gestureRotationObj;
-        
-        if (leftPointerTransformValid) {
-          memcpy(arrayBufferData + index, leftPointerTransform.position.values, sizeof(leftPointerTransform.position.values));
-          gesturePositionObj = Float32Array::New(arrayBuffer, index, sizeof(leftPointerTransform.position.values)/sizeof(leftPointerTransform.position.values[0]));
-          index += sizeof(leftPointerTransform.position.values);
-          
-          memcpy(arrayBufferData + index, leftPointerTransform.rotation.values, sizeof(leftPointerTransform.rotation.values));
-          gestureRotationObj = Float32Array::New(arrayBuffer, index, sizeof(leftPointerTransform.rotation.values)/sizeof(leftPointerTransform.rotation.values[0]));
-          index += sizeof(leftPointerTransform.rotation.values);
-        } else if (leftGripTransformValid) {
-          memcpy(arrayBufferData + index, leftGripTransform.position.values, sizeof(leftGripTransform.position.values));
-          gesturePositionObj = Float32Array::New(arrayBuffer, index, sizeof(leftGripTransform.position.values)/sizeof(leftGripTransform.position.values[0]));
-          index += sizeof(leftGripTransform.position.values);
-          
-          memcpy(arrayBufferData + index, leftGripTransform.rotation.values, sizeof(leftGripTransform.rotation.values));
-          gestureRotationObj = Float32Array::New(arrayBuffer, index, sizeof(leftGripTransform.rotation.values)/sizeof(leftGripTransform.rotation.values[0]));
-          index += sizeof(leftGripTransform.rotation.values);
-        } else {
-          gesturePositionObj = Nan::Null();
-          gestureRotationObj = Nan::Null();
-        }
-        gestureObj->Set(JS_STR("position"), gesturePositionObj);
-        gestureObj->Set(JS_STR("rotation"), gestureRotationObj);
-
-        gestureObj->Set(JS_STR("gesture"), gestureVal);
-        gestureObj->Set(JS_STR("lastGesture"), gestureCategoryToJsValue(lastKeyposeLeft));
-
-        Local<Function> ongesture = Nan::New(this->ongesture);
-        Local<Value> argv[] = {
-          gestureObj,
-        };
-        asyncResource.MakeCallback(ongesture, sizeof(argv)/sizeof(argv[0]), argv);
-      }
-      lastKeyposeLeft = handData.left_hand_state.keypose;
-
-      array->Set(JS_INT(numResults++), obj);
-    }
-
-    if (rightHandBoneValid) {
-      Local<Object> obj = Nan::New<Object>();
-
-      obj->Set(JS_STR("hand"), JS_STR("right"));
-
-      if (rightHandTransformValid) {
-        memcpy(arrayBufferData + index, rightHandCenter.values, sizeof(rightHandCenter.values));
-        obj->Set(JS_STR("center"), Float32Array::New(arrayBuffer, index, sizeof(rightHandCenter.values)/sizeof(rightHandCenter.values[0])));
-        index += sizeof(rightHandCenter.values);
-        
-        memcpy(arrayBufferData + index, rightHandNormal.values, sizeof(rightHandNormal.values));
-        obj->Set(JS_STR("normal"), Float32Array::New(arrayBuffer, index, sizeof(rightHandNormal.values)/sizeof(rightHandNormal.values[0])));
-        index += sizeof(rightHandNormal.values);
-      }
-
-      if (rightPointerTransformValid) {
-        Local<Object> pointerObj = Nan::New<Object>();
-        pointerObj->Set(JS_STR("position"), Float32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), (void *)rightPointerTransform.position.values, 3 * sizeof(float)), 0, 3));
-        pointerObj->Set(JS_STR("rotation"), Float32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), (void *)rightPointerTransform.rotation.values, 4 * sizeof(float)), 0, 4));
-        obj->Set(JS_STR("pointer"), pointerObj);
-      } else {
-        obj->Set(JS_STR("pointer"), Nan::Null());
-      }
-
-      if (rightGripTransformValid) {
-        Local<Object> gripObj = Nan::New<Object>();
-
-        memcpy(arrayBufferData + index, rightGripTransform.position.values, sizeof(rightGripTransform.position.values));
-        gripObj->Set(JS_STR("position"), Float32Array::New(arrayBuffer, index, sizeof(rightGripTransform.position.values)/sizeof(rightGripTransform.position.values[0])));
-        index += sizeof(rightGripTransform.position.values);
-        
-        memcpy(arrayBufferData + index, rightGripTransform.rotation.values, sizeof(rightGripTransform.rotation.values));
-        gripObj->Set(JS_STR("rotation"), Float32Array::New(arrayBuffer, index, sizeof(rightGripTransform.rotation.values)/sizeof(rightGripTransform.rotation.values[0])));
-        index += sizeof(rightGripTransform.rotation.values);
-
-        obj->Set(JS_STR("grip"), gripObj);
-      } else {
-        obj->Set(JS_STR("grip"), Nan::Null());
-      }
-
-      Local<Array> wristArray = Nan::New<Array>(4);
-      for (size_t i = 0; i < 4; i++) {
-        Local<Value> boneVal;
-
-        if (rightWristPositionsValid[i]) {
-          const MLVec3f &position = rightWristPositions[i];
-          
-          memcpy(arrayBufferData + index, position.values, sizeof(position.values));
-          boneVal = Float32Array::New(arrayBuffer, index, sizeof(position.values)/sizeof(position.values[0]));
-          index += sizeof(position.values);
-        } else {
-          boneVal = Nan::Null();
-        }
-
-        wristArray->Set(i, boneVal);
-      }
-      obj->Set(JS_STR("wrist"), wristArray);
-
-      Local<Array> fingersArray = Nan::New<Array>(5);
-      for (size_t i = 0; i < 5; i++) {
-        Local<Array> bonesArray = Nan::New<Array>(4);
-
-        for (size_t j = 0; j < 4; j++) {
-          Local<Value> boneVal;
-
-          uint32_t k = j*4 + i;
-          if (rightFingerPositionsValid[k]) {
-            const MLVec3f &position = rightFingerPositions[k];
-
-            memcpy(arrayBufferData + index, position.values, sizeof(position.values));
-            boneVal = Float32Array::New(arrayBuffer, index, sizeof(position.values)/sizeof(position.values[0]));
-            index += sizeof(position.values);
-          } else {
-            boneVal = Nan::Null();
+          // index
+          {
+            auto &handStaticDataSideFinger = handStaticDataSide.index;
+            Local<Array> fingerArray = Local<Array>::Cast(fingersArray->Get(1));
+            {
+              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(0));
+              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+              setFingerValue(handStaticDataSideFinger.mcp, snapshot, fingerBoneArrayData);
+            }
+            {
+              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(1));
+              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+              setFingerValue(handStaticDataSideFinger.pip, snapshot, fingerBoneArrayData);
+            }
+            {
+              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(2));
+              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+              setFingerValue(handStaticDataSideFinger.dip, snapshot, fingerBoneArrayData);
+            }
+            {
+              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(3));
+              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+              setFingerValue(handStaticDataSideFinger.tip, snapshot, fingerBoneArrayData);
+            }
           }
 
-          bonesArray->Set(j, boneVal);
+          // middle
+          {
+            auto &handStaticDataSideFinger = handStaticDataSide.middle;
+            Local<Array> fingerArray = Local<Array>::Cast(fingersArray->Get(2));
+            {
+              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(0));
+              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+              setFingerValue(handStaticDataSideFinger.mcp, snapshot, fingerBoneArrayData);
+            }
+            {
+              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(1));
+              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+              setFingerValue(handStaticDataSideFinger.pip, snapshot, fingerBoneArrayData);
+            }
+            {
+              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(2));
+              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+              setFingerValue(handStaticDataSideFinger.dip, snapshot, fingerBoneArrayData);
+            }
+            {
+              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(3));
+              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+              setFingerValue(handStaticDataSideFinger.tip, snapshot, fingerBoneArrayData);
+            }
+          }
+
+          // ring
+          {
+            auto &handStaticDataSideFinger = handStaticDataSide.pinky;
+            Local<Array> fingerArray = Local<Array>::Cast(fingersArray->Get(3));
+            {
+              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(0));
+              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+              setFingerValue(handStaticDataSideFinger.mcp, snapshot, fingerBoneArrayData);
+            }
+            {
+              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(1));
+              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+              setFingerValue(handStaticDataSideFinger.pip, snapshot, fingerBoneArrayData);
+            }
+            {
+              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(2));
+              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+              setFingerValue(handStaticDataSideFinger.dip, snapshot, fingerBoneArrayData);
+            }
+            {
+              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(3));
+              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+              setFingerValue(handStaticDataSideFinger.tip, snapshot, fingerBoneArrayData);
+            }
+          }
+
+          // pinky
+          {
+            auto &handStaticDataSideFinger = handStaticDataSide.pinky;
+            Local<Array> fingerArray = Local<Array>::Cast(fingersArray->Get(4));
+            {
+              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(0));
+              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+              setFingerValue(handStaticDataSideFinger.mcp, snapshot, fingerBoneArrayData);
+            }
+            {
+              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(1));
+              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+              setFingerValue(handStaticDataSideFinger.pip, snapshot, fingerBoneArrayData);
+            }
+            {
+              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(2));
+              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+              setFingerValue(handStaticDataSideFinger.dip, snapshot, fingerBoneArrayData);
+            }
+            {
+              Local<Float32Array> fingerBoneFloat32Array = Local<Float32Array>::Cast(fingerArray->Get(3));
+              float *fingerBoneArrayData = (float *)((char *)fingerBoneFloat32Array->Buffer()->GetContents().Data() + fingerBoneFloat32Array->ByteOffset());
+              setFingerValue(handStaticDataSideFinger.tip, snapshot, fingerBoneArrayData);
+            }
+          }
         }
 
-        fingersArray->Set(i, bonesArray);
+        // MLHandTrackingKeyPose &keypose = handDataState.keypose;
       }
-      obj->Set(JS_STR("fingers"), fingersArray);
 
-      Local<Value> gestureVal = gestureCategoryToJsValue(keyposeRight);
-      obj->Set(JS_STR("gesture"), gestureVal);
-
-      if (keyposeRightNew && !this->ongesture.IsEmpty()) {
-        Local<Object> gestureObj = Nan::New<Object>();
-
-        gestureObj->Set(JS_STR("hand"), JS_STR("right"));
-
-        Local<Value> gesturePositionObj;
-        Local<Value> gestureRotationObj;
-        if (rightPointerTransformValid) {
-          memcpy(arrayBufferData + index, rightPointerTransform.position.values, sizeof(rightPointerTransform.position.values));
-          gesturePositionObj = Float32Array::New(arrayBuffer, index, sizeof(rightPointerTransform.position.values)/sizeof(rightPointerTransform.position.values[0]));
-          index += sizeof(rightPointerTransform.position.values);
-          
-          memcpy(arrayBufferData + index, rightPointerTransform.rotation.values, sizeof(rightPointerTransform.rotation.values));
-          gestureRotationObj = Float32Array::New(arrayBuffer, index, sizeof(rightPointerTransform.rotation.values)/sizeof(rightPointerTransform.rotation.values[0]));
-          index += sizeof(rightPointerTransform.rotation.values);
-        } else if (rightGripTransformValid) {
-          memcpy(arrayBufferData + index, rightGripTransform.position.values, sizeof(rightGripTransform.position.values));
-          gesturePositionObj = Float32Array::New(arrayBuffer, index, sizeof(rightGripTransform.position.values)/sizeof(rightGripTransform.position.values[0]));
-          index += sizeof(rightGripTransform.position.values);
-          
-          memcpy(arrayBufferData + index, rightGripTransform.rotation.values, sizeof(rightGripTransform.rotation.values));
-          gestureRotationObj = Float32Array::New(arrayBuffer, index, sizeof(rightGripTransform.rotation.values)/sizeof(rightGripTransform.rotation.values[0]));
-          index += sizeof(rightGripTransform.rotation.values);
-        } else {
-          gesturePositionObj = Nan::Null();
-          gestureRotationObj = Nan::Null();
-        }
-        gestureObj->Set(JS_STR("position"), gesturePositionObj);
-        gestureObj->Set(JS_STR("rotation"), gestureRotationObj);
-
-        gestureObj->Set(JS_STR("gesture"), gestureVal);
-        gestureObj->Set(JS_STR("lastGesture"), gestureCategoryToJsValue(lastKeyposeRight));
-
-        Local<Function> ongesture = Nan::New(this->ongesture);
-        Local<Value> argv[] = {
-          gestureObj,
-        };
-        asyncResource.MakeCallback(ongesture, sizeof(argv)/sizeof(argv[0]), argv);
+      if (MLPerceptionReleaseSnapshot(snapshot) != MLResult_Ok) {
+        ML_LOG(Error, "%s: ML failed to release hand snapshot!", application_name);
       }
-      lastKeyposeRight = handData.right_hand_state.keypose;
-
-      array->Set(JS_INT(numResults++), obj);
+    } else {
+      ML_LOG(Error, "%s: Hand static data get failed! %x", application_name, result);
     }
-
-    if (!this->cb.IsEmpty()) {
-      Local<Function> cb = Nan::New(this->cb);
-      Local<Value> argv[] = {
-        array,
-      };
-      asyncResource.MakeCallback(cb, sizeof(argv)/sizeof(argv[0]), argv);
-    }
-  });
+  } else {
+    ML_LOG(Error, "%s: Hand data get failed! %x", application_name, result);
+  }
 }
 
 NAN_METHOD(MLHandTracker::Destroy) {
   MLHandTracker *mlHandTracker = ObjectWrap::Unwrap<MLHandTracker>(info.This());
 
-  handTrackers.erase(std::remove_if(handTrackers.begin(), handTrackers.end(), [&](MLHandTracker *h) -> bool {
-    if (h == mlHandTracker) {
-      delete h;
-      return true;
-    } else {
-      return false;
-    }
-  }), handTrackers.end());
+  if (MLHandTrackingDestroy(mlHandTracker->tracker) != MLResult_Ok) {
+    ML_LOG(Error, "%s: Failed to destroy hand tracker.", application_name);
+  }
 }
 
 // MLEyeTracker
 
-MLEyeTracker::MLEyeTracker(Local<Object> windowObj) : windowObj(windowObj) {}
+MLEyeTracker::MLEyeTracker() {
+  if (MLEyeTrackingCreate(&tracker) != MLResult_Ok) {
+    ML_LOG(Error, "%s: failed to create eye handle", application_name);
+  }
+}
 
 MLEyeTracker::~MLEyeTracker() {}
 
 NAN_METHOD(MLEyeTracker::New) {
-  MLEyeTracker *mlEyeTracker = new MLEyeTracker(Local<Object>::Cast(info[0]));
+  MLEyeTracker *mlEyeTracker = new MLEyeTracker();
   Local<Object> mlEyeTrackerObj = info.This();
   mlEyeTracker->Wrap(mlEyeTrackerObj);
 
-  Nan::SetAccessor(mlEyeTrackerObj, JS_STR("fixation"), FixationGetter);
-  Nan::SetAccessor(mlEyeTrackerObj, JS_STR("eyes"), EyesGetter);
-
   info.GetReturnValue().Set(mlEyeTrackerObj);
-
-  eyeTrackers.push_back(mlEyeTracker);
 }
 
 Local<Function> MLEyeTracker::Initialize(Isolate *isolate) {
@@ -1506,6 +1409,7 @@ Local<Function> MLEyeTracker::Initialize(Isolate *isolate) {
 
   // prototype
   Local<ObjectTemplate> proto = ctor->PrototypeTemplate();
+  Nan::SetMethod(proto, "waitGetPoses", WaitGetPoses);
   Nan::SetMethod(proto, "destroy", Destroy);
 
   Local<Function> ctorFn = Nan::GetFunction(ctor).ToLocalChecked();
@@ -1513,60 +1417,67 @@ Local<Function> MLEyeTracker::Initialize(Isolate *isolate) {
   return scope.Escape(ctorFn);
 }
 
-NAN_GETTER(MLEyeTracker::FixationGetter) {
+NAN_METHOD(MLEyeTracker::WaitGetPoses) {
   // Nan::HandleScope scope;
+
   MLEyeTracker *mlEyeTracker = ObjectWrap::Unwrap<MLEyeTracker>(info.This());
+  Local<Object> eyeObj = Local<Object>::Cast(info[0]);
+  /* Local<Float32Array> float32Array = Local<Float32Array>::Cast(info[0]);
+  Local<ArrayBuffer> arrayBuffer = float32Array->Buffer();
+  float *floatData = (float *)((char *)arrayBuffer->GetContents().Data() + float32Array->ByteOffset()); */
+  // uint32_t *uint32Data = (uint32_t *)floatData;
 
-  Local<Object> obj = Nan::New<Object>();
-
-  Local<Float32Array> positionArray = Float32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), 3 * sizeof(float)), 0, 3);
-  positionArray->Set(0, JS_NUM(mlEyeTracker->transform.position.x));
-  positionArray->Set(1, JS_NUM(mlEyeTracker->transform.position.y));
-  positionArray->Set(2, JS_NUM(mlEyeTracker->transform.position.z));
-  obj->Set(JS_STR("position"), positionArray);
-
-  Local<Float32Array> rotationArray = Float32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), 4 * sizeof(float)), 0, 4);
-  rotationArray->Set(0, JS_NUM(mlEyeTracker->transform.rotation.x));
-  rotationArray->Set(1, JS_NUM(mlEyeTracker->transform.rotation.y));
-  rotationArray->Set(2, JS_NUM(mlEyeTracker->transform.rotation.z));
-  rotationArray->Set(3, JS_NUM(mlEyeTracker->transform.rotation.w));
-  obj->Set(JS_STR("rotation"), rotationArray);
-
-  info.GetReturnValue().Set(obj);
-}
-
-NAN_GETTER(MLEyeTracker::EyesGetter) {
-  // Nan::HandleScope scope;
-  MLEyeTracker *mlEyeTracker = ObjectWrap::Unwrap<MLEyeTracker>(info.This());
-
-  Local<Array> array = Nan::New<Array>(2);
-  for (size_t i = 0; i < 2; i++) {
-    Local<Object> obj = Nan::New<Object>();
-
-    const MLTransform &eyeTransform = i == 0 ? mlEyeTracker->leftTransform : mlEyeTracker->rightTransform;
-    Local<Float32Array> positionArray = Float32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), 3 * sizeof(float)), 0, 3);
-    positionArray->Set(0, JS_NUM(eyeTransform.position.x));
-    positionArray->Set(1, JS_NUM(eyeTransform.position.y));
-    positionArray->Set(2, JS_NUM(eyeTransform.position.z));
-    obj->Set(JS_STR("position"), positionArray);
-
-    Local<Float32Array> rotationArray = Float32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), 4 * sizeof(float)), 0, 4);
-    rotationArray->Set(0, JS_NUM(eyeTransform.rotation.x));
-    rotationArray->Set(1, JS_NUM(eyeTransform.rotation.y));
-    rotationArray->Set(2, JS_NUM(eyeTransform.rotation.z));
-    rotationArray->Set(3, JS_NUM(eyeTransform.rotation.w));
-    obj->Set(JS_STR("rotation"), rotationArray);
-
-    const bool &eyeBlink = i == 0 ? mlEyeTracker->leftBlink : mlEyeTracker->rightBlink;
-    obj->Set(JS_STR("blink"), JS_BOOL(eyeBlink));
-
-    array->Set(i, obj);
+  MLSnapshot *snapshot;
+  if (MLPerceptionGetSnapshot(&snapshot) != MLResult_Ok) {
+    ML_LOG(Error, "%s: ML failed to get eye snapshot!", application_name);
   }
 
-  info.GetReturnValue().Set(array);
+  MLEyeTrackingStaticData eyeStaticData;
+  if (MLEyeTrackingGetStaticData(mlEyeTracker->tracker, &eyeStaticData) != MLResult_Ok) {
+    ML_LOG(Error, "%s: Eye get static data failed!", application_name);
+  }
+
+  MLEyeTrackingState eyeState;
+  if (MLEyeTrackingGetState(mlEyeTracker->tracker, &eyeState) != MLResult_Ok) {
+    ML_LOG(Error, "%s: Eye get state failed!", application_name);
+  }
+
+  MLTransform transform;
+  if (MLSnapshotGetTransform(snapshot, &eyeStaticData.fixation, &transform) == MLResult_Ok) {
+    // nothing
+  } else {
+    ML_LOG(Error, "%s: ML failed to get eye fixation transform!", application_name);
+  }
+
+  Local<Float32Array> positionArray = Local<Float32Array>::Cast(eyeObj->Get(JS_STR("position")));
+  float *positionArrayData = (float *)((char *)positionArray->Buffer()->GetContents().Data() + positionArray->ByteOffset());
+  memcpy(positionArrayData, transform.position.values, sizeof(transform.position.values));
+  /* int index = 0;
+  memcpy(floatData + index, transform.position.values, sizeof(mlEyeTracker->transform.position.values));
+  index += sizeof(mlEyeTracker->transform.position.values)/sizeof(mlEyeTracker->transform.position.values[0]); */
+
+  Local<Float32Array> orientationArray = Local<Float32Array>::Cast(eyeObj->Get(JS_STR("orientation")));
+  float *orientationArrayData = (float *)((char *)orientationArray->Buffer()->GetContents().Data() + orientationArray->ByteOffset());
+  memcpy(orientationArrayData, transform.rotation.values, sizeof(transform.rotation.values));
+
+  /* memcpy(floatData + index, mlEyeTracker->transform.rotation.values, sizeof(mlEyeTracker->transform.rotation.values));
+  index += sizeof(mlEyeTracker->transform.rotation.values)/sizeof(mlEyeTracker->transform.rotation.values[0]); */
+
+  Local<Float32Array> axesArray = Local<Float32Array>::Cast(eyeObj->Get(JS_STR("axes")));
+  float *axesArrayData = (float *)((char *)axesArray->Buffer()->GetContents().Data() + axesArray->ByteOffset());
+  axesArrayData[0] = eyeState.left_blink ? -1 : 1;
+  axesArrayData[1] = eyeState.right_blink ? -1 : 1;
+  /* floatData[index] = eyeState.left_blink ? -1 : 1;
+  index++;
+  floatData[index] = eyeState.right_blink ? -1 : 1;
+  index++; */
+
+  if (MLPerceptionReleaseSnapshot(snapshot) != MLResult_Ok) {
+    ML_LOG(Error, "%s: ML failed to release eye snapshot!", application_name);
+  }
 }
 
-void MLEyeTracker::Update(MLSnapshot *snapshot) {
+/* void MLEyeTracker::Update(MLSnapshot *snapshot) {
   if (MLSnapshotGetTransform(snapshot, &eyeStaticData.fixation, &this->transform) == MLResult_Ok) {
     // nothing
   } else {
@@ -1612,19 +1523,14 @@ void MLEyeTracker::Update(MLSnapshot *snapshot) {
       decomposeMatrix(transform, position, rotation, scale);
     }
   }
-}
+} */
 
 NAN_METHOD(MLEyeTracker::Destroy) {
   MLEyeTracker *mlEyeTracker = ObjectWrap::Unwrap<MLEyeTracker>(info.This());
 
-  eyeTrackers.erase(std::remove_if(eyeTrackers.begin(), eyeTrackers.end(), [&](MLEyeTracker *e) -> bool {
-    if (e == mlEyeTracker) {
-      delete e;
-      return true;
-    } else {
-      return false;
-    }
-  }));
+  if (MLEyeTrackingDestroy(mlEyeTracker->tracker) != MLResult_Ok) {
+    ML_LOG(Error, "%s: failed to create eye handle", application_name);
+  }
 }
 
 // keyboard callbacks
@@ -2336,7 +2242,7 @@ Handle<Object> MLContext::Initialize(Isolate *isolate) {
   Nan::SetMethod(ctorFn, "RequestHandTracking", RequestHandTracking);
   Nan::SetMethod(ctorFn, "RequestEyeTracking", RequestEyeTracking);
   Nan::SetMethod(ctorFn, "RequestImageTracking", RequestImageTracking);
-  Nan::SetMethod(ctorFn, "RequestDepthPopulation", RequestDepthPopulation);
+  // Nan::SetMethod(ctorFn, "RequestDepthPopulation", RequestDepthPopulation);
   // Nan::SetMethod(ctorFn, "RequestCamera", RequestCamera);
   // Nan::SetMethod(ctorFn, "CancelCamera", CancelCamera);
   Nan::SetMethod(ctorFn, "Update", Update);
@@ -2962,7 +2868,7 @@ NAN_METHOD(MLContext::Present) {
     return;
   } */
 
-  if (MLHandTrackingCreate(&handTracker) != MLResult_Ok) {
+  /* if (MLHandTrackingCreate(&handTracker) != MLResult_Ok) {
     ML_LOG(Error, "%s: Failed to create hand tracker.", application_name);
     info.GetReturnValue().Set(Nan::Null());
     return;
@@ -2982,16 +2888,16 @@ NAN_METHOD(MLContext::Present) {
     ML_LOG(Error, "%s: Failed to set hand tracker config.", application_name);
     info.GetReturnValue().Set(Nan::Null());
     return;
-  }
+  } */
   
-  {
+  /* {
     MLResult result = MLRaycastCreate(&raycastTracker);
     if (result != MLResult_Ok) {
       ML_LOG(Error, "%s: failed to create raycast handle %x", application_name, result);
       Nan::ThrowError("MLContext::Present failed to create raycast handle");
       return;
     }
-  }
+  } */
 
   if (MLPlanesCreate(&floorTracker) != MLResult_Ok) {
     ML_LOG(Error, "%s: failed to create floor handle", application_name);
@@ -2999,36 +2905,21 @@ NAN_METHOD(MLContext::Present) {
     return;
   }
 
-  MLMeshingSettings meshingSettings;
-  if (MLMeshingInitSettings(&meshingSettings) != MLResult_Ok) {
-    ML_LOG(Error, "%s: failed to initialize meshing settings", application_name);
-  }
-  meshingSettings.flags |= MLMeshingFlags_ComputeNormals;
-  // meshingSettings.flags |= MLMeshingFlags_Planarize;
-  {
-    MLResult result = MLMeshingCreateClient(&meshTracker, &meshingSettings);
-    if (result != MLResult_Ok) {
-      ML_LOG(Error, "%s: failed to create mesh handle %x", application_name, result);
-      Nan::ThrowError("MLContext::Present failed to create mesh handle");
-      return;
-    }
-  }
-
-  if (MLPlanesCreate(&planesTracker) != MLResult_Ok) {
+  /* if (MLPlanesCreate(&planesTracker) != MLResult_Ok) {
     ML_LOG(Error, "%s: failed to create planes handle", application_name);
     info.GetReturnValue().Set(Nan::Null());
     return;
-  }
+  } */
 
-  if (MLEyeTrackingCreate(&eyeTracker) != MLResult_Ok) {
+  /* if (MLEyeTrackingCreate(&eyeTracker) != MLResult_Ok) {
     ML_LOG(Error, "%s: failed to create eye handle", application_name);
     info.GetReturnValue().Set(Nan::Null());
     return;
-  }
+  } */
 
   mlContext->TickFloor();
 
-  uv_loop_t *loop = windowsystembase::GetEventLoop();
+  // uv_loop_t *loop = windowsystembase::GetEventLoop();
 
   // HACK: force the app to be "running"
   application_context.dummy_value = DummyValue::RUNNING;
@@ -3074,16 +2965,16 @@ NAN_METHOD(MLContext::Exit) {
     return;
   }
 
-  if (MLHandTrackingDestroy(handTracker) != MLResult_Ok) {
+  /* if (MLHandTrackingDestroy(handTracker) != MLResult_Ok) {
     ML_LOG(Error, "%s: Failed to destroy hand tracker.", application_name);
     info.GetReturnValue().Set(Nan::Null());
     return;
-  }
+  } */
   
-  if (MLRaycastDestroy(raycastTracker) != MLResult_Ok) {
+  /* if (MLRaycastDestroy(raycastTracker) != MLResult_Ok) {
     ML_LOG(Error, "%s: failed to destroy raycast handle", application_name);
     return;
-  }
+  } */
 
   if (MLPlanesDestroy(floorTracker) != MLResult_Ok) {
     ML_LOG(Error, "%s: failed to destroy floor handle", application_name);
@@ -3091,7 +2982,7 @@ NAN_METHOD(MLContext::Exit) {
     return;
   }
 
-  if (MLMeshingDestroyClient(&meshTracker) != MLResult_Ok) {
+  /* if (MLMeshingDestroyClient(&meshTracker) != MLResult_Ok) {
     ML_LOG(Error, "%s: failed to destroy mesh handle", application_name);
     return;
   }
@@ -3106,7 +2997,7 @@ NAN_METHOD(MLContext::Exit) {
     ML_LOG(Error, "%s: failed to create eye handle", application_name);
     info.GetReturnValue().Set(Nan::Null());
     return;
-  }
+  } */
 
   if (MLPerceptionShutdown() != MLResult_Ok) {
     ML_LOG(Error, "%s: Failed to stop perception.", application_name);
@@ -3587,7 +3478,7 @@ NAN_METHOD(MLContext::GetSize) {
 } */
 
 NAN_METHOD(MLContext::RequestMeshing) {
-  if (info[0]->IsObject() && info[1]->IsNumber()) {
+  if (info[0]->IsNumber() && info[1]->IsNumber()) {
     MLContext *mlContext = ObjectWrap::Unwrap<MLContext>(Local<Object>::Cast(info.This()));
     if (mlContext->mlMesherConstructor.IsEmpty()) {
       mlContext->mlMesherConstructor.Reset(MLMesher::Initialize(Isolate::GetCurrent()));
@@ -3605,37 +3496,21 @@ NAN_METHOD(MLContext::RequestMeshing) {
 }
 
 NAN_METHOD(MLContext::RequestPlaneTracking) {
-  if (info[0]->IsObject()) {
-    MLContext *mlContext = ObjectWrap::Unwrap<MLContext>(Local<Object>::Cast(info.This()));
-    if (mlContext->mlPlaneTrackerConstructor.IsEmpty()) {
-      mlContext->mlPlaneTrackerConstructor.Reset(MLPlaneTracker::Initialize(Isolate::GetCurrent()));
-    }
-    Local<Function> mlPlaneTrackerCons = Nan::New(mlContext->mlPlaneTrackerConstructor);
-    Local<Value> argv[] = {
-      info[0],
-    };
-    Local<Object> mlPlaneTrackerObj = mlPlaneTrackerCons->NewInstance(Isolate::GetCurrent()->GetCurrentContext(), sizeof(argv)/sizeof(argv[0]), argv).ToLocalChecked();
-    info.GetReturnValue().Set(mlPlaneTrackerObj);
-  } else {
-    Nan::ThrowError("MLContext::RequestPlaneTracking: invalid arguments");
+  MLContext *mlContext = ObjectWrap::Unwrap<MLContext>(Local<Object>::Cast(info.This()));
+  if (mlContext->mlPlaneTrackerConstructor.IsEmpty()) {
+    mlContext->mlPlaneTrackerConstructor.Reset(MLPlaneTracker::Initialize(Isolate::GetCurrent()));
   }
+  Local<Function> mlPlaneTrackerCons = Nan::New(mlContext->mlPlaneTrackerConstructor);
+  Local<Object> mlPlaneTrackerObj = mlPlaneTrackerCons->NewInstance(Isolate::GetCurrent()->GetCurrentContext(), 0, nullptr).ToLocalChecked();
+  info.GetReturnValue().Set(mlPlaneTrackerObj);
 }
 
 NAN_METHOD(MLContext::RequestHitTest) {
   if (
     info[0]->IsFloat32Array() &&
-    info[1]->IsFloat32Array() &&
-    info[2]->IsFunction() &&
-    info[3]->IsObject()
+    info[1]->IsFloat32Array()
   ) {
-    Local<Float32Array> originFloat32Array = Local<Float32Array>::Cast(info[0]);
-    Local<Float32Array> directionFloat32Array = Local<Float32Array>::Cast(info[1]);
-    Local<Function> cb = Local<Function>::Cast(info[2]);
-    Local<Object> windowObj = Local<Object>::Cast(info[3]);
-
-    memcpy(raycastQuery.position.values, (char *)originFloat32Array->Buffer()->GetContents().Data() + originFloat32Array->ByteOffset(), sizeof(raycastQuery.position.values));
-    memcpy(raycastQuery.direction.values, (char *)directionFloat32Array->Buffer()->GetContents().Data() + directionFloat32Array->ByteOffset(), sizeof(raycastQuery.direction.values));
-    raycastQuery.up_vector = MLVec3f{0, 1, 0};
+    /* raycastQuery.up_vector = MLVec3f{0, 1, 0};
     raycastQuery.horizontal_fov_degrees = 30;
     raycastQuery.width = 1;
     raycastQuery.height = 1;
@@ -3650,55 +3525,59 @@ NAN_METHOD(MLContext::RequestHitTest) {
       MLMat4f transform = multiplyMatrices(transformMatrix, composeMatrix(position, rotation, scale));
       decomposeMatrix(transform, position, rotation, scale);
       direction = applyVectorQuaternion(MLVec3f{0, 0, -1}, rotation);
+    } */
+
+    MLContext *mlContext = ObjectWrap::Unwrap<MLContext>(Local<Object>::Cast(info.This()));
+    if (mlContext->mlRaycastTrackerConstructor.IsEmpty()) {
+      mlContext->mlRaycastTrackerConstructor.Reset(MLRaycaster::Initialize(Isolate::GetCurrent()));
     }
-    
-    MLHandle requestHandle;
+    Local<Function> mlRaycastTrackerCons = Nan::New(mlContext->mlRaycastTrackerConstructor);
+
+    Local<Value> argv[] = {
+      info[0],
+      info[1],
+    };
+    Local<Object> mlRaycastTrackerObj = mlRaycastTrackerCons->NewInstance(Isolate::GetCurrent()->GetCurrentContext(), sizeof(argv)/sizeof(argv[0]), argv).ToLocalChecked();
+    info.GetReturnValue().Set(mlRaycastTrackerObj);
+
+    /*MLHandle requestHandle;
     MLResult result = MLRaycastRequest(raycastTracker, &raycastQuery, &requestHandle);
     if (result == MLResult_Ok) {
-      uv_loop_t *loop = windowsystembase::GetEventLoop();
-      MLRaycaster *raycaster = new MLRaycaster(windowObj, requestHandle, loop, cb);
+      MLRaycaster *raycaster = new MLRaycaster(requestHandle, cb);
       raycasters.push_back(raycaster);
     } else {
       ML_LOG(Error, "%s: Failed to request raycast: %x %x", application_name, result);
       Nan::ThrowError("failed to request raycast");
-    }
+    } */
   } else {
     Nan::ThrowError("MLContext::RequestHitTest: invalid arguments");
   }
 }
 
 NAN_METHOD(MLContext::RequestHandTracking) {
-  if (info[0]->IsObject()) {
-    MLContext *mlContext = ObjectWrap::Unwrap<MLContext>(Local<Object>::Cast(info.This()));
-    if (mlContext->mlHandTrackerConstructor.IsEmpty()) {
-      mlContext->mlHandTrackerConstructor.Reset(MLHandTracker::Initialize(Isolate::GetCurrent()));
-    }
-    Local<Function> mlHandTrackerCons = Nan::New(mlContext->mlHandTrackerConstructor);
-    Local<Value> argv[] = {
-      info[0],
-    };
-    Local<Object> mlHandTrackerObj = mlHandTrackerCons->NewInstance(Isolate::GetCurrent()->GetCurrentContext(), sizeof(argv)/sizeof(argv[0]), argv).ToLocalChecked();
-    info.GetReturnValue().Set(mlHandTrackerObj);
-  } else {
-    Nan::ThrowError("MLContext::RequestHandTracking: invalid arguments");
+  MLContext *mlContext = ObjectWrap::Unwrap<MLContext>(Local<Object>::Cast(info.This()));
+  if (mlContext->mlHandTrackerConstructor.IsEmpty()) {
+    mlContext->mlHandTrackerConstructor.Reset(MLHandTracker::Initialize(Isolate::GetCurrent()));
   }
+  Local<Function> mlHandTrackerCons = Nan::New(mlContext->mlHandTrackerConstructor);
+  /* Local<Value> argv[] = {
+    info[0],
+  }; */
+  Local<Object> mlHandTrackerObj = mlHandTrackerCons->NewInstance(Isolate::GetCurrent()->GetCurrentContext(), 0, nullptr).ToLocalChecked();
+  info.GetReturnValue().Set(mlHandTrackerObj);
 }
 
 NAN_METHOD(MLContext::RequestEyeTracking) {
-  if (info[0]->IsObject()) {
-    MLContext *mlContext = ObjectWrap::Unwrap<MLContext>(Local<Object>::Cast(info.This()));
-    if (mlContext->mlEyeTrackerConstructor.IsEmpty()) {
-      mlContext->mlEyeTrackerConstructor.Reset(MLEyeTracker::Initialize(Isolate::GetCurrent()));
-    }
-    Local<Function> mlEyeTrackerCons = Nan::New(mlContext->mlEyeTrackerConstructor);
-    Local<Value> argv[] = {
-      info[0],
-    };
-    Local<Object> mlEyeTrackerObj = mlEyeTrackerCons->NewInstance(Isolate::GetCurrent()->GetCurrentContext(), sizeof(argv)/sizeof(argv[0]), argv).ToLocalChecked();
-    info.GetReturnValue().Set(mlEyeTrackerObj);
-  } else {
-    Nan::ThrowError("MLContext::RequestPlaneTracking: invalid arguments");
+  MLContext *mlContext = ObjectWrap::Unwrap<MLContext>(Local<Object>::Cast(info.This()));
+  if (mlContext->mlEyeTrackerConstructor.IsEmpty()) {
+    mlContext->mlEyeTrackerConstructor.Reset(MLEyeTracker::Initialize(Isolate::GetCurrent()));
   }
+  Local<Function> mlEyeTrackerCons = Nan::New(mlContext->mlEyeTrackerConstructor);
+  /* Local<Value> argv[] = {
+    info[0],
+  }; */
+  Local<Object> mlEyeTrackerObj = mlEyeTrackerCons->NewInstance(Isolate::GetCurrent()->GetCurrentContext(), 0, nullptr).ToLocalChecked();
+  info.GetReturnValue().Set(mlEyeTrackerObj);
 }
 
 NAN_METHOD(MLContext::RequestImageTracking) {
@@ -3729,13 +3608,13 @@ NAN_METHOD(MLContext::RequestImageTracking) {
   }
 }
 
-NAN_METHOD(MLContext::RequestDepthPopulation) {
+/* NAN_METHOD(MLContext::RequestDepthPopulation) {
   if (info[0]->IsBoolean()) {
     depthEnabled = TO_BOOL(info[0]);
   } else {
     Nan::ThrowError("MLContext::RequestDepthPopulation: invalid arguments");
   }
-}
+} */
 
 /* bool cameraConnected = false;
 NAN_METHOD(MLContext::RequestCamera) {
@@ -3798,72 +3677,6 @@ NAN_METHOD(MLContext::CancelCamera) {
   }
 } */
 
-void setFingerValue(const MLWristState &wristState, MLSnapshot *snapshot, float data[4][1 + 3]);
-void setFingerValue(const MLThumbState &thumbState, MLSnapshot *snapshot, float data[4][1 + 3]);
-void setFingerValue(const MLFingerState &fingerState, MLSnapshot *snapshot, float data[4][1 + 3]);
-void setFingerValue(const MLKeyPointState &keyPointState, MLSnapshot *snapshot, float data[1 + 3]);
-void setFingerValue(float data[1 + 3]);
-
-void setFingerValue(const MLWristState &wristState, MLSnapshot *snapshot, float data[4][1 + 3]) {
-  setFingerValue(wristState.radial, snapshot, data[0]);
-  setFingerValue(wristState.ulnar, snapshot, data[1]);
-  setFingerValue(wristState.center, snapshot, data[2]);
-  setFingerValue(data[3]);
-}
-void setFingerValue(const MLThumbState &thumbState, MLSnapshot *snapshot, float data[4][1 + 3]) {
-  setFingerValue(thumbState.cmc, snapshot, data[0]);
-  setFingerValue(thumbState.mcp, snapshot, data[1]);
-  setFingerValue(thumbState.ip, snapshot, data[2]);
-  setFingerValue(thumbState.tip, snapshot, data[3]);
-}
-void setFingerValue(const MLFingerState &fingerState, MLSnapshot *snapshot, float data[4][1 + 3]) {
-  setFingerValue(fingerState.mcp, snapshot, data[0]);
-  setFingerValue(fingerState.pip, snapshot, data[1]);
-  setFingerValue(fingerState.dip, snapshot, data[2]);
-  setFingerValue(fingerState.tip, snapshot, data[3]);
-}
-void setFingerValue(const MLKeyPointState &keyPointState, MLSnapshot *snapshot, float data[1 + 3]) {
-  uint32_t *uint32Data = (uint32_t *)data;
-  float *floatData = (float *)data;
-
-  if (keyPointState.is_valid) {
-    MLTransform transform;
-    MLResult result = MLSnapshotGetTransform(snapshot, &keyPointState.frame_id, &transform);
-    if (result == MLResult_Ok) {
-      // ML_LOG(Info, "%s: ML keypoint ok", application_name);
-
-      uint32Data[0] = true;
-      floatData[1] = transform.position.x;
-      floatData[2] = transform.position.y;
-      floatData[3] = transform.position.z;
-    } else {
-      // ML_LOG(Error, "%s: ML failed to get finger transform: %s", application_name, MLSnapshotGetResultString(result));
-
-      uint32Data[0] = false;
-      const MLVec3f &position = MLVec3f{0, 0, 0};
-      floatData[1] = position.x;
-      floatData[2] = position.y;
-      floatData[3] = position.z;
-    }
-  } else {
-    uint32Data[0] = false;
-    const MLVec3f &position = MLVec3f{0, 0, 0};
-    floatData[1] = position.x;
-    floatData[2] = position.y;
-    floatData[3] = position.z;
-  }
-}
-void setFingerValue(float data[1 + 3]) {
-  uint32_t *uint32Data = (uint32_t *)data;
-  float *floatData = (float *)data;
-
-  uint32Data[0] = false;
-  const MLVec3f &position = MLVec3f{0, 0, 0};
-  floatData[1] = position.x;
-  floatData[2] = position.y;
-  floatData[3] = position.z;
-}
-
 NAN_METHOD(MLContext::Update) {
   MLContext *mlContext = ObjectWrap::Unwrap<MLContext>(Local<Object>::Cast(info[0]));
 
@@ -3872,76 +3685,6 @@ NAN_METHOD(MLContext::Update) {
   // requests
 
   // XXX
-  if (raycasters.size() > 0) {
-    raycasters.erase(std::remove_if(raycasters.begin(), raycasters.end(), [&](MLRaycaster *r) -> bool {
-      if (r->Update()) {
-        // deletion is handled by MLRaycaster
-        return true;
-      } else {
-        return false;
-      }
-    }), raycasters.end());
-  }
-
-  if (handTrackers.size() > 0) {
-    MLResult result = MLHandTrackingGetData(handTracker, &handData);
-    if (result == MLResult_Ok) {
-      MLResult result = MLHandTrackingGetStaticData(handTracker, &handStaticData);
-      if (result == MLResult_Ok) {
-        if (!snapshot) {
-          if (MLPerceptionGetSnapshot(&snapshot) != MLResult_Ok) {
-            ML_LOG(Error, "%s: ML failed to get eye snapshot!", application_name);
-          }
-        }
-
-        handPresents[0] = handData.left_hand_state.hand_confidence >= 0.5;
-        // setFingerValue(handData.left_hand_state, handBones[0][0]);
-        setFingerValue(handStaticData.left.wrist, snapshot, wristBones[0]);
-        setFingerValue(handStaticData.left.thumb, snapshot, fingerBones[0][0]);
-        setFingerValue(handStaticData.left.index, snapshot, fingerBones[0][1]);
-        setFingerValue(handStaticData.left.middle, snapshot, fingerBones[0][2]);
-        setFingerValue(handStaticData.left.ring, snapshot, fingerBones[0][3]);
-        setFingerValue(handStaticData.left.pinky, snapshot, fingerBones[0][4]);
-
-        handPresents[1] = handData.right_hand_state.hand_confidence >= 0.5;
-        // setFingerValue(handData.left_hand_state, handBones[1][0]);
-        setFingerValue(handStaticData.right.wrist, snapshot, wristBones[1]);
-        setFingerValue(handStaticData.right.thumb, snapshot, fingerBones[1][0]);
-        setFingerValue(handStaticData.right.index, snapshot, fingerBones[1][1]);
-        setFingerValue(handStaticData.right.middle, snapshot, fingerBones[1][2]);
-        setFingerValue(handStaticData.right.ring, snapshot, fingerBones[1][3]);
-        setFingerValue(handStaticData.right.pinky, snapshot, fingerBones[1][4]);
-
-        std::for_each(handTrackers.begin(), handTrackers.end(), [&](MLHandTracker *h) {
-          h->Update();
-        });
-      } else {
-        ML_LOG(Error, "%s: Hand static data get failed! %x", application_name, result);
-      }
-    } else {
-      ML_LOG(Error, "%s: Hand data get failed! %x", application_name, result);
-    }
-  }
-
-  if (eyeTrackers.size() > 0) {
-    if (MLEyeTrackingGetState(eyeTracker, &eyeState) != MLResult_Ok) {
-      ML_LOG(Error, "%s: Eye get state failed!", application_name);
-    }
-
-    if (MLEyeTrackingGetStaticData(eyeTracker, &eyeStaticData) != MLResult_Ok) {
-      ML_LOG(Error, "%s: Eye get static data failed!", application_name);
-    }
-
-    if (!snapshot) {
-      if (MLPerceptionGetSnapshot(&snapshot) != MLResult_Ok) {
-        ML_LOG(Error, "%s: ML failed to get eye snapshot!", application_name);
-      }
-    }
-    std::for_each(eyeTrackers.begin(), eyeTrackers.end(), [&](MLEyeTracker *e) {
-      e->Update(snapshot);
-    });
-  }
-
   if (imageTrackers.size() > 0) {
     if (!snapshot) {
       if (MLPerceptionGetSnapshot(&snapshot) != MLResult_Ok) {
@@ -3951,196 +3694,6 @@ NAN_METHOD(MLContext::Update) {
     std::for_each(imageTrackers.begin(), imageTrackers.end(), [&](MLImageTracker *i) {
       i->Update(snapshot);
     });
-  }
-
-  if ((meshers.size() > 0 || depthEnabled) && !meshInfoRequestPending && !meshRequestsPending) {
-    float range = getMaxRange();
-
-    {
-      // std::unique_lock<std::mutex> lock(mlContext->positionMutex);
-
-      meshExtents.center = mlContext->position;
-      // meshExtents.rotation =  mlContext->rotation;
-      meshExtents.rotation = {0, 0, 0, 1};
-    }
-    meshExtents.extents.x = range;
-    meshExtents.extents.y = range;
-    meshExtents.extents.z = range;
-
-    MLResult result = MLMeshingRequestMeshInfo(meshTracker, &meshExtents, &meshInfoRequestHandle);
-    if (result == MLResult_Ok) {
-      meshInfoRequestPending = true;
-    } else {
-      ML_LOG(Error, "%s: Mesh info request failed! %x", application_name, result);
-    }
-  }
-
-  if (planeTrackers.size() > 0 && !planesRequestPending) {
-    {
-      // std::unique_lock<std::mutex> lock(mlContext->positionMutex);
-
-      planesRequest.bounds_center = mlContext->position;
-      // planesRequest.bounds_rotation = mlContext->rotation;
-      planesRequest.bounds_rotation = {0, 0, 0, 1};
-    }
-    planesRequest.bounds_extents.x = planeRange;
-    planesRequest.bounds_extents.y = planeRange;
-    planesRequest.bounds_extents.z = planeRange;
-
-    planesRequest.flags = MLPlanesQueryFlag_Arbitrary | MLPlanesQueryFlag_AllOrientations | MLPlanesQueryFlag_Semantic_All | MLPlanesQueryFlag_OrientToGravity;
-    // planesRequest.min_hole_length = 0.5;
-    planesRequest.min_plane_area = 0.25;
-    planesRequest.max_results = MAX_NUM_PLANES;
-
-    MLResult result = MLPlanesQueryBegin(planesTracker, &planesRequest, &planesRequestHandle);
-    if (result == MLResult_Ok) {
-      planesRequestPending = true;
-    } else {
-      ML_LOG(Error, "%s: Planes request failed! %x", application_name, result);
-    }
-  }
-
-  /* {
-    // std::unique_lock<std::mutex> lock(cameraRequestsMutex);
-
-    if (cameraRequests.size() > 0) {
-      cameraRequestConditionVariable.notify_one();
-    }
-  } */
-
-  // responses
-
-  if (meshInfoRequestPending) {
-    MLResult result = MLMeshingGetMeshInfoResult(meshTracker, meshInfoRequestHandle, &meshInfo);
-    if (result == MLResult_Ok) {
-      uint32_t dataCount = meshInfo.data_count;
-
-      MLMeshingLOD lod = getMaxLod();
-
-      meshRequestNewMap.clear();
-      meshRequestRemovedMap.clear();
-      meshRequestUnchangedMap.clear();
-      for (uint32_t i = 0; i < dataCount; i++) {
-        const MLMeshingBlockInfo &meshBlockInfo = meshInfo.data[i];
-        const MLMeshingMeshState &state = meshBlockInfo.state;
-        MLMeshingBlockRequest &meshBlockRequest = meshBlockRequests[i];
-        meshBlockRequest.id = meshBlockInfo.id;
-        meshBlockRequest.level = lod;
-
-        const std::string &id = id2String(meshBlockInfo.id);
-        meshRequestNewMap[id] = (state == MLMeshingMeshState_New);
-        meshRequestRemovedMap[id] = (state == MLMeshingMeshState_Deleted);
-        meshRequestUnchangedMap[id] = (state == MLMeshingMeshState_Unchanged);
-      }
-      numMeshBlockRequests = dataCount;
-
-      meshInfoRequestPending = false;
-      meshRequestsPending = true;
-      meshRequestPending = false;
-      meshBlockRequestIndex = 0;
-      MLMeshingFreeResource(meshTracker, &meshInfoRequestHandle);
-    } else if (result == MLResult_Pending) {
-      // nothing
-    } else {
-      ML_LOG(Error, "%s: Mesh info get failed! %x", application_name, result);
-
-      meshInfoRequestPending = false;
-    }
-  }
-  if (meshRequestsPending && !meshRequestPending) {
-    if (meshBlockRequestIndex < numMeshBlockRequests) {
-      uint32_t requestsRemaining = numMeshBlockRequests - meshBlockRequestIndex;
-      uint32_t requestsThisTime = std::min<uint32_t>(requestsRemaining, 16);
-      meshRequest.data = meshBlockRequests.data() + meshBlockRequestIndex;
-      meshRequest.request_count = requestsThisTime;
-
-      meshBlockRequestIndex += requestsThisTime;
-
-      MLResult result = MLMeshingRequestMesh(meshTracker, &meshRequest, &meshRequestHandle);
-      if (result == MLResult_Ok) {
-        meshRequestsPending = true;
-        meshRequestPending = true;
-      } else {
-        ML_LOG(Error, "%s: Mesh request failed! %x", application_name, result);
-
-        meshRequestsPending = false;
-        meshRequestPending = false;
-      }
-    } else {
-      meshRequestsPending = false;
-      meshRequestPending = false;
-    }
-  }
-  if (meshRequestsPending && meshRequestPending) {
-    MLResult result = MLMeshingGetMeshResult(meshTracker, meshRequestHandle, &mesh);
-    if (result == MLResult_Ok) {
-      MLMeshingBlockMesh *blockMeshes = mesh.data;
-      uint32_t dataCount = mesh.data_count;
-
-      // add new mesh buffers
-      for (uint32_t i = 0; i < dataCount; i++) {
-        MLMeshingBlockMesh &blockMesh = blockMeshes[i];
-        const std::string &id = id2String(blockMesh.id);
-
-        if (!meshRequestRemovedMap[id]) {
-          MLTransform transform;
-          MLSnapshotGetTransform(snapshot, &blockMesh.id, &transform);
-
-          meshBuffers[id] = MeshBuffer(transform, (float *)(&blockMesh.vertex->values), blockMesh.vertex_count * 3, (float *)(&blockMesh.normal->values), blockMesh.index, blockMesh.index_count);
-        } else {
-          meshBuffers.erase(id);
-        }
-      }
-
-      // remove outranged mesh buffers
-      float range = getMaxRange();
-      std::vector<std::string> removedIds;
-      for (auto iter = meshBuffers.begin(); iter != meshBuffers.end(); iter++) {
-        const std::string &id = iter->first;
-        MeshBuffer &meshBuffer = iter->second;
-        float distance = distanceTo(mlContext->position, meshBuffer.transform.position);
-        if (distance > range) {
-          meshRequestRemovedMap[id] = true;
-          removedIds.push_back(id);
-        }
-      }
-      for (auto iter = removedIds.begin(); iter != removedIds.end(); iter++) {
-        meshBuffers.erase(*iter);
-      }
-
-      std::for_each(meshers.begin(), meshers.end(), [&](MLMesher *m) {
-        m->Update();
-      });
-
-      meshRequestsPending = true;
-      meshRequestPending = false;
-
-      MLMeshingFreeResource(meshTracker, &meshRequestHandle);
-    } else if (result == MLResult_Pending) {
-      // nothing
-    } else {
-      ML_LOG(Error, "%s: Mesh get failed! %x", application_name, result);
-
-      meshRequestsPending = true;
-      meshRequestPending = false;
-    }
-  }
-
-  if (planesRequestPending) {
-    MLResult result = MLPlanesQueryGetResults(planesTracker, planesRequestHandle, planeResults, &numPlanesResults);
-    if (result == MLResult_Ok) {
-      std::for_each(planeTrackers.begin(), planeTrackers.end(), [&](MLPlaneTracker *p) {
-        p->Update();
-      });
-
-      planesRequestPending = false;
-    } else if (result == MLResult_Pending) {
-      // nothing
-    } else {
-      ML_LOG(Error, "%s: Planes request failed! %x", application_name, result);
-
-      planesRequestPending = false;
-    }
   }
   
   if (snapshot) {

--- a/deps/exokit-bindings/magicleap/src/ml-math.cc
+++ b/deps/exokit-bindings/magicleap/src/ml-math.cc
@@ -701,7 +701,7 @@ bool getHandGripTransform(MLTransform &result, float wristBones[4][1 + 3], float
   return getFingerRayTransform(result, fingers, normal, transform);
 }
 
-void getWristBonePosition(MLVec3f &position, float wristBones[4][1 + 3], int boneIndex, const MLMat4f &transform) {
+/* void getWristBonePosition(MLVec3f &position, float wristBones[4][1 + 3], int boneIndex, const MLMat4f &transform) {
   float *positionValues = (float *)&wristBones[boneIndex][1];
   position.x = positionValues[0];
   position.y = positionValues[1];
@@ -721,7 +721,7 @@ void getFingerBonePosition(MLVec3f &position, float fingerBones[5][4][1 + 3], in
   if (!isIdentityMatrix(transform)) {
     position = applyVectorMatrix(position, transform);
   }
-} 
+} */
 
 }
 

--- a/examples/eyetracking_ml.html
+++ b/examples/eyetracking_ml.html
@@ -25,7 +25,6 @@
   <script src="three.js"></script>
   <script>
     let container, scene, camera, display, eyeMesh;
-    let eyeTracker = null;
 
     const controllerGeometry = new THREE.BoxBufferGeometry(0.1, 0.2, 0.01);
     const controllerMaterial = new THREE.MeshPhongMaterial({
@@ -70,7 +69,7 @@
           color: 0x0000FF,
         });
         const mesh = new THREE.Mesh(geometry, material);
-        mesh.visible = false;
+        // mesh.visible = false;
         mesh.frustumCulled = false;
         return mesh;
       })();
@@ -92,19 +91,21 @@
     }
 
     function animate(time, frame) {
-      if (eyeTracker) {
-        const {position, orientation} = eyeTracker.getFixation();
+      const _updateEyeMesh = () => {
+        const eyeInputSources = display.session.getInputSources().filter(inputSource => inputSource.targetRayMode === 'gaze');
+        if (eyeInputSources.length > 0 && frame) {
+          const eyeInputSource = eyeInputSources[0];
+          const {axes, offsetMatrix} = eyeInputSource;
+          const pose = frame.getInputPose(eyeInputSource);
 
-        eyeMesh.position.fromArray(position);
-        eyeMesh.quaternion.fromArray(orientation);
-        const scaleFactor = eyeTracker.getEyes().some(eye => eye.getBlink()) ? 0.2 : 1;
-        eyeMesh.scale.set(1, scaleFactor, 1);
-        eyeMesh.updateMatrix();
-        eyeMesh.updateMatrixWorld();
-        eyeMesh.visible = true;
-      } else {
-        eyeMesh.visible = false;
-      }
+          eyeMesh.matrix.fromArray(offsetMatrix);
+          eyeMesh.matrix.decompose(eyeMesh.position, eyeMesh.quaternion, eyeMesh.scale);
+          const scaleFactor = axes.some(axis => axis < 0) ? 0.2 : 1;
+          eyeMesh.scale.set(1, scaleFactor, 1);
+          eyeMesh.updateMatrixWorld();
+        }
+      };
+      _updateEyeMesh();
 
       renderer.render(scene, renderer.vr.enabled ? renderer.vr.getCamera(camera) : camera);
     }
@@ -117,6 +118,9 @@
       console.log('request session');
       const session = await display.requestSession({
         exclusive: true,
+        extensions: {
+          eyeTracking: true,
+        },
       });
       display.session = session;
 
@@ -141,7 +145,7 @@
         });
         renderer.vr.setAnimationLoop(animate);
         
-        eyeTracker = session.requestEyeTracking();
+        // eyeTracker = session.requestEyeTracking();
 
         console.log('running!');
       });

--- a/examples/eyetracking_ml.html
+++ b/examples/eyetracking_ml.html
@@ -10,7 +10,7 @@
     if('serviceWorker' in navigator) {
       navigator.serviceWorker.register('/hello_ml_sw.js')
         .then(function() {
-              console.log('Service Worker Registered');
+          console.log('Service Worker Registered');
         });
     }
    </script>
@@ -92,17 +92,22 @@
 
     function animate(time, frame) {
       const _updateEyeMesh = () => {
-        const eyeInputSources = display.session.getInputSources().filter(inputSource => inputSource.targetRayMode === 'gaze');
-        if (eyeInputSources.length > 0 && frame) {
-          const eyeInputSource = eyeInputSources[0];
-          const {axes, offsetMatrix} = eyeInputSource;
-          const pose = frame.getInputPose(eyeInputSource);
+        if (display && display.session && frame) {
+          const eyeInputSources = display.session.getInputSources().filter(inputSource => inputSource.targetRayMode === 'gaze');
+          const eyeGamepads = navigator.getGamepads().filter(gamepad => gamepad.id === 'eye');
+          if (eyeInputSources.length > 0 && eyeGamepads.length > 0) {
+            const eyeInputSource = eyeInputSources[0];
+            const eyeGamepad = eyeGamepads[0];
 
-          eyeMesh.matrix.fromArray(offsetMatrix);
-          eyeMesh.matrix.decompose(eyeMesh.position, eyeMesh.quaternion, eyeMesh.scale);
-          const scaleFactor = axes.some(axis => axis < 0) ? 0.2 : 1;
-          eyeMesh.scale.set(1, scaleFactor, 1);
-          eyeMesh.updateMatrixWorld();
+            const pose = frame.getInputPose(eyeInputSource);
+            const {axes/*, offsetMatrix*/} = eyeGamepad;
+
+            eyeMesh.matrix.fromArray(pose.targetRay.transformMatrix);
+            eyeMesh.matrix.decompose(eyeMesh.position, eyeMesh.quaternion, eyeMesh.scale);
+            const scaleFactor = axes.some(axis => axis < 0) ? 0.2 : 1;
+            eyeMesh.scale.set(1, scaleFactor, 1);
+            eyeMesh.updateMatrixWorld();
+          }
         }
       };
       _updateEyeMesh();

--- a/examples/graffiti_ml.html
+++ b/examples/graffiti_ml.html
@@ -473,6 +473,9 @@ init();
   console.log('request session');
   const session = await display.requestSession({
     exclusive: true,
+    extensions: {
+      meshing: true,
+    },
   });
   display.session = session;
 

--- a/examples/hands_ml.html
+++ b/examples/hands_ml.html
@@ -159,12 +159,12 @@
             const bones = allFingers[j];
             for (let k = 0; k < bones.length; k++) {
               const positionFloat32Array = bones[k];
-              if (positionFloat32Array) {
+              if (positionFloat32Array && isFinite(positionFloat32Array[0])) {
                 // console.log('position', j, k, positionFloat32Array.join(','));
-                const position = localVector.fromArray(positionFloat32Array);
+                // const position = localVector.fromArray(positionFloat32Array);
                 const newGeometry = boneGeometry.clone()
                   .applyMatrix(
-                    localMatrix.makeTranslation(position.x, position.y, position.z)
+                    localMatrix.makeTranslation(positionFloat32Array[0], positionFloat32Array[1], positionFloat32Array[2])
                   );
 
                 _shiftIndex(newGeometry.index.array);

--- a/examples/hands_ml.html
+++ b/examples/hands_ml.html
@@ -24,8 +24,7 @@
   <h1>hands_ml.html example</h1> 
   <script src="three.js"></script>
   <script>
-    let container, scene, camera, display;
-    let handTracker;
+    let container, scene, camera, display, handMesh;
 
     function init() {
       container = document.createElement('div');
@@ -51,83 +50,85 @@
       const localVector2 = new THREE.Vector3();
       const localQuaternion = new THREE.Quaternion();
       const localMatrix = new THREE.Matrix4();
-      const handMesh = (() => {
-        const pointerGeometry = (() => {
-          const geometries = [
-            new THREE.CylinderBufferGeometry(0.001, 0.001, 1, 32, 1)
-              .applyMatrix(localMatrix.makeTranslation(0, 1/2, 0))
-              .applyMatrix(localMatrix.makeRotationFromQuaternion(
-                localQuaternion.setFromUnitVectors(
-                  localVector.set(0, 1, 0),
-                  localVector2.set(0, 0, -1)
-                )
-              )),
-            new THREE.BoxBufferGeometry(0.001, 0.1, 0.001)
-              .applyMatrix(localMatrix.makeTranslation(0, 0.1/2, 0)),
-          ];
+      const pointerGeometry = (() => {
+        const geometries = [
+          new THREE.CylinderBufferGeometry(0.001, 0.001, 1, 32, 1)
+            .applyMatrix(localMatrix.makeTranslation(0, 1/2, 0))
+            .applyMatrix(localMatrix.makeRotationFromQuaternion(
+              localQuaternion.setFromUnitVectors(
+                localVector.set(0, 1, 0),
+                localVector2.set(0, 0, -1)
+              )
+            )),
+          new THREE.BoxBufferGeometry(0.001, 0.1, 0.001)
+            .applyMatrix(localMatrix.makeTranslation(0, 0.1/2, 0)),
+        ];
 
-          const positions = (() => {
-            let numPositions = 0;
-            for (let i = 0; i < geometries.length; i++) {
-              numPositions += geometries[i].attributes.position.array.length;
-            }
+        const positions = (() => {
+          let numPositions = 0;
+          for (let i = 0; i < geometries.length; i++) {
+            numPositions += geometries[i].attributes.position.array.length;
+          }
 
-            const positions = new Float32Array(numPositions);
-            let positionIndex = 0;
-            for (let i = 0; i < geometries.length; i++) {
-              const geometry = geometries[i];
-              positions.set(geometry.attributes.position.array, positionIndex);
-              positionIndex += geometry.attributes.position.array.length;
-            }
-            return positions;
-          })();
-          const normals = (() => {
-            let numNormals = 0;
-            for (let i = 0; i < geometries.length; i++) {
-              numNormals += geometries[i].attributes.normal.array.length;
-            }
-
-            const normals = new Float32Array(numNormals);
-            let normalIndex = 0;
-            for (let i = 0; i < geometries.length; i++) {
-              const geometry = geometries[i];
-              normals.set(geometry.attributes.normal.array, normalIndex);
-              normalIndex += geometry.attributes.normal.array.length;
-            }
-            return normals;
-          })();
-          const indices = (() => {
-            let numIndices = 0;
-            for (let i = 0; i < geometries.length; i++) {
-              numIndices += geometries[i].index.array.length;
-            }
-
-            const indices = new Uint16Array(numIndices);
-            let indexIndex = 0;
-            let positionIndex = 0;
-            for (let i = 0; i < geometries.length; i++) {
-              const geometry = geometries[i];
-              indices.set(geometry.index.array, indexIndex);
-
-              const positionOffset = positionIndex / 3;
-              for (let j = 0; j < geometry.index.array.length; j++) {
-                indices[indexIndex + j] += positionOffset;
-              }
-
-              indexIndex += geometry.index.array.length;
-              positionIndex += geometry.attributes.position.array.length;
-            }
-            return indices;
-          })();
-
-          const geometry = new THREE.BufferGeometry();
-          geometry.addAttribute('position', new THREE.BufferAttribute(positions, 3));
-          geometry.addAttribute('normal', new THREE.BufferAttribute(normals, 3));
-          geometry.setIndex(new THREE.BufferAttribute(indices, 1));
-          return geometry;
+          const positions = new Float32Array(numPositions);
+          let positionIndex = 0;
+          for (let i = 0; i < geometries.length; i++) {
+            const geometry = geometries[i];
+            positions.set(geometry.attributes.position.array, positionIndex);
+            positionIndex += geometry.attributes.position.array.length;
+          }
+          return positions;
         })();
-        const boneGeometry = new THREE.BoxBufferGeometry(0.005, 0.005, 0.005);
+        const normals = (() => {
+          let numNormals = 0;
+          for (let i = 0; i < geometries.length; i++) {
+            numNormals += geometries[i].attributes.normal.array.length;
+          }
 
+          const normals = new Float32Array(numNormals);
+          let normalIndex = 0;
+          for (let i = 0; i < geometries.length; i++) {
+            const geometry = geometries[i];
+            normals.set(geometry.attributes.normal.array, normalIndex);
+            normalIndex += geometry.attributes.normal.array.length;
+          }
+          return normals;
+        })();
+        const indices = (() => {
+          let numIndices = 0;
+          for (let i = 0; i < geometries.length; i++) {
+            numIndices += geometries[i].index.array.length;
+          }
+
+          const indices = new Uint16Array(numIndices);
+          let indexIndex = 0;
+          let positionIndex = 0;
+          for (let i = 0; i < geometries.length; i++) {
+            const geometry = geometries[i];
+            indices.set(geometry.index.array, indexIndex);
+
+            const positionOffset = positionIndex / 3;
+            for (let j = 0; j < geometry.index.array.length; j++) {
+              indices[indexIndex + j] += positionOffset;
+            }
+
+            indexIndex += geometry.index.array.length;
+            positionIndex += geometry.attributes.position.array.length;
+          }
+          return indices;
+        })();
+
+        const geometry = new THREE.BufferGeometry();
+        geometry.addAttribute('position', new THREE.BufferAttribute(positions, 3));
+        geometry.addAttribute('normal', new THREE.BufferAttribute(normals, 3));
+        geometry.setIndex(new THREE.BufferAttribute(indices, 1));
+        return geometry;
+      })();
+      const boneGeometry = new THREE.BoxBufferGeometry(0.005, 0.005, 0.005);
+      const handMaterial =  new THREE.MeshPhongMaterial({
+        color: 0xFF0000,
+      });
+      const _makeHandMesh = i => {
         const geometry = new THREE.BufferGeometry();
 
         const positions = new Float32Array(boneGeometry.attributes.position.array.length * 2 * 6 * 4 + pointerGeometry.attributes.position.array.length * 2);
@@ -138,12 +139,11 @@
         const indexAttribute = new THREE.BufferAttribute(indices, 1);
         geometry.setIndex(indexAttribute);
 
-        const material =  new THREE.MeshPhongMaterial({
-          color: 0xFF0000,
-        });
+        const mesh = new THREE.Mesh(geometry, handMaterial);
+        mesh.update = () => {
+          const handInputSources = display.session.getInputSources().filter(inputSource => inputSource.targetRayMode === 'hand');
+          const inputSource = handInputSources[i];
 
-        const mesh = new THREE.Mesh(geometry, material);
-        mesh.update = hands => {
           let positionIndex = 0;
           let indexIndex = 0;
 
@@ -153,82 +153,90 @@
             }
           };
 
-          for (let i = 0; i < hands.length; i++) {
-            const hand = hands[i];
-            const {pointer, grip, wrist, fingers} = hand;
-            const allFingers = [wrist].concat(fingers);
+          const {wrist, fingers, offsetMatrix} = inputSource;
+          const allFingers = [wrist].concat(fingers);
+          for (let j = 0; j < allFingers.length; j++) {
+            const bones = allFingers[j];
+            for (let k = 0; k < bones.length; k++) {
+              const positionFloat32Array = bones[k];
+              if (positionFloat32Array) {
+                // console.log('position', j, k, positionFloat32Array.join(','));
+                const position = localVector.fromArray(positionFloat32Array);
+                const newGeometry = boneGeometry.clone()
+                  .applyMatrix(
+                    localMatrix.makeTranslation(position.x, position.y, position.z)
+                  );
 
-            for (let j = 0; j < allFingers.length; j++) {
-              const bones = allFingers[j];
-              for (let k = 0; k < bones.length; k++) {
-                const positionFloat32Array = bones[k];
-                if (positionFloat32Array) {
-                  const position = localVector.fromArray(positionFloat32Array);
-                  const newGeometry = boneGeometry.clone()
-                    .applyMatrix(
-                      localMatrix.makeTranslation(position.x, position.y, position.z)
-                    );
+                _shiftIndex(newGeometry.index.array);
 
-                  _shiftIndex(newGeometry.index.array);
+                positions.set(newGeometry.attributes.position.array, positionIndex);
+                positionIndex += newGeometry.attributes.position.array.length;
 
-                  positions.set(newGeometry.attributes.position.array, positionIndex);
-                  positionIndex += newGeometry.attributes.position.array.length;
-
-                  indices.set(newGeometry.index.array, indexIndex);
-                  indexIndex += newGeometry.index.array.length;
-                }
+                indices.set(newGeometry.index.array, indexIndex);
+                indexIndex += newGeometry.index.array.length;
               }
             }
-
-            if (pointer) {
-              const newGeometry = pointerGeometry.clone()
-                .applyMatrix(
-                  localMatrix
-                    .compose(
-                      localVector.fromArray(pointer.position),
-                      localQuaternion.fromArray(pointer.rotation),
-                      localVector2.set(1, 1, 1),
-                    )
-                );
-
-              _shiftIndex(newGeometry.index.array);
-
-              positions.set(newGeometry.attributes.position.array, positionIndex);
-              positionIndex += newGeometry.attributes.position.array.length;
-
-              indices.set(newGeometry.index.array, indexIndex);
-              indexIndex += newGeometry.index.array.length;
-            }
-
-            if (grip) {
-              const newGeometry = pointerGeometry.clone()
-                .applyMatrix(
-                  localMatrix
-                    .compose(
-                      localVector.fromArray(grip.position),
-                      localQuaternion.fromArray(grip.rotation),
-                      localVector2.set(1, 1, 1),
-                    )
-                );
-
-              _shiftIndex(newGeometry.index.array);
-
-              positions.set(newGeometry.attributes.position.array, positionIndex);
-              positionIndex += newGeometry.attributes.position.array.length;
-
-              indices.set(newGeometry.index.array, indexIndex);
-              indexIndex += newGeometry.index.array.length;
-            }
           }
+
+          /* if (pointer) {
+            const newGeometry = pointerGeometry.clone()
+              .applyMatrix(
+                localMatrix
+                  .compose(
+                    localVector.fromArray(pointer.position),
+                    localQuaternion.fromArray(pointer.rotation),
+                    localVector2.set(1, 1, 1),
+                  )
+              );
+
+            _shiftIndex(newGeometry.index.array);
+
+            positions.set(newGeometry.attributes.position.array, positionIndex);
+            positionIndex += newGeometry.attributes.position.array.length;
+
+            indices.set(newGeometry.index.array, indexIndex);
+            indexIndex += newGeometry.index.array.length;
+          }
+
+          if (grip) {
+            const newGeometry = pointerGeometry.clone()
+              .applyMatrix(
+                localMatrix
+                  .compose(
+                    localVector.fromArray(grip.position),
+                    localQuaternion.fromArray(grip.rotation),
+                    localVector2.set(1, 1, 1),
+                  )
+              );
+
+            _shiftIndex(newGeometry.index.array);
+
+            positions.set(newGeometry.attributes.position.array, positionIndex);
+            positionIndex += newGeometry.attributes.position.array.length;
+
+            indices.set(newGeometry.index.array, indexIndex);
+            indexIndex += newGeometry.index.array.length;
+          } */
 
           positionAttribute.needsUpdate = true;
           indexAttribute.needsUpdate = true;
           geometry.setDrawRange(0, indexIndex);
+          
+          mesh.matrix.fromArray(offsetMatrix);
+          mesh.matrix.decompose(mesh.position, mesh.quaternion, mesh.scale);
+          // console.log('transform matrix', offsetMatrix, mesh.position.toArray());
+          mesh.updateMatrixWorld();
         };
         mesh.frustumCulled = false;
         return mesh;
-      })();
-      scene.add(handMesh);
+      };
+      handMeshes = [
+        _makeHandMesh(0),
+        _makeHandMesh(1),
+      ];
+      for (let i = 0; i < handMeshes.length; i++) {
+        scene.add(handMeshes[i]);
+      }
       const _onHands = hands => {
         handMesh.update(hands);
 
@@ -299,10 +307,9 @@
         lastPincheds[handIndex] = pinched;
       };
 
-      handTracker = window.browser.magicleap.RequestHandTracking();
-      handTracker.onhands = _onHands;
-      handTracker.ongesture = _onGesture;
-      handMesh.visible = true;
+      /* handTracker.onhands = _onHands;
+      handTracker.ongesture = _onGesture; */
+      // handMesh.visible = true;
 
       renderer = new THREE.WebGLRenderer({
         antialias: true,
@@ -320,6 +327,10 @@
     }
 
     function animate(time, frame) {
+      for (let i = 0; i < handMeshes.length; i++) {
+        handMeshes[i].update();
+      }
+
       renderer.render(scene, renderer.vr.enabled ? renderer.vr.getCamera(camera) : camera);
     }
 
@@ -331,6 +342,9 @@
       console.log('request session');
       const session = await display.requestSession({
         exclusive: true,
+        extensions: {
+          handTracking: true,
+        },
       });
       display.session = session;
 

--- a/examples/hands_ml.html
+++ b/examples/hands_ml.html
@@ -10,7 +10,7 @@
     if('serviceWorker' in navigator) {
       navigator.serviceWorker.register('/hands_ml_sw.js')
         .then(function() {
-              console.log('Service Worker Registered');
+          console.log('Service Worker Registered');
         });
     }
    </script>
@@ -36,7 +36,6 @@
 
       camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
       // camera.position.set(0, 1, 0);
-      camera.lookAt(new THREE.Vector3());
       scene.add(camera);
 
       const ambientLight = new THREE.AmbientLight(0x808080);
@@ -124,7 +123,7 @@
         geometry.setIndex(new THREE.BufferAttribute(indices, 1));
         return geometry;
       })();
-      const boneGeometry = new THREE.BoxBufferGeometry(0.005, 0.005, 0.005);
+      const boneGeometry = new THREE.BoxBufferGeometry(0.01, 0.01, 0.01);
       const handMaterial =  new THREE.MeshPhongMaterial({
         color: 0xFF0000,
       });
@@ -140,93 +139,106 @@
         geometry.setIndex(indexAttribute);
 
         const mesh = new THREE.Mesh(geometry, handMaterial);
-        mesh.update = () => {
-          const handInputSources = display.session.getInputSources().filter(inputSource => inputSource.targetRayMode === 'hand');
-          const inputSource = handInputSources[i];
+        mesh.update = frame => {
+          if (display && display.session && frame) {
+            const handInputSources = display.session.getInputSources().filter(inputSource => inputSource.targetRayMode === 'hand');
+            if (handInputSources.length > 0) {
+              const inputSource = handInputSources[i];
 
-          let positionIndex = 0;
-          let indexIndex = 0;
+              if (inputSource.connected) {
+                let positionIndex = 0;
+                let indexIndex = 0;
 
-          const _shiftIndex = array => {
-            for (let l = 0; l < array.length; l++) {
-              array[l] += positionIndex / 3;
-            }
-          };
+                const _shiftIndex = array => {
+                  for (let l = 0; l < array.length; l++) {
+                    array[l] += positionIndex / 3;
+                  }
+                };
 
-          const {wrist, fingers, offsetMatrix} = inputSource;
-          const allFingers = [wrist].concat(fingers);
-          for (let j = 0; j < allFingers.length; j++) {
-            const bones = allFingers[j];
-            for (let k = 0; k < bones.length; k++) {
-              const positionFloat32Array = bones[k];
-              if (positionFloat32Array && isFinite(positionFloat32Array[0])) {
-                // console.log('position', j, k, positionFloat32Array.join(','));
-                // const position = localVector.fromArray(positionFloat32Array);
-                const newGeometry = boneGeometry.clone()
-                  .applyMatrix(
-                    localMatrix.makeTranslation(positionFloat32Array[0], positionFloat32Array[1], positionFloat32Array[2])
-                  );
+                const pose = frame.getInputPose(inputSource);
+                const {wrist, fingers} = inputSource;
+                const allFingers = [wrist].concat(fingers);
+                for (let j = 0; j < allFingers.length; j++) {
+                  const bones = allFingers[j];
+                  for (let k = 0; k < bones.length; k++) {
+                    const positionFloat32Array = bones[k];
+                    if (positionFloat32Array && isFinite(positionFloat32Array[0])) {
+                      const newGeometry = boneGeometry.clone()
+                        .applyMatrix(
+                          localMatrix.makeTranslation(positionFloat32Array[0], positionFloat32Array[1], positionFloat32Array[2])
+                        );
 
-                _shiftIndex(newGeometry.index.array);
+                      _shiftIndex(newGeometry.index.array);
 
-                positions.set(newGeometry.attributes.position.array, positionIndex);
-                positionIndex += newGeometry.attributes.position.array.length;
+                      positions.set(newGeometry.attributes.position.array, positionIndex);
+                      positionIndex += newGeometry.attributes.position.array.length;
 
-                indices.set(newGeometry.index.array, indexIndex);
-                indexIndex += newGeometry.index.array.length;
+                      indices.set(newGeometry.index.array, indexIndex);
+                      indexIndex += newGeometry.index.array.length;
+                    }
+                  }
+                }
+
+                /* if (pointer) {
+                  const newGeometry = pointerGeometry.clone()
+                    .applyMatrix(
+                      localMatrix
+                        .compose(
+                          localVector.fromArray(pointer.position),
+                          localQuaternion.fromArray(pointer.rotation),
+                          localVector2.set(1, 1, 1),
+                        )
+                    );
+
+                  _shiftIndex(newGeometry.index.array);
+
+                  positions.set(newGeometry.attributes.position.array, positionIndex);
+                  positionIndex += newGeometry.attributes.position.array.length;
+
+                  indices.set(newGeometry.index.array, indexIndex);
+                  indexIndex += newGeometry.index.array.length;
+                }
+
+                if (grip) {
+                  const newGeometry = pointerGeometry.clone()
+                    .applyMatrix(
+                      localMatrix
+                        .compose(
+                          localVector.fromArray(grip.position),
+                          localQuaternion.fromArray(grip.rotation),
+                          localVector2.set(1, 1, 1),
+                        )
+                    );
+
+                  _shiftIndex(newGeometry.index.array);
+
+                  positions.set(newGeometry.attributes.position.array, positionIndex);
+                  positionIndex += newGeometry.attributes.position.array.length;
+
+                  indices.set(newGeometry.index.array, indexIndex);
+                  indexIndex += newGeometry.index.array.length;
+                } */
+
+                positionAttribute.needsUpdate = true;
+                indexAttribute.needsUpdate = true;
+                geometry.setDrawRange(0, indexIndex);
+
+                mesh.matrix.fromArray(pose.targetRay.transformMatrix);
+                mesh.matrix.decompose(mesh.position, mesh.quaternion, mesh.scale);
+                mesh.updateMatrixWorld(true);
+                
+                mesh.visible = true;
+              } else {
+                mesh.visible = false;
               }
+            } else {
+              mesh.visible = false;
             }
+          } else {
+            mesh.visible = false;
           }
-
-          /* if (pointer) {
-            const newGeometry = pointerGeometry.clone()
-              .applyMatrix(
-                localMatrix
-                  .compose(
-                    localVector.fromArray(pointer.position),
-                    localQuaternion.fromArray(pointer.rotation),
-                    localVector2.set(1, 1, 1),
-                  )
-              );
-
-            _shiftIndex(newGeometry.index.array);
-
-            positions.set(newGeometry.attributes.position.array, positionIndex);
-            positionIndex += newGeometry.attributes.position.array.length;
-
-            indices.set(newGeometry.index.array, indexIndex);
-            indexIndex += newGeometry.index.array.length;
-          }
-
-          if (grip) {
-            const newGeometry = pointerGeometry.clone()
-              .applyMatrix(
-                localMatrix
-                  .compose(
-                    localVector.fromArray(grip.position),
-                    localQuaternion.fromArray(grip.rotation),
-                    localVector2.set(1, 1, 1),
-                  )
-              );
-
-            _shiftIndex(newGeometry.index.array);
-
-            positions.set(newGeometry.attributes.position.array, positionIndex);
-            positionIndex += newGeometry.attributes.position.array.length;
-
-            indices.set(newGeometry.index.array, indexIndex);
-            indexIndex += newGeometry.index.array.length;
-          } */
-
-          positionAttribute.needsUpdate = true;
-          indexAttribute.needsUpdate = true;
-          geometry.setDrawRange(0, indexIndex);
-          
-          mesh.matrix.fromArray(offsetMatrix);
-          mesh.matrix.decompose(mesh.position, mesh.quaternion, mesh.scale);
-          // console.log('transform matrix', offsetMatrix, mesh.position.toArray());
-          mesh.updateMatrixWorld();
         };
+        mesh.visible = false;
         mesh.frustumCulled = false;
         return mesh;
       };
@@ -237,7 +249,7 @@
       for (let i = 0; i < handMeshes.length; i++) {
         scene.add(handMeshes[i]);
       }
-      const _onHands = hands => {
+      /* const _onHands = hands => {
         handMesh.update(hands);
 
         for (let i = 0; i < hands.length; i++) {
@@ -261,7 +273,7 @@
             }
           }
         }
-      };
+      }; */
       const objectGeometry = new THREE.BoxBufferGeometry(0.1, 0.2, 0.001);
       const objectMaterial = new THREE.MeshPhongMaterial({
         color: 0x0000FF,
@@ -328,7 +340,7 @@
 
     function animate(time, frame) {
       for (let i = 0; i < handMeshes.length; i++) {
-        handMeshes[i].update();
+        handMeshes[i].update(frame);
       }
 
       renderer.render(scene, renderer.vr.enabled ? renderer.vr.getCamera(camera) : camera);
@@ -348,7 +360,6 @@
       });
       display.session = session;
 
-      // console.log('request first frame');
       session.requestAnimationFrame((timestamp, frame) => {
         renderer.vr.setSession(session, {
           frameOfReferenceType: 'stage',

--- a/examples/launcher/src/components/Engine.jsx
+++ b/examples/launcher/src/components/Engine.jsx
@@ -310,6 +310,10 @@ class Engine extends React.Component {
                     <i class="fal fa-crosshairs"/>
                     <div className="label">Hit test</div>
                   </div>
+                  <div className="menu-item-popup-item" onClick={() => this.addTemplate('hands')}>
+                    <i class="fal fa-hand-paper"/>
+                    <div className="label">Hand tracking</div>
+                  </div>
                   <div className="menu-item-popup-item" onClick={() => this.addTemplate('eyeTracking')}>
                     <i class="fal fa-eye"/>
                     <div className="label">Eye tracking</div>

--- a/examples/meshing_ml.html
+++ b/examples/meshing_ml.html
@@ -25,7 +25,7 @@
   <script src="three.js"></script>
   <script>
     let container, scene, camera, display, model;
-    let mesher = null;
+    // let mesher = null;
 
     /* const localVector = new THREE.Vector3();
     const localVector2 = new THREE.Vector3();
@@ -149,7 +149,21 @@
       }
       terrainMeshes.length = 0;
     }; */
-    const _onMesh = e => {
+    const _meshadd = e => {
+      _loadTerrainMesh(_getTerrainMesh(e.update.id), e.update);
+    };
+    const _meshupdate = e => {
+      _loadTerrainMesh(_getTerrainMesh(e.update.id), e.update);
+    };
+    const _meshremove = e => {
+      const index = terrainMeshes.findIndex(terrainMesh => terrainMesh.meshId === e.update.id);
+      if (index !== -1) {
+        const terrainMesh = terrainMeshes[index];
+        _removeTerrainMesh(terrainMesh);
+        terrainMeshes.splice(index, 1);
+      }
+    };
+    /* const _onMesh = e => {
       const {updates} = e;
       for (let i = 0; i < updates.length; i++) {
         const update = updates[i];
@@ -168,7 +182,7 @@
           }
         }
       }
-    };
+    }; */
 
     function init() {
       container = document.createElement('div');
@@ -202,87 +216,6 @@
 
       container.appendChild(renderer.domElement);
 
-      /* if (window.browser && window.browser.magicleap) {
-        mesher = window.browser.magicleap.RequestMeshing();
-        mesher.onmesh = _onMesh;
-      } else {
-        const gl = renderer.getContext();
-
-        const geometryPositions = cubeGeometry.attributes.position.array;
-        const geometryNormals = cubeGeometry.attributes.normal.array;
-        const geometryIndices = cubeGeometry.index.array;
-
-        const positionArray = new Float32Array(new ArrayBuffer(numCubes * geometryPositions.length * Float32Array.BYTES_PER_ELEMENT));
-        const normalArray = new Float32Array(new ArrayBuffer(numCubes * geometryNormals.length * Float32Array.BYTES_PER_ELEMENT));
-        const indexArray = new Uint16Array(new ArrayBuffer(numCubes * geometryIndices.length * Float32Array.BYTES_PER_ELEMENT));
-        for (let i = 0; i < numCubes; i++) {
-          const positionDstOffset = i*geometryPositions.length;
-          const offsetVector = localVector2.set((Math.random()-0.5)*2*cubeRange, (Math.random()-0.5), (Math.random()-0.5)*2*cubeRange);
-          const offsetEuler = localEuler.set((Math.random()-0.5)*2*Math.PI, (Math.random()-0.5)*2*Math.PI, (Math.random()-0.5)*2*Math.PI, 'YXZ');
-          for (let j = 0; j < geometryPositions.length; j += 3) {
-            localVector
-              .fromArray(geometryPositions, j)
-              .multiplyScalar(cubeSize)
-              .applyEuler(offsetEuler)
-              .add(offsetVector)
-              .toArray(positionArray, positionDstOffset + j);
-          }
-
-          const normalDstOffset = i*geometryNormals.length;
-          for (let j = 0; j < geometryNormals.length; j++) {
-            normalArray[normalDstOffset + j] = geometryNormals[j];
-          }
-
-          const indexDstOffset = i*geometryIndices.length;
-          const indexSrcOffset = i*geometryPositions.length/3;
-          for (let j = 0; j < geometryIndices.length; j++) {
-            indexArray[indexDstOffset + j] = geometryIndices[j] + indexSrcOffset;
-          }
-        }
-
-        const transformMatrix = localMatrix
-          .fromArray(window.document.xrOffset.matrix)
-          .getInverse(localMatrix)
-          .toArray(localFloat32Array);
-
-        const positionBuffer = gl.createBuffer();
-        gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
-        gl.bufferData(gl.ARRAY_BUFFER, positionArray, gl.STATIC_DRAW);
-        const positionCount = positionArray.length;
-
-        const normalBuffer = gl.createBuffer();
-        gl.bindBuffer(gl.ARRAY_BUFFER, normalBuffer);
-        gl.bufferData(gl.ARRAY_BUFFER, normalArray, gl.STATIC_DRAW);
-        const normalCount = normalArray.length;
-
-        const indexBuffer = gl.createBuffer();
-        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
-        gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indexArray, gl.STATIC_DRAW);
-        const count = indexArray.length;
-
-        renderer.state.reset();
-
-        const updates = [
-          {
-            id: 0,
-            type: 'update',
-            transformMatrix,
-            positionArray,
-            positionBuffer,
-            positionCount,
-            normalArray,
-            normalBuffer,
-            normalCount,
-            indexArray,
-            indexBuffer,
-            count,
-          },
-        ];
-        setInterval(() => {
-          _onMesh(updates);
-        }, 100);
-      } */
-
       renderer.setAnimationLoop(animate);
     }
 
@@ -308,6 +241,9 @@
       console.log('request session');
       const session = await display.requestSession({
         exclusive: true,
+        extensions: {
+          meshing: true,
+        },
       });
 
       // console.log('request first frame');
@@ -328,8 +264,12 @@
         renderer.vr.setDevice(display);
         renderer.vr.setAnimationLoop(animate);
         
-        mesher = session.requestMeshing();
-        mesher.onmesh = _onMesh;
+        session.addEventListener('meshadd', _meshadd);
+        session.addEventListener('meshupdate', _meshupdate);
+        session.addEventListener('meshremove', _meshremove);
+        
+        /* mesher = session.requestMeshing();
+        mesher.onmesh = _onMesh; */
 
         console.log('running!');
       });

--- a/examples/meshing_ml.html
+++ b/examples/meshing_ml.html
@@ -24,7 +24,7 @@
   <h1>meshing_ml</h1>
   <script src="three.js"></script>
   <script>
-    let container, scene, camera, display, model;
+    let container, scene, camera, display;
     // let mesher = null;
 
     /* const localVector = new THREE.Vector3();
@@ -95,52 +95,61 @@
       mesh.matrixAutoUpdate = false;
       mesh.frustumCulled = false;
       mesh.meshId = meshId;
+      mesh.visible = false;
       return mesh;
     };
     const _loadTerrainMesh = (terrainMesh, {transformMatrix, positionArray, normalArray, indexArray}) => {
-      terrainMesh.matrix.fromArray(transformMatrix);
-      terrainMesh.matrixWorldNeedsUpdate = true;
+      if (indexArray.length > 0) {
+        terrainMesh.matrix.fromArray(transformMatrix);
+        terrainMesh.matrix.decompose(terrainMesh.position, terrainMesh.quaternion, terrainMesh.scale);
+        terrainMesh.updateMatrixWorld(true);
 
-      const {geometry} = terrainMesh;
-      const attributes = renderer.getAttributes();
+        const {geometry} = terrainMesh;
+        // const attributes = renderer.getAttributes();
 
-      const positions = new Float32Array(indexArray.length*3);
-      const barycentrics = new Float32Array(indexArray.length*3);
-      for (let i = 0; i < indexArray.length; i += 3) {
-        const ai = indexArray[i];
-        const bi = indexArray[i+1];
-        const ci = indexArray[i+2];
+        const positions = new Float32Array(indexArray.length*3);
+        const barycentrics = new Float32Array(indexArray.length*3);
+        for (let i = 0; i < indexArray.length; i += 3) {
+          const ai = indexArray[i];
+          const bi = indexArray[i+1];
+          const ci = indexArray[i+2];
 
-        const baseA = ai*3;
-        const baseB = bi*3;
-        const baseC = ci*3;
+          const baseA = ai*3;
+          const baseB = bi*3;
+          const baseC = ci*3;
 
-        const baseIndex = i*3;
-        positions[baseIndex] = positionArray[baseA];
-        positions[baseIndex+1] = positionArray[baseA+1];
-        positions[baseIndex+2] = positionArray[baseA+2];
-        positions[baseIndex+3] = positionArray[baseB];
-        positions[baseIndex+4] = positionArray[baseB+1];
-        positions[baseIndex+5] = positionArray[baseB+2];
-        positions[baseIndex+6] = positionArray[baseC];
-        positions[baseIndex+7] = positionArray[baseC+1];
-        positions[baseIndex+8] = positionArray[baseC+2];
+          const baseIndex = i*3;
+          positions[baseIndex] = positionArray[baseA];
+          positions[baseIndex+1] = positionArray[baseA+1];
+          positions[baseIndex+2] = positionArray[baseA+2];
+          positions[baseIndex+3] = positionArray[baseB];
+          positions[baseIndex+4] = positionArray[baseB+1];
+          positions[baseIndex+5] = positionArray[baseB+2];
+          positions[baseIndex+6] = positionArray[baseC];
+          positions[baseIndex+7] = positionArray[baseC+1];
+          positions[baseIndex+8] = positionArray[baseC+2];
 
-        barycentrics[baseIndex] = 1;
-        barycentrics[baseIndex+1] = 0;
-        barycentrics[baseIndex+2] = 0;
-        barycentrics[baseIndex+3] = 0;
-        barycentrics[baseIndex+4] = 1;
-        barycentrics[baseIndex+5] = 0;
-        barycentrics[baseIndex+6] = 0;
-        barycentrics[baseIndex+7] = 0;
-        barycentrics[baseIndex+8] = 1;
+          barycentrics[baseIndex] = 1;
+          barycentrics[baseIndex+1] = 0;
+          barycentrics[baseIndex+2] = 0;
+          barycentrics[baseIndex+3] = 0;
+          barycentrics[baseIndex+4] = 1;
+          barycentrics[baseIndex+5] = 0;
+          barycentrics[baseIndex+6] = 0;
+          barycentrics[baseIndex+7] = 0;
+          barycentrics[baseIndex+8] = 1;
+        }
+        geometry.addAttribute('position', new THREE.BufferAttribute(positions, 3));
+        geometry.addAttribute('barycentric', new THREE.BufferAttribute(barycentrics, 3));
+
+        terrainMesh.visible = true;
+      } else {
+        terrainMesh.visible = false;
       }
-      geometry.addAttribute('position', new THREE.BufferAttribute(positions, 3));
-      geometry.addAttribute('barycentric', new THREE.BufferAttribute(barycentrics, 3));
     };
     const _removeTerrainMesh = terrainMesh => {
       scene.remove(terrainMesh);
+      terrainMeshes.splice(terrainMeshes.indexOf(terrainMesh), 1);
       terrainMesh.geometry.dispose();
     };
     /* const _clearTerrainMeshes = () => {
@@ -150,17 +159,19 @@
       terrainMeshes.length = 0;
     }; */
     const _meshadd = e => {
+      console.log('mesh add', e.update.id);
       _loadTerrainMesh(_getTerrainMesh(e.update.id), e.update);
     };
     const _meshupdate = e => {
-      _loadTerrainMesh(_getTerrainMesh(e.update.id), e.update);
+      console.log('mesh update', e.update.id);
+      _loadTerrainMesh(_getTerrainMesh(e.update.id), e.update, e.update.positionArray.length, e.update.normalArray.length, e.update.indexArray.length);
     };
     const _meshremove = e => {
+      console.log('mesh remove', e.update.id);
       const index = terrainMeshes.findIndex(terrainMesh => terrainMesh.meshId === e.update.id);
       if (index !== -1) {
         const terrainMesh = terrainMeshes[index];
         _removeTerrainMesh(terrainMesh);
-        terrainMeshes.splice(index, 1);
       }
     };
     /* const _onMesh = e => {
@@ -194,7 +205,7 @@
 
       camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
       // camera.position.set(0, 1, 0);
-      camera.lookAt(new THREE.Vector3());
+      // camera.lookAt(new THREE.Vector3());
       scene.add(camera);
 
       const ambientLight = new THREE.AmbientLight(0x808080);
@@ -220,7 +231,7 @@
     }
 
     function animate(time, frame) {
-      if (model) {
+      /* if (model) {
         const animationTime = 4000;
         const f = ((Date.now() % animationTime) / animationTime) * (Math.PI * 2);
         model.quaternion.setFromUnitVectors(
@@ -228,7 +239,7 @@
           new THREE.Vector3(Math.cos(f), 0, Math.sin(f)).normalize()
         );
         model.updateMatrixWorld();
-      }
+      } */
 
       renderer.render(scene, renderer.vr.enabled ? renderer.vr.getCamera(camera) : camera);
     }

--- a/examples/planes_ml.html
+++ b/examples/planes_ml.html
@@ -110,9 +110,39 @@
       }
       planeMeshes.length = 0;
     }; */
-    const _onPlanes = e => {
+    /* const _onPlanes = e => {
       const {updates} = e;
       _loadPlanes(updates);
+    }; */
+    const _planeadd = e => {
+      const {type, id, position, normal, scale} = e.update;
+
+      const planeMesh = new THREE.Object3D();
+      planeMesh.position.fromArray(position);
+      planeMesh.quaternion.setFromUnitVectors(
+        localVector.set(0, 0, 1),
+        localVector2.fromArray(normal)
+      );
+      planeMesh.scale.fromArray(scale);
+      planeMesh.planeId = id;
+
+      const plantMesh = (() => {
+        const index = Math.floor(Math.random() * plantMeshes.length);
+        const plantMesh = plantMeshes[index];
+        return plantMesh.clone();
+      })();
+      planeMesh.add(plantMesh);
+
+      scene.add(planeMesh);
+      planeMeshes.push(planeMesh);
+    };
+    const _planeremove = e => {
+      const index = planeMeshes.findIndex(planeMesh => planeMesh.planeId === e.update.id);
+      if (index !== -1) {
+        const planeMesh = planeMeshes[index];
+        scene.remove(planeMesh);
+        planeMeshes.splice(index, 1);
+      }
     };
 
     async function init() {
@@ -188,6 +218,9 @@
       // console.log('request session');
       const session = await display.requestSession({
         exclusive: true,
+        extensions: {
+          planesTracking: true,
+        },
       });
       display.session = session;
 
@@ -212,9 +245,11 @@
         _loadPlantMeshes()
           .then(newPlantMeshes => {
             plantMeshes = newPlantMeshes;
-            
-            planeTracker = session.requestPlaneTracking();
-            planeTracker.onplanes = _onPlanes;
+
+            session.addEventListener('planeadd', _planeadd);
+            session.addEventListener('planeremove', _planeremove);
+            /* planeTracker = session.requestPlaneTracking();
+            planeTracker.onplanes = _onPlanes; */
           })
           .catch(err => {
             console.warn(err.stack);

--- a/examples/planes_ml.html
+++ b/examples/planes_ml.html
@@ -10,7 +10,7 @@
     if('serviceWorker' in navigator) {
       navigator.serviceWorker.register('/planes_ml_sw.js')
         .then(function() {
-              console.log('Service Worker Registered');
+          console.log('Service Worker Registered');
         });
     }
    </script>
@@ -67,7 +67,7 @@
     const planeMaterial2 = new THREE.MeshPhongMaterial({
       color: 0x673ab7,
     }); */
-    const _loadPlanes = updates => {
+    /* const _loadPlanes = updates => {
       // _clearPlanes();
 
       for (let i = 0; i < updates.length; i++) {
@@ -102,7 +102,7 @@
           }
         }
       }
-    };
+    }; */
     /* const _clearPlanes = () => {
       for (let i = 0; i < planeMeshes.length; i++) {
         const planeMesh = planeMeshes[i];
@@ -115,7 +115,8 @@
       _loadPlanes(updates);
     }; */
     const _planeadd = e => {
-      const {type, id, position, normal, scale} = e.update;
+      const {type, id, position, normal, size} = e.update;
+      console.log('plane add', id);
 
       const planeMesh = new THREE.Object3D();
       planeMesh.position.fromArray(position);
@@ -123,7 +124,7 @@
         localVector.set(0, 0, 1),
         localVector2.fromArray(normal)
       );
-      planeMesh.scale.fromArray(scale);
+      // planeMesh.scale.set(size[0], size[1], 1);
       planeMesh.planeId = id;
 
       const plantMesh = (() => {
@@ -136,7 +137,23 @@
       scene.add(planeMesh);
       planeMeshes.push(planeMesh);
     };
+    const _planeupdate = e => {
+      console.log('plane update', e.update.id);
+
+      const planeMesh = planeMeshes.find(planeMesh => planeMesh.planeId === e.update.id);
+      if (planeMesh) {
+      const {position, normal, size} = e.update;
+        planeMesh.position.fromArray(position);
+        planeMesh.quaternion.setFromUnitVectors(
+          localVector.set(0, 0, 1),
+          localVector2.fromArray(normal)
+        );
+        // planeMesh.scale.set(size[0], size[1], 1);
+      }
+    };
     const _planeremove = e => {
+      console.log('plane remove', e.update.id);
+
       const index = planeMeshes.findIndex(planeMesh => planeMesh.planeId === e.update.id);
       if (index !== -1) {
         const planeMesh = planeMeshes[index];
@@ -219,7 +236,7 @@
       const session = await display.requestSession({
         exclusive: true,
         extensions: {
-          planesTracking: true,
+          planeTracking: true,
         },
       });
       display.session = session;

--- a/src/Event.js
+++ b/src/Event.js
@@ -259,6 +259,19 @@ class PromiseRejectionEvent extends Event {
 }
 module.exports.PromiseRejectionEvent = PromiseRejectionEvent;
 
+class SpatialEvent extends Event {
+  constructor(type, init = {}) {
+    super(type);
+
+    if (init.detail) {
+      for (const k in init.detail) {
+        this[k] = init.detail[k];
+      }
+    }
+  }
+}
+module.exports.SpatialEvent = SpatialEvent;
+
 class CustomEvent extends Event {
   constructor(type, init = {}) {
     super(type, init);

--- a/src/VR.js
+++ b/src/VR.js
@@ -152,7 +152,9 @@ class Gamepad {
   get connected() {
     return this._xrGamepad.connected[0] !== 0;
   }
-  set connected(connected) {}
+  set connected(connected) {
+    this._xrGamepad.connected[0] = connected ? 1 : 0;
+  }
 
   /* copy(gamepad) {
     this.connected = gamepad.connected;

--- a/src/VR.js
+++ b/src/VR.js
@@ -687,7 +687,6 @@ class FakeVRDisplay extends VRDisplay {
       });
     };
 
-    this._onends = [];
     this._lastPresseds = [false, false];
 
     // this._frameData = new VRFrameData();
@@ -727,16 +726,28 @@ class FakeVRDisplay extends VRDisplay {
     let planesTracker;
     let eyeTracker;
     const session = {
+      listeners: [],
       addEventListener(e, fn) {
-        if (e === 'end') {
-          self._onends.push(fn);
+        if (!this.listeners[e]) {
+          this.listeners[e] = [];
         }
+        this.listeners[e].push(fn);
       },
       removeEventListener(e, fn) {
-        if (e === 'end') {
-          const index = self._onends.indexOf(fn);
+        const listeners = this.listeners[e];
+        if (listeners) {
+          const index = listeners.indexOf(fn);
           if (index !== -1) {
-            self._onends.splice(index, 1);
+            listeners.splice(index, 1);
+          }
+        }
+      },
+      dispatchEvent(e) {
+        let listeners = this.listeners[e.type];
+        if (listeners) {
+          listeners = listeners.slice();
+          for (let i = 0; i < listeners.length; i++) {
+            listeners[i](e);
           }
         }
       },
@@ -777,7 +788,7 @@ class FakeVRDisplay extends VRDisplay {
         xrState.fakeVrDisplayEnabled[0] = 1;
         self.session = null;
 
-        const onends = self._onends.slice();
+        const onends = self.listeners['end'].slice();
         for (let i = 0; i < onends.length; i++) {
           onends[i]();
         }

--- a/src/VR.js
+++ b/src/VR.js
@@ -577,9 +577,10 @@ class FakeVRDisplay extends VRDisplay {
     this.position = new THREE.Vector3();
     this.quaternion = new THREE.Quaternion();
 
-    const _makeGamepad = (hand, targetRayMode, xrStateGamepad) => {
-      const gamepad = new Gamepad('', hand, xrStateGamepad, null);
-
+    if (!globalGamepads) {
+      globalGamepads = _makeGlobalGamepads();
+    }
+    const _decorateGamepad = (gamepad, targetRayMode) => {
       gamepad.handedness = gamepad.hand;
       gamepad.targetRayMode = targetRayMode;
       gamepad.pose.targetRay = {
@@ -587,27 +588,27 @@ class FakeVRDisplay extends VRDisplay {
         direction: new GlobalContext.DOMPoint(0, 0, -1),
         transformMatrix: Float32Array.from([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]),
       };
-      gamepad.pose.targetRay.origin.values = xrStateGamepad.position;
-      gamepad.pose.targetRay.direction.values = xrStateGamepad.direction;
-      gamepad.pose._localPointerMatrix = xrStateGamepad.transformMatrix;
-      
-      return gamepad;
+      gamepad.pose.targetRay.origin.values = gamepad._xrGamepad.position;
+      gamepad.pose.targetRay.direction.values = gamepad._xrGamepad.direction;
+      gamepad.pose._localPointerMatrix = gamepad._xrGamepad.transformMatrix;
     };
-    this.gamepads = [
-      _makeGamepad('left', 'tracked-pointer', GlobalContext.xrState.gamepads[0]),
-      _makeGamepad('right', 'tracked-pointer', GlobalContext.xrState.gamepads[1]),
-    ];
-    
-    this.handGamepads = [
-      _makeGamepad('left', 'hand', GlobalContext.xrState.hands[0]),
-      _makeGamepad('right', 'hand', GlobalContext.xrState.hands[1]),
-    ];
-    for (let i = 0; i < this.handGamepads.length; i++) {
-      const handGamepad = this.handGamepads[i];
+    for (let i = 0; i < globalGamepads.main.length; i++) {
+      _decorateGamepad(globalGamepads.main[i], 'tracked-pointer');
+    }
+    for (let i = 0; i < globalGamepads.tracker.length; i++) {
+      _decorateGamepad(globalGamepads.tracker[i], 'tracked-pointer');
+    }
+    for (let i = 0; i < globalGamepads.hand.length; i++) {
+      _decorateGamepad(globalGamepads.hand[i], 'hand');
+    }
+    _decorateGamepad(globalGamepads.eye, 'gaze');
+
+    for (let i = 0; i < globalGamepads.hand.length; i++) {
+      const handGamepad = globalGamepads.hand[i];
       const hand = handGamepad._xrGamepad;
-      
-      handGamepad.wrist = hand.wrist;
-      handGamepad.fingers = hand.fingers;
+
+      /* handGamepad.wrist = hand.wrist;
+      handGamepad.fingers = hand.fingers; */
 
       const offsetMatrix = new Float32Array(16);
       Object.defineProperty(handGamepad, 'offsetMatrix', {
@@ -637,13 +638,11 @@ class FakeVRDisplay extends VRDisplay {
         },
       });
     }
-
     {
-      const eyeGamepad = _makeGamepad('', 'gaze', GlobalContext.xrState.eye);
-      const eye = eyeGamepad._xrGamepad;
+      const eye = globalGamepads.eye._xrGamepad;
 
       const offsetMatrix = new Float32Array(16);
-      Object.defineProperty(eyeGamepad, 'offsetMatrix', {
+      Object.defineProperty(globalGamepads.eye, 'offsetMatrix', {
         get: () => {
           /* localMatrix.compose(
             localVector.fromArray(eye.position),
@@ -652,7 +651,7 @@ class FakeVRDisplay extends VRDisplay {
           ); */
 
           localMatrix.compose(
-            localVector.fromArray(eye.position),
+            localVector.fromArray(GlobalContext.xrState.eye.position),
             localQuaternion.fromArray(eye.orientation),
             localVector2.set(1, 1, 1)
           );
@@ -676,8 +675,6 @@ class FakeVRDisplay extends VRDisplay {
           return offsetMatrix;
         },
       });
-
-      this.eyeGamepad = eyeGamepad;
     }
 
     this.onrequestanimationframe = fn => window.requestAnimationFrame(fn);
@@ -767,14 +764,7 @@ class FakeVRDisplay extends VRDisplay {
       baseLayer: null,
       _frame: null, // defer
       getInputSources() {
-        const gamepads = this.device.gamepads.slice();
-        if (GlobalContext.xrState.handTracking[0]) {
-          gamepads.push.apply(gamepads, this.device.handGamepads);
-        }
-        if (GlobalContext.xrState.eyeTracking[0]) {
-          gamepads.push(this.device.eyeGamepad);
-        }
-        return gamepads;
+        return getGamepads();
       },
       requestFrameOfReference() {
         return Promise.resolve({});
@@ -928,8 +918,8 @@ class FakeVRDisplay extends VRDisplay {
     GlobalContext.xrState.rightViewMatrix.set(GlobalContext.xrState.leftViewMatrix);
 
     // update gamepads
-    for (let i = 0; i < this.gamepads.length; i++) {
-      const gamepad = this.gamepads[i];
+    for (let i = 0; i < globalGamepads.main.length; i++) {
+      const gamepad = globalGamepads.main[i];
       localVector.copy(this.position)
         .add(
           localVector2.set(-0.3 + i*0.6, -0.3, -0.35)
@@ -945,14 +935,14 @@ class FakeVRDisplay extends VRDisplay {
         )
         .toArray(gamepad.pose._localPointerMatrix);
 
-      GlobalContext.xrState.gamepads[i].connected[0] = 1;
+      gamepad.connected = true;
     }
   }
 
   update() {
     const _updateGamepadEvents = () => {
-      for (let i = 0; i < this.gamepads.length; i++) {
-        const gamepad = this.gamepads[i];
+      for (let i = 0; i < globalGamepads.main.length; i++) {
+        const gamepad = globalGamepads.main[i];
         const pressed = gamepad.buttons[1].pressed;
         const lastPressed = this._lastPresseds[i];
         if (pressed && !lastPressed) {
@@ -1038,9 +1028,7 @@ const controllerIDs = {
 function getControllerID(hmdType, hand) {
   return controllerIDs[hmdType] || controllerIDs[hmdType + hand.charAt(0).toUpperCase() + hand.slice(1)];
 }
-
-let gamepads = null;
-function getGamepads(window) {
+function getGamepads() {
   if (GlobalContext.xrState.isPresenting[0]) {
     const hmdType = getHMDType();
     if (!globalGamepads) {

--- a/src/VR.js
+++ b/src/VR.js
@@ -510,7 +510,7 @@ class FakeMesher extends EventEmitter {
   }
 }
 
-class FakePlanesTracker extends EventEmitter {
+class FakePlaneTracker extends EventEmitter {
   constructor() {
     super();
 
@@ -723,8 +723,8 @@ class FakeVRDisplay extends VRDisplay {
     if (extensions.meshing) {
       xrState.meshing[0] = 1;
     }
-    if (extensions.planesTracking) {
-      xrState.planesTracking[0] = 1;
+    if (extensions.planeTracking) {
+      xrState.planeTracking[0] = 1;
     }
     if (extensions.handTracking) {
       xrState.handTracking[0] = 1;
@@ -1044,7 +1044,7 @@ GlobalContext.getGamepads = getGamepads;
 module.exports = {
   VRDisplay,
   FakeMesher,
-  FakePlanesTracker,
+  FakePlaneTracker,
   FakeVRDisplay,
   VRFrameData,
   VRPose,

--- a/src/VR.js
+++ b/src/VR.js
@@ -940,7 +940,7 @@ class FakeVRDisplay extends VRDisplay {
       const gamepad = this.gamepads[i];
       localVector.copy(this.position)
         .add(
-          localVector2.set(-0.3 + i*0.6, -0.3, 0)
+          localVector2.set(-0.3 + i*0.6, -0.3, -0.35)
             .applyQuaternion(this.quaternion)
         ).toArray(gamepad.pose.position);
       this.quaternion.toArray(gamepad.pose.orientation); // XXX updates xrState

--- a/src/VR.js
+++ b/src/VR.js
@@ -356,18 +356,6 @@ class VRDisplay extends EventEmitter {
   }
 }
 
-class SpatialEvent extends Event {
-  constructor(type, init = {}) {
-    super(type);
-
-    if (init.detail) {
-      for (const k in init.detail) {
-        this[k] = init.detail[k];
-      }
-    }
-  }
-}
-
 class FakeMesher extends EventTarget {
   constructor(session) {
     super();

--- a/src/Window.js
+++ b/src/Window.js
@@ -1603,6 +1603,7 @@ global.onrunasync = request => {
                   localQuaternion.fromArray(xrOffset.orientation),
                   localVector2.fromArray(xrOffset.scale)
                 )
+                .getInverse(localMatrix2)
               )
               .toArray(update.transformMatrix);          
           }
@@ -1628,7 +1629,7 @@ global.onrunasync = request => {
           localVector.fromArray(xrOffset.position),
           localQuaternion.fromArray(xrOffset.orientation),
           localVector2.fromArray(xrOffset.scale)
-        );
+        ).getInverse(localMatrix);
       }
       
       const presentingVrDisplays = [

--- a/src/Window.js
+++ b/src/Window.js
@@ -637,7 +637,7 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
       }
       return window[symbols.mrDisplaysSymbol].fakeVrDisplay;
     },
-    getGamepads: getGamepads.bind(null, window),
+    getGamepads,
     clipboard: {
       read: () => Promise.resolve(), // Not implemented yet
       readText: () => new Promise(resolve => {

--- a/src/Window.js
+++ b/src/Window.js
@@ -1560,6 +1560,24 @@ global.onrunasync = request => {
       }
       break;
     }
+    case 'keyEvent': {
+      const {event} = request;
+      switch (event.type) {
+        case 'keydown':
+        case 'keypress':
+        case 'keyup': {
+          if (vrPresentState.glContext) {
+            const {canvas} = vrPresentState.glContext;
+            canvas.dispatchEvent(new global.KeyboardEvent(event.type, event));
+          }
+          break;
+        }
+        default: {
+          break;
+        }
+      }
+      break;
+    }
     case 'meshes': {
       for (let i = 0; i < windows.length; i++) {
         windows[i].runAsync(request);

--- a/src/Window.js
+++ b/src/Window.js
@@ -1639,7 +1639,7 @@ global.onrunasync = request => {
         const presentingVrDisplay = presentingVrDisplays[0];
         for (let i = 0; i < request.updates.length; i++) {
           const update = request.updates[i];
-          if (xrOffset) { // XXX
+          if (update.position && xrOffset) { // XXX
             localVector.fromArray(update.position).applyMatrix4(localMatrix).toArray(update.position);
             localVector.fromArray(update.normal).applyQuaternion(localQuaternion).toArray(update.normal);
           }

--- a/src/Window.js
+++ b/src/Window.js
@@ -1641,7 +1641,7 @@ global.onrunasync = request => {
           const update = request.updates[i];
           if (xrOffset) { // XXX
             localVector.fromArray(update.position).applyMatrix4(localMatrix).toArray(update.position);
-            localVector.fromArray(update.normal).applyMatrix4(localMatrix).toArray(update.normal);
+            localVector.fromArray(update.normal).applyQuaternion(localQuaternion).toArray(update.normal);
           }
           const e = new SpatialEvent(update.type, {
             detail: {

--- a/src/Window.js
+++ b/src/Window.js
@@ -12,7 +12,6 @@ const {parentPort} = require('worker_threads');
 const util = require('util');
 const {URL} = url;
 const {TextEncoder, TextDecoder} = util;
-const {XRRigidTransform} = require('./XR.js');
 const {performance} = require('perf_hooks');
 const {
   workerData: {
@@ -26,6 +25,7 @@ const {
   },
 } = require('worker_threads');
 
+const {XRRigidTransform} = require('./XR.js');
 const {WorkerVm} = require('./WindowVm.js');
 const {FileReader} = require('./File.js');
 

--- a/src/Window.js
+++ b/src/Window.js
@@ -1199,7 +1199,7 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
     }
   };
   window.tickAnimationFrame = async () => {
-    const _emitXrEvents = () => {
+    const _updateLocalXr = () => {
       if (vrPresentState.hmdType === 'fake') {
         window[symbols.mrDisplaysSymbol].fakeVrDisplay.update();
       }
@@ -1325,7 +1325,7 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
       clearTimeout(timeout);
     };
     
-    _emitXrEvents();
+    _updateLocalXr();
 
     const childPromises = _renderChildren();
     _renderLocal();

--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -114,7 +114,7 @@ parentPort.on('message', m => {
     case 'runAsync': {
       let result, err;
       try {
-        result = window.onrunasync ? window.onrunasync(m.jsString) : null;
+        result = window.onrunasync ? window.onrunasync(m.request) : null;
       } catch(e) {
         err = e.stack;
       }

--- a/src/XR.js
+++ b/src/XR.js
@@ -57,8 +57,21 @@ class XRDevice {
   supportsSession() {
     return Promise.resolve(null);
   }
-  async requestSession({exclusive = false, outputContext = null} = {}) {
+  async requestSession({exclusive = false, outputContext = null, extensions = {}} = {}) {
     if (!this.session) {
+      if (extensions.meshing) {
+        GlobalContext.xrState.meshing[0] = 1;
+      }
+      if (extensions.planeTracking) {
+        GlobalContext.xrState.planeTracking[0] = 1;
+      }
+      if (extensions.handTracking) {
+        GlobalContext.xrState.handTracking[0] = 1;
+      }
+      if (extensions.eyeTracking) {
+        GlobalContext.xrState.eyeTracking[0] = 1;
+      }
+      
       const session = new XRSession({
         device: this,
         exclusive,

--- a/src/XR.js
+++ b/src/XR.js
@@ -535,7 +535,9 @@ class XRInputSource {
   get connected() {
     return this._xrStateGamepad.connected[0] !== 0;
   }
-  set connected(connected) {}
+  set connected(connected) {
+    this._xrStateGamepad.connected[0] = connected ? 1 : 0;
+  }
 }
 module.exports.XRInputSource = XRInputSource;
 

--- a/src/XR.js
+++ b/src/XR.js
@@ -98,7 +98,7 @@ class XRSession extends EventTarget {
 
     this._frame = new XRPresentationFrame(this);
     this._frameOfReference = new XRFrameOfReference();
-    this._inputSources = (() => {
+    this._gamepadInputSources = (() => {
       const result = Array(2 + maxNumTrackers);
       for (let i = 0; i < maxNumTrackers; i++) {
         let hand, targetRayMode;
@@ -112,10 +112,23 @@ class XRSession extends EventTarget {
           hand = null;
           targetRayMode = 'tracker';
         }
-        result[i] = new XRInputSource(hand, targetRayMode, i);
+        result[i] = new XRInputSource(hand, targetRayMode, GlobalContext.xrState.gamepads[i]);
       }
       return result;
     })();
+    this._handInputSources = (() => {
+      const result = [
+        new XRInputSource('left', 'hand', GlobalContext.xrState.hands[0]),
+        new XRInputSource('right', 'hand', GlobalContext.xrState.hands[1]),
+      ];
+      for (let i = 0; i < result.length; i++) {
+        const inputSource = result[i];
+        inputSource.wrist = inputSource._xrStateGamepad.wrist;
+        inputSource.fingers = inputSource._xrStateGamepad.fingers;
+      }
+      return result;
+    })();
+    this._eyeInputSource = new XRInputSource('', 'gaze', GlobalContext.xrState.eye);
     this._lastPresseds = [false, false];
     this._rafs = [];
   }
@@ -151,7 +164,14 @@ class XRSession extends EventTarget {
     return Promise.resolve(this._frameOfReference);
   }
   getInputSources() {
-    return this._inputSources.filter(inputSource => inputSource.connected);
+    const inputSources = this._gamepadInputSources.filter(inputSource => inputSource.connected);
+    if (GlobalContext.xrState.handTracking[0]) {
+      inputSources.push.apply(inputSources, this._handInputSources);
+    }
+    if (GlobalContext.xrState.eyeTracking[0]) {
+      inputSources.push(this._eyeInputSource);
+    }
+    return inputSources;
   }
   requestAnimationFrame(fn) {
     if (this.device.onrequestanimationframe) {
@@ -189,12 +209,13 @@ class XRSession extends EventTarget {
     return Promise.resolve();
   }
   update() {
-    const gamepads = GlobalContext.getGamepads(this.device.window);
-    
-    for (let i = 0; i < gamepads.length; i++) {
+    const inputSources = this.getInputSources();
+    const gamepads = GlobalContext.getGamepads();
+
+    for (let i = 0; i < inputSources.length; i++) {
+      const inputSource = inputSources[i];
       const gamepad = gamepads[i];
-      const inputSource = this._inputSources[i];
-      
+
       const pressed = gamepad.buttons[1].pressed;
       const lastPressed = this._lastPresseds[i];
       if (pressed && !lastPressed) {
@@ -417,7 +438,7 @@ class XRPresentationFrame {
 
     if (this.session.baseLayer) {
       const {xrOffset} = this.session.baseLayer.context.canvas.ownerDocument;
-      
+
       if (xrOffset) {
         localMatrix
           .premultiply(
@@ -430,7 +451,7 @@ class XRPresentationFrame {
       .toArray(inputSource._pose.targetRay.transformMatrix)
     localMatrix
       .toArray(inputSource._pose.gripMatrix);
-    
+
     return inputSource._pose;
   }
 }
@@ -501,19 +522,18 @@ class XRDevicePose {
 module.exports.XRDevicePose = XRDevicePose;
 
 class XRInputSource {
-  constructor(handedness = 'left', targetRayMode = 'tracked-pointer', index = 0) {
+  constructor(handedness, targetRayMode, xrStateGamepad) {
     this.handedness = handedness;
     this.targetRayMode = targetRayMode;
-    this._index = index;
+    this._xrStateGamepad = xrStateGamepad;
 
     this._pose = new XRInputPose();
-    const gamepad = GlobalContext.xrState.gamepads[index];
-    this._pose.targetRay.origin.values = gamepad.position;
-    this._pose.targetRay.direction.values = gamepad.direction;
-    this._pose._localPointerMatrix = gamepad.transformMatrix;
+    this._pose.targetRay.origin.values = xrStateGamepad.position;
+    this._pose.targetRay.direction.values = xrStateGamepad.direction;
+    this._pose._localPointerMatrix = xrStateGamepad.transformMatrix;
   }
   get connected() {
-    return GlobalContext.xrState.gamepads[this._index].connected[0] !== 0;
+    return this._xrStateGamepad.connected[0] !== 0;
   }
   set connected(connected) {}
 }

--- a/src/XR.js
+++ b/src/XR.js
@@ -88,18 +88,18 @@ class XRSession extends EventTarget {
     this._inputSources = (() => {
       const result = Array(2 + maxNumTrackers);
       for (let i = 0; i < maxNumTrackers; i++) {
-        let hand, pointerOrigin;
+        let hand, targetRayMode;
         if (i === 0) {
           hand = 'left';
-          pointerOrigin = 'hand';
+          targetRayMode = 'tracked-pointer';
         } else if (i === 1) {
           hand = 'right';
-          pointerOrigin = 'hand';
+          targetRayMode = 'tracked-pointer';
         } else {
           hand = null;
-          pointerOrigin = 'tracker';
+          targetRayMode = 'tracker';
         }
-        result[i] = new XRInputSource(hand, pointerOrigin, i);
+        result[i] = new XRInputSource(hand, targetRayMode, i);
       }
       return result;
     })();
@@ -488,9 +488,9 @@ class XRDevicePose {
 module.exports.XRDevicePose = XRDevicePose;
 
 class XRInputSource {
-  constructor(handedness = 'left', pointerOrigin = 'hand', index = 0) {
+  constructor(handedness = 'left', targetRayMode = 'tracked-pointer', index = 0) {
     this.handedness = handedness;
-    this.pointerOrigin = pointerOrigin;
+    this.targetRayMode = targetRayMode;
     this._index = index;
 
     this._pose = new XRInputPose();

--- a/src/index.js
+++ b/src/index.js
@@ -303,7 +303,6 @@ const xrState = (() => {
   })();
   result.eye = _makeGamepad();
   result.id = _makeTypedArray(Uint32Array, 1);
-  result.vrRequest = _makeTypedArray(Uint32Array, 2);
   result.tex = _makeTypedArray(Uint32Array, 1);
   result.depthTex = _makeTypedArray(Uint32Array, 1);
   result.hidden = _makeTypedArray(Uint32Array, 1);
@@ -1147,7 +1146,7 @@ const _startTopRenderLoop = () => {
     }
 
     // tick animation frames
-    await Promise.all(windows.map(window => window.runAsync('tickAnimationFrame')));
+    await Promise.all(windows.map(window => window.runAsync({method: 'tickAnimationFrame'})));
 
     if (args.performance) {
       const now = Date.now();

--- a/src/index.js
+++ b/src/index.js
@@ -197,7 +197,7 @@ const xrState = (() => {
       return result;
     };
   };
-  const _makeTypedArray = _makeSab(4*1024);
+  const _makeTypedArray = _makeSab(8*1024);
 
   const result = {};
   result.isPresenting = _makeTypedArray(Uint32Array, 1);

--- a/src/index.js
+++ b/src/index.js
@@ -278,7 +278,7 @@ const xrState = (() => {
     for (let i = 0; i < result.length; i++) {
       const hand = _makeGamepad();
       hand.wrist = (() => {
-        const result = Array(3);
+        const result = Array(4);
         for (let i = 0; i < result.length; i++) {
           result[i] = _makeTypedArray(Float32Array, 3);
         }

--- a/src/index.js
+++ b/src/index.js
@@ -1062,21 +1062,11 @@ const _startTopRenderLoop = () => {
       
       const _updatePlanes = () => {
         if (xrState.planeTracking[0] && !topVrPresentState.planeTracker) {
-          const planeTracker = new FakePlaneTracker();
-          planeTracker.on('planes', updates => {
-            const request = {
-              method: 'planes',
-              updates,
-            };
-            for (let i = 0; i < windows.length; i++) {
-              windows[i].runAsync(request);
-            }
-          });
-          topVrPresentState.planeTracker = planeTracker;
-        } else if (!xrState.planeTracking[0] && topVrPresentState.planeTracker) {
+          _startFakePlaneTracker();
+        } /* else if (!xrState.planeTracking[0] && topVrPresentState.planeTracker) {
           topVrPresentState.planeTracker.destroy();
           topVrPresentState.planeTracker = null;
-        }
+        } */
       };
       _updatePlanes();
 

--- a/src/index.js
+++ b/src/index.js
@@ -1052,21 +1052,11 @@ const _startTopRenderLoop = () => {
 
       const _updateMeshing = () => {
         if (xrState.meshing[0] && !topVrPresentState.mesher) {
-          const mesher = new FakeMesher();
-          mesher.on('meshes', updates => {
-            const request = {
-              method: 'meshes',
-              updates,
-            };
-            for (let i = 0; i < windows.length; i++) {
-              windows[i].runAsync(request);
-            }
-          });
-          topVrPresentState.mesher = mesher;
-        } else if (!xrState.meshing[0] && topVrPresentState.mesher) {
+          _startFakeMesher();
+        } /* else if (!xrState.meshing[0] && topVrPresentState.mesher) {
           topVrPresentState.mesher.destroy();
           topVrPresentState.mesher = null;
-        }
+        } */
       };
       _updateMeshing();
       

--- a/src/index.js
+++ b/src/index.js
@@ -1030,27 +1030,6 @@ const _startTopRenderLoop = () => {
           topVrPresentState.handTracker.waitGetPoses(xrState.hands);
         }
         if (topVrPresentState.eyeTracker) {
-          /* const blink = (Date.now() % 2000) < 200;
-          const blinkAxis = blink ? -1 : 1;
-
-          const eye = xrState.eye;
-          localMatrix
-            .fromArray(GlobalContext.xrState.leftViewMatrix)
-            .getInverse(localMatrix)
-            .decompose(localVector, localQuaternion, localVector2);
-          localVector
-            .add(
-              localVector2.set(0, 0, -1)
-                .applyQuaternion(localQuaternion)
-            )
-            .toArray(eye.position);
-          localQuaternion.toArray(eye.orientation);
-          // localVector.set(0, 0, -1).toArray(eye.position);
-          // localQuaternion.set(0, 0, 0, 1).toArray(eye.orientation);
-
-          eye.axes[0] = blinkAxis;
-          eye.axes[1] = blinkAxis; */
-
           topVrPresentState.eyeTracker.waitGetPoses(xrState.eye);
         }
       };

--- a/src/index.js
+++ b/src/index.js
@@ -1274,6 +1274,33 @@ const _startTopRenderLoop = () => {
 };
 _startTopRenderLoop();
 
+const _startFakeMesher = () => {
+  const mesher = new FakeMesher();
+  mesher.on('meshes', updates => {
+    const request = {
+      method: 'meshes',
+      updates,
+    };
+    for (let i = 0; i < windows.length; i++) {
+      windows[i].runAsync(request);
+    }
+  });
+  topVrPresentState.mesher = mesher;
+};
+const _startFakePlaneTracker = () => {
+  const planeTracker = new FakePlaneTracker();
+  planeTracker.on('planes', updates => {
+    const request = {
+      method: 'planes',
+      updates,
+    };
+    for (let i = 0; i < windows.length; i++) {
+      windows[i].runAsync(request);
+    }
+  });
+  topVrPresentState.planeTracker = planeTracker;
+};
+
 const _prepare = () => Promise.all([
   (() => {
     if (!process.env['DISPLAY']) {

--- a/src/index.js
+++ b/src/index.js
@@ -479,7 +479,10 @@ const exitPresent = async () => {
 };
 GlobalContext.exitPresent = exitPresent;
 const requestHitTest = (origin, direction, coordinateSystem) => {
-  if (topVrPresentState.mesher) {
+  if (topVrPresentState.hmdType === 'fake') {
+    if (!topVrPresentState.mesher) {
+      _startFakeMesher();
+    }
     return topVrPresentState.mesher.requestHitTest(origin, direction, coordinateSystem);
   } else {
     return Promise.resolve([]);

--- a/src/index.js
+++ b/src/index.js
@@ -279,6 +279,10 @@ const xrState = (() => {
   result.depthTex = _makeTypedArray(Uint32Array, 1);
   result.hidden = _makeTypedArray(Uint32Array, 1);
   result.fakeVrDisplayEnabled = _makeTypedArray(Uint32Array, 1);
+  result.meshing = _makeTypedArray(Uint32Array, 1);
+  result.planesTracking = _makeTypedArray(Uint32Array, 1);
+  result.handTracking = _makeTypedArray(Uint32Array, 1);
+  result.eyeTracking = _makeTypedArray(Uint32Array, 1);
 
   return result;
 })();

--- a/src/index.js
+++ b/src/index.js
@@ -484,6 +484,8 @@ const requestHitTest = (origin, direction, coordinateSystem) => {
       _startFakeMesher();
     }
     return topVrPresentState.mesher.requestHitTest(origin, direction, coordinateSystem);
+  } else if (topVrPresentState.hmdType === 'magicleap') {
+    return topVrPresentState.vrContext.requestHitTest(origin, direction, coordinateSystem);
   } else {
     return Promise.resolve([]);
   }
@@ -971,33 +973,33 @@ const _startTopRenderLoop = () => {
 
       const _loadExtensions = () => {
         if (xrState.meshing[0] && !topVrPresentState.mesher) {
-          topVrPresentState.mesher = topVrPresentState.vrContext.requestMeshing();
-        } else if (!xrState.meshing[0] && topVrPresentState.mesher) {
+          topVrPresentState.mesher = topVrPresentState.vrContext.requestMeshing(5, 2);
+        } /* else if (!xrState.meshing[0] && topVrPresentState.mesher) {
           topVrPresentState.mesher.destroy();
           topVrPresentState.mesher = null;
-        }
+        } */
         if (xrState.planeTracking[0] && !topVrPresentState.planeTracker) {
-          topVrPresentState.planeTracker = topVrPresentState.vrContext.requestPlaneTracking();
-        } else if (!xrState.planeTracking[0] && topVrPresentState.planeTracker) {
+          topVrPresentState.planeTracker = topVrPresentState.vrContext.requestPlaneTracking(10);
+        } /* else if (!xrState.planeTracking[0] && topVrPresentState.planeTracker) {
           topVrPresentState.planeTracker.destroy();
           topVrPresentState.planeTracker = null;
-        }
+        } */
         if (xrState.handTracking[0] && !topVrPresentState.handTracker) {
           topVrPresentState.handTracker = topVrPresentState.vrContext.requestHandTracking();
-        } else if (!xrState.handTracking[0] && topVrPresentState.handTracker) {
+        } /* else if (!xrState.handTracking[0] && topVrPresentState.handTracker) {
           topVrPresentState.handTracker.destroy();
           topVrPresentState.handTracker = null;
-        }
+        } */
         if (xrState.eyeTracking[0] && !topVrPresentState.eyeTracker) {
           topVrPresentState.eyeTracker = topVrPresentState.vrContext.requestEyeTracking();
-        } else if (!xrState.eyeTracking[0] && topVrPresentState.eyeTracker) {
+        } /* else if (!xrState.eyeTracking[0] && topVrPresentState.eyeTracker) {
           topVrPresentState.eyeTracker.destroy();
           topVrPresentState.eyeTracker = null;
-        }
+        } */
       };
       _loadExtensions();
 
-      nativeBindings.nativeMl.Update(topVrPresentState.vrContext);
+      topVrPresentState.vrContext.update();
 
       const _waitExtensions = () => {
         if (topVrPresentState.mesher) {

--- a/src/index.js
+++ b/src/index.js
@@ -273,6 +273,35 @@ const xrState = (() => {
     }
     return result;
   })();
+  result.hands = (() => {
+    const result = Array(2);
+    for (let i = 0; i < result.length; i++) {
+      const hand = _makeGamepad();
+      hand.wrist = (() => {
+        const result = Array(3);
+        for (let i = 0; i < result.length; i++) {
+          result[i] = _makeTypedArray(Float32Array, 3);
+        }
+        return result;
+      })();
+      hand.fingers = (() => {
+        const result = Array(5);
+        for (let i = 0; i < result.length; i++) {
+          result[i] = (() => {
+            const result = Array(4);
+            for (let i = 0; i < result.length; i++) {
+              result[i] = _makeTypedArray(Float32Array, 3);
+            }
+            return result;
+          })();
+        }
+        return result;
+      })();
+      result[i] = hand;
+    }
+    return result;
+  })();
+  result.eye = _makeGamepad();
   result.id = _makeTypedArray(Uint32Array, 1);
   result.vrRequest = _makeTypedArray(Uint32Array, 2);
   result.tex = _makeTypedArray(Uint32Array, 1);

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ const {defaultEyeSeparation, maxNumTrackers} = require('./constants.js');
 const symbols = require('./symbols');
 const THREE = require('../lib/three-min.js');
 
-const {getHMDType} = require('./VR.js');
+const {getHMDType, FakeMesher, FakePlanesTracker} = require('./VR.js');
 
 const nativeBindings = require(path.join(__dirname, 'native-bindings.js'));
 
@@ -327,6 +327,8 @@ const topVrPresentState = {
   vrSystem: null,
   vrCompositor: null,
   hasPose: false,
+  mesher: null,
+  planesTracker: null,
 };
 
 const requestPresent = async () => {

--- a/src/index.js
+++ b/src/index.js
@@ -1195,10 +1195,14 @@ const _startTopRenderLoop = () => {
     for (let i = 0; i < xrState.gamepads.length; i++) {
       _deriveGamepadData(xrState.gamepads[i]);
     }
-    for (let i = 0; i < xrState.hands.length; i++) {
-      _deriveGamepadData(xrState.hands[i]);
+    if (xrState.handTracking[0]) {
+      for (let i = 0; i < xrState.hands.length; i++) {
+        _deriveGamepadData(xrState.hands[i]);
+      }
     }
-    _deriveGamepadData(xrState.eye);
+    if (xrState.eyeTracking[0]) {
+      _deriveGamepadData(xrState.eye);
+    }
 
     if (args.performance) {
       const now = Date.now();

--- a/src/index.js
+++ b/src/index.js
@@ -985,8 +985,7 @@ const _startTopRenderLoop = () => {
     await _waitGetPoses();
 
     // compute derived gamepads data
-    for (let i = 0; i < xrState.gamepads.length; i++) {
-      const gamepad = xrState.gamepads[i];
+    const _deriveGamepadData = gamepad => {
       localQuaternion.fromArray(gamepad.orientation);
       localVector
         .set(0, 0, -1)
@@ -997,7 +996,14 @@ const _startTopRenderLoop = () => {
       localMatrix
         .compose(localVector, localQuaternion, localVector2)
         .toArray(gamepad.transformMatrix);
+    };
+    for (let i = 0; i < xrState.gamepads.length; i++) {
+      _deriveGamepadData(xrState.gamepads[i]);
     }
+    for (let i = 0; i < xrState.hands.length; i++) {
+      _deriveGamepadData(xrState.hands[i]);
+    }
+    _deriveGamepadData(xrState.eye);
 
     if (args.performance) {
       const now = Date.now();

--- a/src/native-bindings.js
+++ b/src/native-bindings.js
@@ -566,70 +566,9 @@ GlobalContext.nativeMl = bindings.nativeMl;
 GlobalContext.nativeBrowser = bindings.nativeBrowser;
 
 if (bindings.nativeMl) {
-  const _mlEvent = e => {
-    // console.log('got ml keyboard event', e);
-
-    const window = canvas.ownerDocument.defaultView;
-
-    switch (e.type) {
-      case 'newInitArg': {
-        break;
-      }
-      case 'stop':
-      case 'pause': {
-        if (mlPresentState.mlContext) {
-          mlPresentState.mlContext.Exit();
-        }
-        bindings.nativeMl.DeinitLifecycle();
-        process.exit();
-        break;
-      }
-      case 'resume': {
-        break;
-      }
-      case 'unloadResources': {
-        break;
-      }
-      case 'keydown': {
-        let handled = false;
-        if (e.keyCode === 27) { // ESC
-          if (window.document.pointerLockElement) {
-            window.document.exitPointerLock();
-            handled = true;
-          }
-          if (window.document.fullscreenElement) {
-            window.document.exitFullscreen();
-            handled = true;
-          }
-        }
-        if (e.keyCode === 122) { // F11
-          if (window.document.fullscreenElement) {
-            window.document.exitFullscreen();
-            handled = true;
-          } else {
-            window.document.requestFullscreen();
-            handled = true;
-          }
-        }
-
-        if (!handled) {
-          canvas.dispatchEvent(new window.KeyboardEvent(e.type, e));
-        }
-        break;
-      }
-      case 'keyup':
-      case 'keypress': {
-        canvas.dispatchEvent(new window.KeyboardEvent(e.type, e));
-        break;
-      }
-      default:
-        break;
-    }
-  };
   if (isMainThread) {
     if (!bindings.nativeMl.IsSimulated()) {
       bindings.nativeMl.InitLifecycle();
-      bindings.nativeMl.SetEventHandler(_mlEvent);
     } else {
       // try to connect to MLSDK
       const MLSDK_PORT = 17955;
@@ -637,7 +576,6 @@ if (bindings.nativeMl) {
         s.destroy();
 
         bindings.nativeMl.InitLifecycle();
-        bindings.nativeMl.SetEventHandler(_mlEvent);
       });
       s.on('error', () => {});
     }


### PR DESCRIPTION
This PR refactors the non-standard WebXR hardware bindings (meshing, planes, hands, eyes) into a generic system that is not tied to the Magic Leap API binding.

The reasons for doing this are:

- Simpler to manage the bindings in one place at the top level render loop, instead of internally in the user windows
- We now emulate these APIs in the studio, allowing us to test and develop against them without needing hardware
- Allows us to support more hardware (such as Leap Motion/Zed/Valve Index) without leaking hardware API warts specific to a particular platform
- More standards-compliant -- these are finding their way into the WebXR spec and we want Exokit to follow suit