### PR TITLE
[Go/Quest] Direct blit

### DIFF
--- a/deps/exokit-bindings/egl/src/egl.cc
+++ b/deps/exokit-bindings/egl/src/egl.cc
@@ -218,8 +218,8 @@ NATIVEwindow *CreateNativeWindow(unsigned int width, unsigned int height, bool v
     EGL_GREEN_SIZE, 8,
     EGL_BLUE_SIZE, 8,
     EGL_ALPHA_SIZE, 8, // need alpha for the multi-pass timewarp compositor
-    EGL_DEPTH_SIZE, 24,
-    EGL_STENCIL_SIZE, 8,
+    EGL_DEPTH_SIZE, 0,
+    EGL_STENCIL_SIZE, 0,
     EGL_SAMPLES, 0,
     EGL_NONE
 #endif

--- a/deps/exokit-bindings/windowsystem/src/windowsystem.cc
+++ b/deps/exokit-bindings/windowsystem/src/windowsystem.cc
@@ -599,8 +599,6 @@ NAN_METHOD(CreateVrTopRenderTarget) {
 }
 
 void CreateVrCompositorRenderTarget(WebGLRenderingContext *gl, int width, int height, GLuint *pFbo, GLuint *pmsFbo, GLuint *pmsColorTex, GLuint *pmsDepthStencilTex) {
-  const int samples = 4;
-
   GLuint &fbo = *pFbo;
   GLuint &msFbo = *pmsFbo;
   GLuint &msColorTex = *pmsColorTex;
@@ -615,9 +613,9 @@ void CreateVrCompositorRenderTarget(WebGLRenderingContext *gl, int width, int he
     glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, msColorTex);
     glTexParameteri(GL_TEXTURE_2D_MULTISAMPLE, GL_TEXTURE_MAX_LEVEL, 0);
 #if !defined(ANDROID) && !defined(LUMIN)
-    glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, samples, GL_RGBA8, width, height, true);
+    glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, NUM_SAMPLES, GL_RGBA8, width, height, true);
 #else
-    glTexStorage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, samples, GL_RGBA8, width, height, true);
+    glTexStorage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, NUM_SAMPLES, GL_RGBA8, width, height, true);
 #endif
     glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D_MULTISAMPLE, msColorTex, 0);
 
@@ -625,9 +623,9 @@ void CreateVrCompositorRenderTarget(WebGLRenderingContext *gl, int width, int he
     glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, msDepthStencilTex);
     glTexParameteri(GL_TEXTURE_2D_MULTISAMPLE, GL_TEXTURE_MAX_LEVEL, 0);
 #if !defined(ANDROID) && !defined(LUMIN)
-    glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, samples, GL_DEPTH24_STENCIL8, width, height, true);
+    glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, NUM_SAMPLES, GL_DEPTH24_STENCIL8, width, height, true);
 #else
-    glTexStorage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, samples, GL_DEPTH24_STENCIL8, width, height, true);
+    glTexStorage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, NUM_SAMPLES, GL_DEPTH24_STENCIL8, width, height, true);
 #endif
     glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D_MULTISAMPLE, msDepthStencilTex, 0);
 

--- a/deps/oculus-mobile/include/oculus-context.h
+++ b/deps/oculus-mobile/include/oculus-context.h
@@ -22,6 +22,7 @@ public:
   static NAN_METHOD(New);
   void Destroy();
 
+  static NAN_METHOD(CreateSwapChain);
   static NAN_METHOD(WaitGetPoses);
   static NAN_METHOD(Submit);
   static NAN_METHOD(GetRecommendedRenderTargetSize);
@@ -34,12 +35,12 @@ public:
   ovrMobile *ovrState;
   bool running;
   ANativeWindow *androidNativeWindow;
-  ovrTextureSwapChain *swapChains[2];
+  ovrTextureSwapChain *colorSwapChain;
+  ovrTextureSwapChain *depthSwapChain;
   int swapChainMetrics[2];
   int swapChainLength;
   int swapChainIndex;
   bool hasSwapChain;
-  GLuint fboId;
   ovrTracking2 tracking;
   long long frameIndex;
 	double displayTime;

--- a/deps/oculus-mobile/include/oculus-context.h
+++ b/deps/oculus-mobile/include/oculus-context.h
@@ -37,7 +37,6 @@ public:
   ANativeWindow *androidNativeWindow;
   ovrTextureSwapChain *colorSwapChain;
   ovrTextureSwapChain *depthSwapChain;
