### PR TITLE
Clear gamepads on request/exit present

### DIFF
--- a/src/VR.js
+++ b/src/VR.js
@@ -676,6 +676,10 @@ function getGamepads(window) {
   }
 };
 GlobalContext.getGamepads = getGamepads;
+function clearGamepads() {
+  gamepads = null;
+}
+GlobalContext.clearGamepads = clearGamepads;
 
 module.exports = {
   VRDisplay,

--- a/src/Window.js
+++ b/src/Window.js
@@ -1378,6 +1378,7 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
         });
 
         vrPresentState.hmdType = hmdType;
+        GlobalContext.clearGamepads();
       }
     };
     const _onmakeswapchain = context => {
@@ -1451,6 +1452,7 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
         });
 
         vrPresentState.hmdType = null;
+        GlobalContext.clearGamepads();
       }
     };
 


### PR DESCRIPTION
The `navigator.getGamepads` implementation for most browsers returns no gamepads until you request the XR session. Exokit follows suit.

However, we recently started caching the generated gamepad objects for lookup performance (many apps get gamepads on every frame).

This presents a problem when the present state of the app changes. In that case, we need to clear the cached gamepads and regenerate them on the next call. This PR effects that change.

Fixes Supercraft.