### PR TITLE
[MagicLeap] bump node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "hterm-repl": "0.0.10",
     "isolator": "0.0.9",
     "leapmotion": "0.0.4",
-    "libnode.a": "0.0.11",
+    "libnode.a": "0.0.12",
     "libnode.a-android": "0.0.2",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
This bumps the magic leap node version to `11.15.0` for parity with Android.

Snapshots and inspector are supported.