### PR TITLE
Add window vm uncaught exception/rejection handler

### DIFF
--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -157,9 +157,18 @@ parentPort.on('close', () => {
 if (workerData.args) {
   global.args = workerData.args;
 }
+
+process.on('uncaughtException', err => {
+  console.warn(err.stack);
+});
+process.on('unhandledRejection', err => {
+  console.warn(err.stack);
+});
+
 if (workerData.initModule) {
   require(workerData.initModule);
 }
+
 if (!workerData.args.require) {
   global.require = undefined;
 }


### PR DESCRIPTION
This should ward off some crashes in favor of console spam.

Which, is how browsers do it 🤔.