-  int swapChainMetrics[2];
   int swapChainLength;
   int swapChainIndex;
   bool hasSwapChain;

--- a/deps/oculus-mobile/include/oculus-mobile.h
+++ b/deps/oculus-mobile/include/oculus-mobile.h
@@ -1,13 +1,15 @@
 #ifndef _OCULUS_MOBILE_H_
 #define _OCULUS_MOBILE_H_
 
+#include <unistd.h>
+#include <android/native_window_jni.h>
+#include <android_native_app_glue.h>
+
 #include <v8.h>
 #include <nan.h>
 
 #include <defines.h>
 
-#include <android/native_window_jni.h>
-#include <android_native_app_glue.h>
 #include <exout>
 
 #include "VrApi.h"

--- a/deps/oculus-mobile/src/oculus-context.cpp
+++ b/deps/oculus-mobile/src/oculus-context.cpp
@@ -285,8 +285,10 @@ NAN_METHOD(OculusMobileContext::WaitGetPoses) {
   bool hasPose = oculusMobileContext->ovrState != nullptr;
   if (hasPose) {
     oculusMobileContext->frameIndex++;
-    const double predictedDisplayTime = vrapi_GetPredictedDisplayTime(oculusMobileContext->ovrState, oculusMobileContext->frameIndex);
-    const ovrTracking2 &tracking = vrapi_GetPredictedTracking2(oculusMobileContext->ovrState, predictedDisplayTime);
+    oculusMobileContext->displayTime = vrapi_GetPredictedDisplayTime(oculusMobileContext->ovrState, oculusMobileContext->frameIndex);
+    oculusMobileContext->tracking = vrapi_GetPredictedTracking2(oculusMobileContext->ovrState, oculusMobileContext->displayTime);
+    const double &predictedDisplayTime = oculusMobileContext->displayTime;
+    const ovrTracking2 &tracking = oculusMobileContext->tracking;
 
     // headset
     {
@@ -410,10 +412,6 @@ NAN_METHOD(OculusMobileContext::WaitGetPoses) {
         break;
       }
     }
-
-    // advance
-    oculusMobileContext->tracking = tracking;
-    oculusMobileContext->displayTime = predictedDisplayTime;
   }
 
   info.GetReturnValue().Set(JS_BOOL(hasPose));

--- a/deps/oculus-mobile/src/oculus-context.cpp
+++ b/deps/oculus-mobile/src/oculus-context.cpp
@@ -13,7 +13,6 @@ OculusMobileContext::OculusMobileContext(NATIVEwindow *windowHandle) :
   androidNativeWindow(nullptr),
   colorSwapChain(nullptr),
   depthSwapChain(nullptr),
-  swapChainMetrics{0, 0},
   swapChainLength(0),
   swapChainIndex(0),
   hasSwapChain(false),
@@ -143,8 +142,6 @@ void OculusMobileContext::CreateSwapChain(int width, int height) {
     oculusMobileContext->colorSwapChain = vrapi_CreateTextureSwapChain3(VRAPI_TEXTURE_TYPE_2D, GL_RGBA8, width, height, 1, 3);
     oculusMobileContext->depthSwapChain = vrapi_CreateTextureSwapChain3(VRAPI_TEXTURE_TYPE_2D, GL_DEPTH24_STENCIL8, width, height, 1, 3);
 
-    oculusMobileContext->swapChainMetrics[0] = width;
-    oculusMobileContext->swapChainMetrics[1] = height;
     oculusMobileContext->swapChainLength = vrapi_GetTextureSwapChainLength(oculusMobileContext->colorSwapChain);
     oculusMobileContext->swapChainIndex = 0;
     oculusMobileContext->hasSwapChain = true;

--- a/deps/oculus-mobile/src/oculus-context.cpp
+++ b/deps/oculus-mobile/src/oculus-context.cpp
@@ -207,15 +207,17 @@ void OculusMobileContext::PollEvents(bool wait) {
         oculusMobileContext->androidNativeWindow = nullptr;
       }
 
-      /* static const int CPU_LEVEL = 2;
+      static const int CPU_LEVEL = 3;
       static const int GPU_LEVEL = 3;
-      static const int NUM_MULTI_SAMPLES = 4;
       // Set performance parameters once we have entered VR mode and have a valid ovrMobile.
       if (oculusMobileContext->ovrState) {
-        vrapi_SetClockLevels( app->Ovr, app->CpuLevel, app->GpuLevel );
-        vrapi_SetPerfThread( app->Ovr, VRAPI_PERF_THREAD_TYPE_MAIN, app->MainThreadTid );
-        vrapi_SetPerfThread( app->Ovr, VRAPI_PERF_THREAD_TYPE_RENDERER, app->RenderThreadTid );
-      } */
+        vrapi_SetClockLevels(oculusMobileContext->ovrState, CPU_LEVEL, GPU_LEVEL);
+        pid_t tid = gettid();
+        vrapi_SetPerfThread(oculusMobileContext->ovrState, VRAPI_PERF_THREAD_TYPE_MAIN, tid);
+        // vrapi_SetPerfThread(oculusMobileContext->ovrState, VRAPI_PERF_THREAD_TYPE_RENDERER, tid);
+        vrapi_SetDisplayRefreshRate(oculusMobileContext->ovrState, 72);
+        vrapi_SetExtraLatencyMode(oculusMobileContext->ovrState, VRAPI_EXTRA_LATENCY_MODE_ON);
+      }
     } else if (!shouldBeRunning && oculusMobileContext->ovrState != nullptr) {
       vrapi_LeaveVrMode(oculusMobileContext->ovrState);
       oculusMobileContext->ovrState = nullptr;

--- a/deps/oculus-mobile/src/oculus-context.cpp
+++ b/deps/oculus-mobile/src/oculus-context.cpp
@@ -444,15 +444,16 @@ NAN_METHOD(OculusMobileContext::Submit) {
 	}
   layer.Header.Flags |= VRAPI_FRAME_LAYER_FLAG_CHROMATIC_ABERRATION_CORRECTION;
 
-  const ovrLayerHeader2 * layerHeaders[ovrMaxLayerCount] = {0};
-  layerHeaders[0] = &layer.Header;
+  const ovrLayerHeader2 *layers[] = {
+    &layer.Header,
+  };
 
   ovrSubmitFrameDescription2 frameDesc = {0};
   frameDesc.Flags = 0;
   frameDesc.SwapInterval = oculusMobileContext->swapInterval;
   frameDesc.FrameIndex = oculusMobileContext->frameIndex;
-  frameDesc.DisplayTime = oculusMobileContext->displayTime;
-  frameDesc.Layers = layerHeaders;
+  frameDesc.DisplayTime = vrapi_GetTimeInSeconds();
+  frameDesc.Layers = layers;
   frameDesc.LayerCount = 1;
 
   // Hand over the eye images to the time warp.

--- a/deps/oculus-mobile/src/oculus-context.cpp
+++ b/deps/oculus-mobile/src/oculus-context.cpp
@@ -446,16 +446,16 @@ NAN_METHOD(OculusMobileContext::Submit) {
 	}
   layer.Header.Flags |= VRAPI_FRAME_LAYER_FLAG_CHROMATIC_ABERRATION_CORRECTION;
 
-  const ovrLayerHeader2 *layers[] = {
-    &layer.Header,
-  };
+  const ovrLayerHeader2 * layerHeaders[ovrMaxLayerCount] = {0};
+  layerHeaders[0] = &layer.Header;
+
   ovrSubmitFrameDescription2 frameDesc = {0};
   frameDesc.Flags = 0;
   frameDesc.SwapInterval = oculusMobileContext->swapInterval;
   frameDesc.FrameIndex = oculusMobileContext->frameIndex;
   frameDesc.DisplayTime = oculusMobileContext->displayTime;
-  frameDesc.LayerCount = sizeof(layers)/sizeof(layers[0]);
-  frameDesc.Layers = layers;
+  frameDesc.Layers = layerHeaders;
+  frameDesc.LayerCount = 1;
 
   // Hand over the eye images to the time warp.
   vrapi_SubmitFrame2(oculusMobileContext->ovrState, &frameDesc);

--- a/deps/oculus/include/ovrsession.h
+++ b/deps/oculus/include/ovrsession.h
@@ -60,8 +60,8 @@ private:
   }
 
   void ResetSwapChain();
