### PR TITLE
Remove appveyor artifacts config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,10 +36,6 @@ after_test:
       .\buildtools\iscc "$pwd\metadata\exokit.iss" "/dMyAppVersion=$version" /odist /qp
       mv dist\*.exe exokit-win-x64.exe
 
-artifacts:
-  - path: "exokit-win-x64.exe"
-    name: exokit-windows-installer
-
 deploy:
   - provider: GitHub
     description: 'Exokit installer'


### PR DESCRIPTION
Appveyor recently instituted new limits on artifacts size, which we hit.

We only use Github artifacts anyway for releases, so this PR removes the artifact config from `appveyor.yml`.