### PR TITLE
Bugfix Oculus desktop gamepads data acquisition

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -505,7 +505,7 @@ const _startTopRenderLoop = () => {
       xrGamepad.orientation.set(controllerQuaternionArray4);
 
       // Input
-      topVrPresentState.vrContext.GetControllersInputState(0, localGamepadArray);
+      topVrPresentState.vrContext.GetControllersInputState(i, localGamepadArray);
 
       xrGamepad.connected[0] = localGamepadArray[0];
 
@@ -532,7 +532,7 @@ const _startTopRenderLoop = () => {
       xrGamepad.buttons[2].value[0] = localGamepadArray[6]; // grip
     };
     _loadGamepad(0, leftControllerPositionArray3, leftControllerQuaternionArray4);
-    _loadGamepad(1, leftControllerPositionArray3, leftControllerQuaternionArray4);
+    _loadGamepad(1, rightControllerPositionArray3, rightControllerQuaternionArray4);
   };
   const _waitGetPosesOpenvr = async () => {
     // wait for frame


### PR DESCRIPTION
There were typos from the recent optimization to make the XR main loop pose acquisition functions tighter.