-  void EnsureFbos();
-  void AttachFbos();
+  // void EnsureFbos();
+  // void AttachFbos();
   void DestroySwapChain();
   void DestroySession();
   void ResetSession();
@@ -73,8 +73,6 @@ private:
   bool swapChainValid;
   ovrPosef eyeRenderPoses[2];
   int swapChainMetrics[2];
-  int fboMetrics[2];
-  GLuint fbo;
   int frameIndex;
   double sensorSampleTime;
   bool hmdMounted;

--- a/deps/oculus/src/ovrsession.cpp
+++ b/deps/oculus/src/ovrsession.cpp
@@ -99,8 +99,6 @@ OVRSession::OVRSession() :
   session(nullptr),
   swapChainValid(false),
   swapChainMetrics{0, 0},
-  fboMetrics{0, 0},
-  fbo(0),
   frameIndex(0),
   hmdMounted(true)
 {
@@ -402,8 +400,7 @@ NAN_METHOD(OVRSession::GetControllersInputState) {
 
 NAN_METHOD(OVRSession::Submit) {
 
-  if (info.Length() != 0)
-  {
+  if (info.Length() != 0) {
     Nan::ThrowError("Wrong number of arguments.");
     return;
   }
@@ -446,27 +443,26 @@ NAN_METHOD(OVRSession::Submit) {
   ovr_SubmitFrame(*session->session, session->frameIndex, nullptr, layers, sizeof(layers)/sizeof(layers[0]));
   session->frameIndex++;
   
-  session->AttachFbos();
+  // session->AttachFbos();
 
   GLuint colorTex;
   {
     int curIndex;
     ovr_GetTextureSwapChainCurrentIndex(*session->session, session->swapChain.ColorTextureChain, &curIndex);
     ovr_GetTextureSwapChainBufferGL(*session->session, session->swapChain.ColorTextureChain, curIndex, &colorTex);
-    glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, colorTex, 0);
+    // glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, colorTex, 0);
   }
   GLuint depthStencilTex;
   {
     int curIndex;
     ovr_GetTextureSwapChainCurrentIndex(*session->session, session->swapChain.DepthTextureChain, &curIndex);
     ovr_GetTextureSwapChainBufferGL(*session->session, session->swapChain.DepthTextureChain, curIndex, &depthStencilTex);
-    glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, depthStencilTex, 0);
+    // glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, depthStencilTex, 0);
   }
 
-  Local<Array> array = Array::New(Isolate::GetCurrent(), 3);
-  array->Set(0, JS_INT(session->fbo));
-  array->Set(1, JS_INT(colorTex));
-  array->Set(2, JS_INT(depthStencilTex));
+  Local<Array> array = Array::New(Isolate::GetCurrent(), 2);
+  array->Set(0, JS_INT(colorTex));
+  array->Set(1, JS_INT(depthStencilTex));
   info.GetReturnValue().Set(array);
 }
 
@@ -567,19 +563,16 @@ void OVRSession::ResetSwapChain() {
     }
   }
 
-  EnsureFbos();
-  AttachFbos();
+  // EnsureFbos();
+  // AttachFbos();
   
   this->swapChainValid = true;
 }
 
