### PR TITLE
Remove --experimental-worker requirement

### DIFF
--- a/examples/launcher/backend.js
+++ b/examples/launcher/backend.js
@@ -11,7 +11,7 @@ if (typeof require !== 'undefined') {
   function launch(flags, url){
       console.log('launching...')
       console.log('flags', flags)
-      let flagsArray = ['--experimental-worker', '.', url];
+      let flagsArray = ['.', url];
       let flagsString = '';
       if(flags.length > 1){
           flagsString += '-';

--- a/main.cpp
+++ b/main.cpp
@@ -124,43 +124,6 @@ void jniOnload(JavaVM *vm) {
   androidJniEnv = env;
   __android_log_print(ANDROID_LOG_INFO, "exokit", "Got JNI Env %lx", (unsigned long)androidJniEnv);
 
-  // parse args
-  // adb shell am start -n com.webmr.exokit/android.app.NativeActivity -e ARGS "'node --experimental-worker /package /package/examples/tutorial.html'"
-  /* {
-    std::vector<std::string> &args = androidArgs;
-
-    jobject activity = androidApp->activity->clazz;
-    jmethodID get_intent_method = env->GetMethodID(env->GetObjectClass(activity), "getIntent", "()Landroid/content/Intent;");
-    jobject intent = env->CallObjectMethod(activity, get_intent_method);
-    jmethodID get_string_extra_method = env->GetMethodID(env->GetObjectClass(intent), "getStringExtra", "(Ljava/lang/String;)Ljava/lang/String;");
-    jvalue get_string_extra_args;
-    get_string_extra_args.l = env->NewStringUTF("ARGS");
-    jstring extra_str = static_cast<jstring>(env->CallObjectMethodA(intent, get_string_extra_method, &get_string_extra_args));
-
-    std::string args_str;
-    if (extra_str) {
-      const char* extra_utf = env->GetStringUTFChars(extra_str, nullptr);
-      args_str = extra_utf;
-      env->ReleaseStringUTFChars(extra_str, extra_utf);
-      env->DeleteLocalRef(extra_str);
-    }
-
-    __android_log_print(ANDROID_LOG_INFO, "exokit", "got args 1 '%s'", args_str.c_str());
-
-    env->DeleteLocalRef(get_string_extra_args.l);
-    env->DeleteLocalRef(intent);
-
-    // split args_str
-    std::stringstream ss(args_str);
-    std::string arg;
-    while (std::getline(ss, arg, ' ')) {
-      if (!arg.empty()) {
-        __android_log_print(ANDROID_LOG_INFO, "exokit", "got args 2 %lx '%s'", args.size(), arg.c_str());
-
-        args.push_back(arg);
-      }
-    }
-  } */
   {
     jobject activity = androidApp->activity->clazz;
     jmethodID get_intent_method = env->GetMethodID(env->GetObjectClass(activity), "getIntent", "()Landroid/content/Intent;");
@@ -417,7 +380,6 @@ int main(int argc, char **argv) {
     }
 
     const char *nodeString = "node";
-    const char *experimentalWorkerString = "--experimental-worker";
 #ifndef ANDROID
     const char *dotString = ".";
 #else
@@ -430,10 +392,6 @@ int main(int argc, char **argv) {
     strncpy(nodeArg, nodeString, sizeof(argsString) - i);
     i += strlen(nodeString) + 1;
 
-    char *experimentalWorkerArg = argsString + i;
-    strncpy(experimentalWorkerArg, experimentalWorkerString, sizeof(argsString) - i);
-    i += strlen(experimentalWorkerString) + 1;
-
     char *dotArg = argsString + i;
     strncpy(dotArg, dotString, sizeof(argsString) - i);
     i += strlen(dotString) + 1;
@@ -442,7 +400,7 @@ int main(int argc, char **argv) {
     strncpy(jsArg, jsString, sizeof(argsString) - i);
     i += strlen(jsString) + 1;
 
-    char *argv[] = {nodeArg, experimentalWorkerArg, dotArg, jsArg};
+    char *argv[] = {nodeArg, dotArg, jsArg};
     size_t argc = sizeof(argv) / sizeof(argv[0]);
 
     result = node::Start(argc, argv);

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "lint": "eslint src tests",
     "rebuild": "shx rm -rf node_modules && npm cache clean --force && npm install",
     "serve": "serve examples",
-    "start": "node --experimental-worker .",
-    "test": "node node_modules/mocha/bin/mocha --experimental-worker --full-trace --exit --bail --timeout 5000 tests/unit/__setup.test.js tests/unit/*.test.js tests/unit/**/*.test.js",
+    "start": "node .",
+    "test": "node node_modules/mocha/bin/mocha --full-trace --exit --bail --timeout 5000 tests/unit/__setup.test.js tests/unit/*.test.js tests/unit/**/*.test.js",
     "test:watch": "npm run test -- --watch"
   },
   "repository": {

--- a/scripts/debug-android.sh
+++ b/scripts/debug-android.sh
@@ -11,7 +11,7 @@
 #
 # am_cmd.append("-e")
 # am_cmd.append("ARGS")
-# am_cmd.append("'node --experimental-worker /package /package/examples/tutorial.html'")
+# am_cmd.append("'node /package /package/examples/tutorial.html'")
 
 set -e
 

--- a/scripts/debug-ml.sh
+++ b/scripts/debug-ml.sh
@@ -6,4 +6,4 @@ cd "$(dirname "$0")"
 
 source ./version-ml.sh
 
-cmd.exe /c "$MLSDK_WIN/debug.cmd" -p com.webmr.exokit ../build/magicleap/program-device/release_lumin_clang-3.8_aarch64/program-device --env "ARGS=node --experimental-worker . $@"
+cmd.exe /c "$MLSDK_WIN/debug.cmd" -p com.webmr.exokit ../build/magicleap/program-device/release_lumin_clang-3.8_aarch64/program-device --env "ARGS=node . $@"

--- a/scripts/exokit-macos
+++ b/scripts/exokit-macos
@@ -14,4 +14,4 @@ if [ -x "$DIR/node/bin/node" ]; then
 fi
 
 cd "$DIR/.."
-exec "$NODE_BIN" "--experimental-worker" . "${@:--h -l}"
+exec "$NODE_BIN" . "${@:--h -l}"

--- a/scripts/exokit.cmd
+++ b/scripts/exokit.cmd
@@ -5,7 +5,7 @@ set node=%home%..\node\node.exe
 set code=%home%..\src\index.js
 
 IF EXIST "%node%" (
-  "%node%" "--experimental-worker" "%code%" %*
+  "%node%" "%code%" %*
 ) ELSE (
-  node "--experimental-worker" "%code%" %*
+  node "%code%" %*
 )

--- a/scripts/exokit.sh
+++ b/scripts/exokit.sh
@@ -14,4 +14,4 @@ if [ -x "$DIR/node/bin/node" ]; then
 fi
 
 cd "$DIR/.."
-exec "$NODE_BIN" "--experimental-worker" . "${@:--h -l}"
+exec "$NODE_BIN" . "${@:--h -l}"

--- a/scripts/run-ml.sh
+++ b/scripts/run-ml.sh
@@ -7,5 +7,5 @@ cd "$(dirname "$0")"
 source ./version-ml.sh
 
 cmd.exe /c "$MLSDK_WIN/tools/mldb/mldb.exe" terminate -f com.webmr.exokit || true
-cmd.exe /c "$MLSDK_WIN/tools/mldb/mldb.exe" launch com.webmr.exokit -v "ARGS=node --experimental-worker . $@"
+cmd.exe /c "$MLSDK_WIN/tools/mldb/mldb.exe" launch com.webmr.exokit -v "ARGS=node . $@"
 cmd.exe /c "$MLSDK_WIN/tools/mldb/mldb.exe" log exokit:*


### PR DESCRIPTION
With the move to new `node` versions, we no longer need any special flags to run `exokit`.

Therefore, remove the flag from all of the nooks and crannies it found its way into.