### PR TITLE
Web Worker API fixes

### DIFF
--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -151,10 +151,13 @@ parentPort.on('message', m => {
     default: throw new Error(`invalid method: ${JSON.stringify(m.method)}`);
   }
 });
-parentPort.on('close', () => {
-  window.onexit && window.onexit();
+
+function close() {
+  global.onexit && global.onexit();
   process.exit(); // thread exit
-});
+};
+global.close = close;
+parentPort.on('close', close);
 
 // run init module
 

--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const vm = require('vm');
 const util = require('util');
 const {Worker, workerData, parentPort} = require('worker_threads');
+const {MessageEvent} = require('./Event');
 const {process} = global;
 
 // global initialization
@@ -138,7 +139,10 @@ parentPort.on('message', m => {
     }
     case 'postMessage': {
       try {
-        global.emit('message', m.message);
+        const e = new MessageEvent('messge', {
+          data: m.message,
+        });
+        global.emit('message', e);
       } catch(err) {
         console.warn(err.stack);
       }

--- a/src/Worker.js
+++ b/src/Worker.js
@@ -38,16 +38,9 @@ const _normalizeUrl = src => {
 };
 const filename = _normalizeUrl(src);
 
-const _mapMessageType = type => {
-  if (type === 'message') {
-    return 'clientMessage';
-  }
-  return type;
-};
-
 global.self = global;
-global.addEventListener = (type, fn) => global.on(_mapMessageType(type), fn);
-global.removeEventListener = (type, fn) => global.removeListener(_mapMessageType(type), fn); 
+global.addEventListener = (type, fn) => global.on(type, fn);
+global.removeEventListener = (type, fn) => global.removeListener(type, fn);
 global.location = url.parse(filename);
 global.fetch = (s, options) => fetch(_normalizeUrl(s), options);
 global.XMLHttpRequest = XMLHttpRequest;
@@ -59,20 +52,9 @@ global.postMessage = (oldPostMessage => (message, transferList) => oldPostMessag
 global.createImageBitmap = createImageBitmap;
 global.FileReader = FileReader;
 
-global.on('message', m => {
-  global.emit('clientmessage', {
-    data: m,
-  });
-});
-global.on('clientmessage', m => {
-  if (typeof global.onmessage === 'function') {
-    global.onmessage(m);
-  }
-});
 global.on('error', err => {
-  if (typeof global.onerror === 'function') {
-    global.onerror(err);
-  }
+  const {onerror} = global;
+  onerror && onerror(err);
 });
 
 const _handleError = err => {


### PR DESCRIPTION
This fixes some spec incompatibilities and regressions introduced in the new isolated threading model.

- `MessageEvent` type not coming in as worker message events
- Remove old hack for routing message events to workers
- Add worker `close()` method