-void OVRSession::EnsureFbos() {
+/* void OVRSession::EnsureFbos() {
   if (fbo == 0) {
     glGenFramebuffers(1, &fbo);
   }
-
-  this->fboMetrics[0] = this->swapChainMetrics[0];
-  this->fboMetrics[1] = this->swapChainMetrics[1];
 }
 
 void OVRSession::AttachFbos() {
@@ -598,7 +591,7 @@ void OVRSession::AttachFbos() {
     ovr_GetTextureSwapChainBufferGL(*this->session, this->swapChain.DepthTextureChain, curIndex, &depthStencilTex);
     glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, depthStencilTex, 0);
   }
-}
+} */
 
 void OVRSession::DestroySwapChain() {
   ovr_DestroyTextureSwapChain(*this->session, this->swapChain.ColorTextureChain);
@@ -640,20 +633,19 @@ NAN_METHOD(OVRSession::CreateSwapChain) {
     int curIndex;
     ovr_GetTextureSwapChainCurrentIndex(*session->session, session->swapChain.ColorTextureChain, &curIndex);
     ovr_GetTextureSwapChainBufferGL(*session->session, session->swapChain.ColorTextureChain, curIndex, &colorTex);
-    glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, colorTex, 0);
+    // glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, colorTex, 0);
   }
   GLuint depthStencilTex;
   {
     int curIndex;
     ovr_GetTextureSwapChainCurrentIndex(*session->session, session->swapChain.DepthTextureChain, &curIndex);
     ovr_GetTextureSwapChainBufferGL(*session->session, session->swapChain.DepthTextureChain, curIndex, &depthStencilTex);
-    glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, depthStencilTex, 0);
+    // glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, depthStencilTex, 0);
   }
 
-  Local<Array> array = Array::New(Isolate::GetCurrent(), 3);
-  array->Set(0, JS_INT(session->fbo));
-  array->Set(1, JS_INT(colorTex));
-  array->Set(2, JS_INT(depthStencilTex));
+  Local<Array> array = Array::New(Isolate::GetCurrent(), 2);
+  array->Set(0, JS_INT(colorTex));
+  array->Set(1, JS_INT(depthStencilTex));
   info.GetReturnValue().Set(array);
 }
 
@@ -662,8 +654,5 @@ NAN_METHOD(OVRSession::ExitPresent) {
   
   ovr_DestroyTextureSwapChain(*session->session, session->swapChain.ColorTextureChain);
   ovr_DestroyTextureSwapChain(*session->session, session->swapChain.DepthTextureChain);
-  
-  if (session->fbo != 0) {
-    glDeleteFramebuffers(1, &session->fbo);
-  }
+
 }

--- a/src/Window.js
+++ b/src/Window.js
@@ -1194,6 +1194,7 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
   window.tickAnimationFrame = async () => {
     const _bindXrFramebuffer = () => {
       if (vrPresentState.glContext) {
+        nativeWindow.setCurrentWindowContext(vrPresentState.glContext.getWindowHandle());
         vrPresentState.glContext.setDefaultFramebuffer((vrPresentState.layers.length > 0 || vrPresentState.glContext.attrs.antialias) ? vrPresentState.msFbo : vrPresentState.fbo);
         nativeWindow.bindVrChildFbo(vrPresentState.glContext, vrPresentState.fbo, xrState.tex[0], xrState.depthTex[0]);
       }

--- a/src/Window.js
+++ b/src/Window.js
@@ -1244,7 +1244,7 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
       }
     };
     const _composeLayers = () => {
-      const syncs =[];
+      const syncs = [];
 
       for (let i = 0; i < contexts.length; i++) {
         const context = contexts[i];

--- a/src/Window.js
+++ b/src/Window.js
@@ -1360,10 +1360,6 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
         {
           let [fbo, tex, depthTex, _msFbo, _msTex, _msDepthTex] = nativeWindow.createRenderTarget(context, width, height);
 
-          /* msFbo = vrPresentState.msFbo;
-          msTex = vrPresentState.msTex;
-          msDepthTex = vrPresentState.msDepthTex; */
-
           context.canvas.framebuffer = {
             type: 'compositor',
             width,

--- a/src/Window.js
+++ b/src/Window.js
@@ -1178,6 +1178,7 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
   const timeouts = [];
   const intervals = [];
   const localCbs = [];
+  const childSyncs = [];
   const _cacheLocalCbs = cbs => {
     for (let i = 0; i < cbs.length; i++) {
       localCbs[i] = cbs[i];
@@ -1207,10 +1208,47 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
         window[symbols.mrDisplaysSymbol].vrDevice.session.update();
       }
     };
+    const _composeXrContext = (context, windowHandle) => {
+      const width = xrState.renderWidth[0]*2;
+      const height = xrState.renderHeight[0];
+      if (vrPresentState.layers.length > 0) {
+        nativeWindow.composeLayers(context, vrPresentState.fbo, vrPresentState.layers, xrState);
+      } else {
+        if (context.getDefaultFramebuffer() === vrPresentState.msFbo) { // if rendering to msFbo, not direct to fbo
+          nativeWindow.blitFrameBuffer(context, vrPresentState.msFbo, vrPresentState.fbo, width, height, width, height, true, false, false);
+        }
+      }
+
+      if (vrPresentState.hmdType === 'fake' || vrPresentState.hmdType === 'oculus' || vrPresentState.hmdType === 'openvr') {
+        const {width: dWidth, height: dHeight} = nativeWindow.getFramebufferSize(windowHandle);
+        nativeWindow.blitFrameBuffer(context, vrPresentState.fbo, 0, width, height, dWidth, dHeight, true, false, false);
+
+        if (isMac) {
+          context.bindFramebufferRaw(context.FRAMEBUFFER, null);
+        }
+        nativeWindow.swapBuffers(windowHandle);
+      }
+    };
+    const _composeBasicContext = (context, windowHandle) => {
+      if (!context.attrs.desynchronized) {
+        const width = context.canvas.width * (args.blit ? 0.5 : 1);
+        const height = context.canvas.height;
+        const {width: dWidth, height: dHeight} = nativeWindow.getFramebufferSize(windowHandle);
+        nativeWindow.blitFrameBuffer(context, context.framebuffer.msFbo, context.framebuffer.fbo, width, height, width, height, true, false, false);
+        nativeWindow.blitFrameBuffer(context, context.framebuffer.fbo, 0, width, height, dWidth, dHeight, true, false, false);
+
+        if (isMac) {
+          context.bindFramebufferRaw(context.FRAMEBUFFER, null);
+        }
+        nativeWindow.swapBuffers(windowHandle);
+      }
+    };
     const _composeLayers = () => {
+      const syncs =[];
+
       for (let i = 0; i < contexts.length; i++) {
         const context = contexts[i];
-        const isDirty = (!!context.isDirty && context.isDirty()) || context === vrPresentState.glContext /*|| mlPresentState.mlGlContext === context*/;
+        const isDirty = (!!context.isDirty && context.isDirty()) || context === vrPresentState.glContext;
         if (isDirty) {
           const windowHandle = context.getWindowHandle();
 
@@ -1220,34 +1258,11 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
           }
 
           if (context === vrPresentState.glContext) {
-            const width = xrState.renderWidth[0]*2;
-            const height = xrState.renderHeight[0];
-            if (vrPresentState.layers.length > 0) {
-              nativeWindow.composeLayers(context, vrPresentState.fbo, vrPresentState.layers, xrState);
-            } else {
-              if (context.getDefaultFramebuffer() === vrPresentState.msFbo) { // if rendering to msFbo, not direct to fbo
-                nativeWindow.blitFrameBuffer(context, vrPresentState.msFbo, vrPresentState.fbo, width, height, width, height, true, false, false);
-              }
-            }
-
-            if (vrPresentState.hmdType === 'fake' || vrPresentState.hmdType === 'oculus' || vrPresentState.hmdType === 'openvr') {
-              const {width: dWidth, height: dHeight} = nativeWindow.getFramebufferSize(windowHandle);
-              nativeWindow.blitFrameBuffer(context, vrPresentState.fbo, 0, width, height, dWidth, dHeight, true, false, false);
-            }
+            _composeXrContext(context, windowHandle);
           } else {
-            if (!context.attrs.desynchronized) {
-              const width = context.canvas.width * (args.blit ? 0.5 : 1);
-              const height = context.canvas.height;
-              const {width: dWidth, height: dHeight} = nativeWindow.getFramebufferSize(windowHandle);
-              nativeWindow.blitFrameBuffer(context, context.framebuffer.msFbo, context.framebuffer.fbo, width, height, width, height, true, false, false);
-              nativeWindow.blitFrameBuffer(context, context.framebuffer.fbo, 0, width, height, dWidth, dHeight, true, false, false);
-            }
+            _composeBasicContext(context, windowHandle);
           }
 
-          if (isMac) {
-            context.bindFramebufferRaw(context.FRAMEBUFFER, null);
-          }
-          nativeWindow.swapBuffers(windowHandle);
           if (isMac) {
             const drawFramebuffer = context.getBoundFramebuffer(context.DRAW_FRAMEBUFFER);
             if (drawFramebuffer) {
@@ -1261,21 +1276,23 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
           }
 
           context.clearDirty();
+
+          if (context.finish) {
+            syncs.push(nativeWindow.getSync());
+          }
         }
       }
-      for (let i = 0; i < contexts.length; i++) {
-        const context = contexts[i];
-        context.finish && context.finish();
-      }
-      
+
       for (let i = 0; i < windows.length; i++) {
         const window = windows[i];
         if (window.phase === PHASES.RENDERED) {
           window.phase = PHASES.NULL;
         }
       }
+
+      return Promise.resolve(syncs);
     };
-    const _renderLocal = async () => {
+    const _renderLocal = () => {
       if (rafCbs.length > 0) {
         _cacheLocalCbs(rafCbs);
         
@@ -1300,39 +1317,54 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
         _clearLocalCbs(); // release garbage
       }
     };
-    const _renderChildren = async () => {
-      let timeout;
+    const _renderChildren = () => {
+      /* let timeout;
       const timeoutPromise = new Promise((accept, reject) => {
         timeout = setTimeout(() => {
           accept();
         }, 1000/60); // XXX make this timeout accurate
-      });
+      }); */
       for (let i = 0; i < windows.length; i++) {
         const window = windows[i];
         if (window.phase === PHASES.NULL) {
           window.promise = window.runAsync('tickAnimationFrame')
             .then(syncs => {
+              if (vrPresentState.glContext) {
+                nativeWindow.setCurrentWindowContext(vrPresentState.glContext.getWindowHandle());
+
+                for (let i = 0; i < syncs.length; i++) {
+                  const sync = syncs[i];
+                  nativeWindow.waitSync(sync);
+                  childSyncs.push(sync);
+                }
+              }
+
               window.phase = PHASES.RENDERED;
               window.promise = null;
             });
           window.phase = PHASES.RENDERING;
         }
       }
-      await Promise.race([
+      /* await Promise.race([
         timeoutPromise,
         Promise.all(windows.map(window => window.promise)),
       ]);
-      clearTimeout(timeout);
+      clearTimeout(timeout); */
+      return Promise.all(windows.map(window => window.promise));
     };
 
     _bindXrFramebuffer();
     _emitXrEvents();
 
-    const childPromises = _renderChildren();
+    for (let i = 0; i < childSyncs.length; i++) {
+      nativeWindow.deleteSync(childSyncs[i]);
+    }
+    childSyncs.length = 0;
+    const childrenPromise = _renderChildren();
     _renderLocal();
-    await childPromises;
+    await childrenPromise;
     
-    _composeLayers();
+    return _composeLayers();
   };
   
   const _makeMrDisplays = () => {

--- a/src/Window.js
+++ b/src/Window.js
@@ -1230,7 +1230,7 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
       }
     };
     const _composeBasicContext = (context, windowHandle) => {
-      if (!context.attrs.desynchronized) {
+      if (context.framebuffer.type === 'canvas' && !context.desynchronized) {
         const width = context.canvas.width * (args.blit ? 0.5 : 1);
         const height = context.canvas.height;
         const {width: dWidth, height: dHeight} = nativeWindow.getFramebufferSize(windowHandle);

--- a/src/index.js
+++ b/src/index.js
@@ -308,6 +308,7 @@ const _startTopRenderLoop = () => {
     total: 0,
   };
   const TIMESTAMP_FRAMES = 100;
+  const childSyncs = [];
 
   if (nativeBindings.nativeWindow.pollEvents) {
     setInterval(() => {
@@ -914,8 +915,23 @@ const _startTopRenderLoop = () => {
       console.log('-'.repeat(80) + 'start frame');
     }
 
+    for (let i = 0; i < childSyncs.length; i++) {
+      nativeBindings.nativeWindow.deleteSync(childSyncs[i]);
+    }
+    childSyncs.length = 0;
+
     // tick animation frames
-    await Promise.all(windows.map(window => window.runAsync('tickAnimationFrame')));
+    await Promise.all(windows.map(window => window.runAsync('tickAnimationFrame').then(syncs => {
+      if (topVrPresentState.windowHandle) {
+        nativeBindings.nativeWindow.setCurrentWindowContext(topVrPresentState.windowHandle);
+        for (let i = 0; i < syncs.length; i++) {
+          const sync = syncs[i];
+          nativeBindings.nativeWindow.waitSync(sync);
+          childSyncs.push(sync);
+        }
+      }
+    })));
+
 
     if (args.performance) {
       const now = Date.now();

--- a/src/index.js
+++ b/src/index.js
@@ -346,7 +346,7 @@ const _startTopRenderLoop = () => {
         const {width: halfWidth, height} = system.GetRecommendedRenderTargetSize();
         const width = halfWidth * 2;
 
-        const [fbo, tex, depthTex] = system.CreateSwapChain(width, height);
+        const [tex, depthTex] = system.CreateSwapChain(width, height);
 
         xrState.tex[0] = tex;
         xrState.depthTex[0] = depthTex;
@@ -837,7 +837,7 @@ const _startTopRenderLoop = () => {
   const _submitFrame = async () => {
     if (topVrPresentState.hasPose) {
       if (topVrPresentState.hmdType === 'oculus') {
-        const [fbo, tex, depthTex] = topVrPresentState.vrContext.Submit();
+        const [tex, depthTex] = topVrPresentState.vrContext.Submit();
         xrState.tex[0] = tex;
         xrState.depthTex[0] = depthTex;
       } else if (topVrPresentState.hmdType === 'openvr') {

--- a/src/index.js
+++ b/src/index.js
@@ -380,9 +380,8 @@ const _startTopRenderLoop = () => {
         const {width: halfWidth, height} = vrContext.GetRecommendedRenderTargetSize();
         const width = halfWidth * 2;
 
-        const [fbo, tex, depthTex] = nativeBindings.nativeWindow.createVrTopRenderTarget(width, height);
+        const [tex, depthTex] = vrContext.CreateSwapChain(width, height);
 
-        topVrPresentState.fbo = fbo;
         xrState.tex[0] = tex;
         xrState.depthTex[0] = depthTex;
         xrState.renderWidth[0] = halfWidth;
@@ -844,7 +843,9 @@ const _startTopRenderLoop = () => {
       } else if (topVrPresentState.hmdType === 'openvr') {
         topVrPresentState.vrCompositor.Submit(xrState.tex[0]);
       } else if (topVrPresentState.hmdType === 'oculusMobile') {
-        topVrPresentState.vrContext.Submit(topVrPresentState.fbo, xrState.renderWidth[0]*2, xrState.renderHeight[0]);
+        const [tex, depthTex] = topVrPresentState.vrContext.Submit();
+        xrState.tex[0] = tex;
+        xrState.depthTex[0] = depthTex;
       } else if (topVrPresentState.hmdType === 'magicleap') {
         topVrPresentState.vrContext.SubmitFrame(topVrPresentState.fbo, xrState.renderWidth[0]*2, xrState.renderHeight[0]);
       }

--- a/src/native-bindings.js
+++ b/src/native-bindings.js
@@ -61,7 +61,10 @@ const _onGl3DConstruct = (gl, canvas, attrs) => {
 
   gl.d = 3;
   gl.canvas = canvas;
-  gl.desynchronized = !!attrs.desynchronized;
+  gl.attrs = {
+    antialias: !!attrs.antialias,
+    desynchronized: !!attrs.desynchronized,
+  };
 
   const document = canvas.ownerDocument;
   const window = document.defaultView;
@@ -234,7 +237,7 @@ const _onGl3DConstruct = (gl, canvas, attrs) => {
       }
     });
     
-    const [fbo, tex, depthTex, msFbo, msTex, msDepthTex] = gl.desynchronized ? [
+    const [fbo, tex, depthTex, msFbo, msTex, msDepthTex] = gl.attrs.desynchronized ? [
       0, 0, 0, 0, 0, 0,
     ] : nativeWindow.createRenderTarget(gl, canvasWidth, canvasHeight);
     if (msFbo) {
@@ -250,7 +253,7 @@ const _onGl3DConstruct = (gl, canvas, attrs) => {
       depthTex,
     };
     gl.resize = (width, height) => {
-      if (!gl.desynchronized && gl.framebuffer.type === 'canvas') {
+      if (!gl.attrs.desynchronized && gl.framebuffer.type === 'canvas') {
         nativeWindow.setCurrentWindowContext(windowHandle);
         const [newFbo, newTex, newDepthTex, newMsFbo, newMsTex, newMsDepthTex] = nativeWindow.resizeRenderTarget(gl, width, height, fbo, tex, depthTex, msFbo, msTex, msDepthTex);
 


### PR DESCRIPTION
This PR drops the blit from window texture to the OVR swapchain from the Oculus Go/Quest render pipeline.

The trick to doing this was to multiply the tan angle texture matrix to allow a single side-by-side texture to be used for both eyes.

This makes the Oculus Go render pipeline basically the same as the Oculus desktop one, with incrementing swap chain passed to the user window and no finalization blit.

Also cleans up some Oculus desktop binding.

Fixes https://github.com/exokitxr/exokit/pull/1071.
Supercedes https://github.com/exokitxr/exokit/pull/930.