### PR TITLE
WebAudio asyncification

### DIFF
--- a/deps/exokit-bindings/canvascontext/include/image-context.h
+++ b/deps/exokit-bindings/canvascontext/include/image-context.h
@@ -36,7 +36,7 @@ protected:
   static NAN_GETTER(WidthGetter);
   static NAN_GETTER(HeightGetter);
   static NAN_GETTER(DataGetter);
-  static NAN_METHOD(LoadMethod);
+  static NAN_METHOD(Load);
 
   Image();
   ~Image();

--- a/deps/exokit-bindings/canvascontext/src/image-context.cc
+++ b/deps/exokit-bindings/canvascontext/src/image-context.cc
@@ -13,7 +13,7 @@ Local<Object> Image::Initialize(Isolate *isolate) {
   // prototype
   Local<ObjectTemplate> proto = ctor->PrototypeTemplate();
 
-  Nan::SetMethod(proto, "load", LoadMethod);
+  Nan::SetMethod(proto, "load", Load);
 
   return scope.Escape(Nan::GetFunction(ctor).ToLocalChecked());
 }
@@ -52,7 +52,7 @@ void Image::RunInMainThread(uv_async_t *handle) {
   Image *image = (Image *)handle->data;
 
   Local<Object> asyncObject = Nan::New<Object>();
-  AsyncResource asyncResource(Isolate::GetCurrent(), asyncObject, "imageLoad");
+  AsyncResource asyncResource(Isolate::GetCurrent(), asyncObject, "Image::RunInMainThread");
 
   Local<Function> cbFn = Nan::New(image->cbFn);
   Local<String> arg0 = Nan::New<String>(image->error).ToLocalChecked();
@@ -74,7 +74,6 @@ void Image::Load(Local<ArrayBuffer> arrayBuffer, size_t byteOffset, size_t byteL
 
     this->arrayBuffer.Reset(arrayBuffer);
     this->cbFn.Reset(cbFn);
-    this->error = "";
 
     uv_loop_t *loop = windowsystembase::GetEventLoop();
     uv_async_init(loop, &this->threadAsyncHandle, RunInMainThread);
@@ -200,8 +199,8 @@ NAN_GETTER(Image::DataGetter) {
   info.GetReturnValue().Set(Nan::New(image->dataArray));
 }
 
-NAN_METHOD(Image::LoadMethod) {
-  Nan::HandleScope scope;
+NAN_METHOD(Image::Load) {
+  // Nan::HandleScope scope;
 
   if (info[1]->IsFunction()) {
     if (info[0]->IsArrayBuffer()) {

--- a/deps/exokit-bindings/webaudiocontext/include/Audio.h
+++ b/deps/exokit-bindings/webaudiocontext/include/Audio.h
@@ -23,7 +23,7 @@ public:
   void Play();
   void Pause();
   void Load(uint8_t *bufferValue, size_t bufferLength, Local<Function> cbFn);
-  void Reparent(AudioContext *audioContext);
+  void Reparent(AudioContext *newAudioContext);
 
 protected:
   static NAN_METHOD(New);
@@ -43,8 +43,7 @@ protected:
   static void ProcessInMainThread(Audio *self);
 
   Nan::Persistent<Function> onended;
-  bool loaded;
-  bool connected;
+
   lab::AudioContext *audioContext;
   Nan::Persistent<Function> cbFn;
   shared_ptr<lab::AudioBus> audioBus;

--- a/deps/exokit-bindings/webaudiocontext/include/Audio.h
+++ b/deps/exokit-bindings/webaudiocontext/include/Audio.h
@@ -14,6 +14,8 @@ using namespace node;
 
 namespace webaudio {
 
+class AudioContext;
+
 class Audio : public ObjectWrap {
 public:
   static Local<Object> Initialize(Isolate *isolate);
@@ -21,7 +23,7 @@ public:
   void Play();
   void Pause();
   void Load(uint8_t *bufferValue, size_t bufferLength, Local<Function> cbFn);
-  void Reparent();
+  void Reparent(AudioContext *audioContext);
 
 protected:
   static NAN_METHOD(New);
@@ -43,6 +45,7 @@ protected:
   Nan::Persistent<Function> onended;
   bool loaded;
   bool connected;
+  lab::AudioContext *audioContext;
   Nan::Persistent<Function> cbFn;
   shared_ptr<lab::AudioBus> audioBus;
   std::string error;

--- a/deps/exokit-bindings/webaudiocontext/include/Audio.h
+++ b/deps/exokit-bindings/webaudiocontext/include/Audio.h
@@ -17,9 +17,11 @@ namespace webaudio {
 class Audio : public ObjectWrap {
 public:
   static Local<Object> Initialize(Isolate *isolate);
-  void Load(uint8_t *bufferValue, size_t bufferLength);
+
   void Play();
   void Pause();
+  void Load(uint8_t *bufferValue, size_t bufferLength, Local<Function> cbFn);
+  void Reparent();
 
 protected:
   static NAN_METHOD(New);
@@ -34,9 +36,16 @@ protected:
   static NAN_SETTER(LoopSetter);
   static NAN_GETTER(OnEndedGetter);
   static NAN_SETTER(OnEndedSetter);
+
+  static void ProcessLoadInMainThread(Audio *self);
   static void ProcessInMainThread(Audio *self);
 
   Nan::Persistent<Function> onended;
+  bool loaded;
+  bool connected;
+  Nan::Persistent<Function> cbFn;
+  shared_ptr<lab::AudioBus> audioBus;
+  std::string error;
 
   Audio();
   ~Audio();

--- a/deps/exokit-bindings/webaudiocontext/include/AudioBuffer.h
+++ b/deps/exokit-bindings/webaudiocontext/include/AudioBuffer.h
@@ -35,9 +35,16 @@ protected:
   static NAN_METHOD(GetChannelData);
   static NAN_METHOD(CopyFromChannel);
   static NAN_METHOD(CopyToChannel);
+  static NAN_METHOD(Load);
+  
+  void Load(Local<ArrayBuffer> arrayBuffer, size_t byteOffset, size_t byteLength, Local<Function> cbFn);
+  static void ProcessLoadInMainThread(AudioBuffer *audioBuffer);
 
   uint32_t sampleRate;
   Nan::Persistent<Array> buffers;
+  Nan::Persistent<Function> cbFn;
+  shared_ptr<lab::AudioBus> audioBus;
+  string error;
 
   friend class AudioBufferSourceNode;
   friend class ScriptProcessorNode;

--- a/deps/exokit-bindings/webaudiocontext/include/AudioContext.h
+++ b/deps/exokit-bindings/webaudiocontext/include/AudioContext.h
@@ -47,7 +47,8 @@ public:
   Local<Object> CreatePanner(Local<Function> pannerNodeConstructor, Local<Object> audioContextObj);
   Local<Object> CreateStereoPanner(Local<Function> stereoPannerNodeConstructor, Local<Object> audioContextObj);
   Local<Object> CreateOscillator(Local<Function> oscillatorNodeConstructor, Local<Object> audioContextObj);
-  Local<Object> CreateBuffer(Local<Function> audioBufferConstructor, uint32_t bufferSize, uint32_t numberOfInputChannels, uint32_t numberOfOutputChannels);
+  Local<Object> CreateBuffer(Local<Function> audioBufferConstructor, uint32_t numOfChannels, uint32_t length, uint32_t sampleRate);
+  Local<Object> CreateEmptyBuffer(Local<Function> audioBufferConstructor, uint32_t sampleRate);
   Local<Object> CreateBufferSource(Local<Function> audioBufferSourceNodeConstructor, Local<Object> audioContextObj);
   Local<Object> CreateScriptProcessor(Local<Function> scriptProcessorNodeConstructor, uint32_t bufferSize, uint32_t numberOfInputChannels, uint32_t numberOfOutputChannels, Local<Object> audioContextObj);
   void Suspend();
@@ -66,6 +67,7 @@ public:
   static NAN_METHOD(CreateStereoPanner);
   static NAN_METHOD(CreateOscillator);
   static NAN_METHOD(CreateBuffer);
+  static NAN_METHOD(CreateEmptyBuffer);
   static NAN_METHOD(CreateBufferSource);
   static NAN_METHOD(CreateScriptProcessor);
   static NAN_METHOD(Suspend);

--- a/deps/exokit-bindings/webaudiocontext/include/AudioContext.h
+++ b/deps/exokit-bindings/webaudiocontext/include/AudioContext.h
@@ -42,7 +42,6 @@ public:
   Local<Object> CreateMediaStreamSource(Local<Function> audioSourceNodeConstructor, Local<Object> mediaStream, Local<Object> audioContextObj);
   void CreateMediaStreamDestination();
   void CreateMediaStreamTrackSource();
-  Local<Value> _DecodeAudioDataSync(Local<Function> audioBufferConstructor, Local<ArrayBuffer> srcArrayBuffer);
   Local<Object> CreateGain(Local<Function> gainNodeConstructor, Local<Object> audioContextObj);
   Local<Object> CreateAnalyser(Local<Function> analyserNodeConstructor, Local<Object> audioContextObj);
   Local<Object> CreatePanner(Local<Function> pannerNodeConstructor, Local<Object> audioContextObj);
@@ -57,7 +56,6 @@ public:
   static NAN_METHOD(New);
   static NAN_METHOD(Close);
   static NAN_METHOD(Destroy);
-  static NAN_METHOD(_DecodeAudioDataSync);
   static NAN_METHOD(CreateMediaElementSource);
   static NAN_METHOD(CreateMediaStreamSource);
   static NAN_METHOD(CreateMediaStreamDestination);

--- a/deps/exokit-bindings/webaudiocontext/include/AudioContext.h
+++ b/deps/exokit-bindings/webaudiocontext/include/AudioContext.h
@@ -97,12 +97,15 @@ public:
   ~WebAudioAsync();
 
   void QueueOnMainThread(lab::ContextRenderLock &r, function<void()> &&newThreadFn);
+  void QueueOnMainThread(function<void()> &&newThreadFn);
   static void RunInMainThread(uv_async_t *handle);
 
 // protected:
-  function<void()> threadFn;
+  std::deque<function<void()>> threadFns;
+  std::mutex mutex;
   uv_async_t *threadAsync;
-  uv_sem_t threadSemaphore;
+  /* uv_sem_t threadReqSemaphore;
+  uv_sem_t threadResSemaphore; */
 };
 
 extern thread_local unique_ptr<lab::AudioContext> _defaultAudioContext;

--- a/deps/exokit-bindings/webaudiocontext/include/AudioContext.h
+++ b/deps/exokit-bindings/webaudiocontext/include/AudioContext.h
@@ -106,8 +106,6 @@ public:
   std::deque<function<void()>> threadFns;
   std::mutex mutex;
   uv_async_t *threadAsync;
-  /* uv_sem_t threadReqSemaphore;
-  uv_sem_t threadResSemaphore; */
 };
 
 extern thread_local unique_ptr<lab::AudioContext> _defaultAudioContext;

--- a/deps/exokit-bindings/webaudiocontext/src/Audio.cpp
+++ b/deps/exokit-bindings/webaudiocontext/src/Audio.cpp
@@ -4,7 +4,7 @@
 
 namespace webaudio {
 
-Audio::Audio() : loaded(false), connected(false), audioContext(nullptr) {
+Audio::Audio() : audioContext(nullptr) {
   WebAudioAsync *webaudioAsync = getWebAudioAsync();
   audioNode.reset(new lab::FinishableSourceNode(
     [this, webaudioAsync](lab::ContextRenderLock &r){

--- a/deps/exokit-bindings/webaudiocontext/src/AudioContext.cpp
+++ b/deps/exokit-bindings/webaudiocontext/src/AudioContext.cpp
@@ -467,16 +467,12 @@ NAN_GETTER(AudioContext::SampleRateGetter) {
 WebAudioAsync::WebAudioAsync() : threadAsync(new uv_async_t()) {
   uv_async_init(windowsystembase::GetEventLoop(), threadAsync, RunInMainThread);
   threadAsync->data = this;
-  /* uv_sem_init(&threadReqSemaphore, 1);
-  uv_sem_init(&threadResSemaphore, 0); */
 }
 
 WebAudioAsync::~WebAudioAsync() {
   uv_close((uv_handle_t *)threadAsync, [](uv_handle_t *handle) {
     delete handle;
   });
-  /* uv_sem_destroy(&threadReqSemaphore);
-  uv_sem_destroy(&threadResSemaphore); */
 }
 
 void WebAudioAsync::QueueOnMainThread(lab::ContextRenderLock &r, function<void()> &&newThreadFn) {

--- a/deps/exokit-bindings/webaudiocontext/src/AudioContext.cpp
+++ b/deps/exokit-bindings/webaudiocontext/src/AudioContext.cpp
@@ -62,6 +62,7 @@ Local<Object> AudioContext::Initialize(Isolate *isolate, Local<Value> audioListe
   Nan::SetMethod(proto, "createStereoPanner", CreateStereoPanner);
   Nan::SetMethod(proto, "createOscillator", CreateOscillator);
   Nan::SetMethod(proto, "createBuffer", CreateBuffer);
+  Nan::SetMethod(proto, "createEmptyBuffer", CreateEmptyBuffer);
   Nan::SetMethod(proto, "createBufferSource", CreateBufferSource);
   Nan::SetMethod(proto, "createScriptProcessor", CreateScriptProcessor);
   Nan::SetMethod(proto, "suspend", Suspend);
@@ -168,6 +169,15 @@ Local<Object> AudioContext::CreateBuffer(Local<Function> audioBufferConstructor,
   Local<Value> argv[] = {
     JS_INT(numOfChannels),
     JS_INT(length),
+    JS_INT(sampleRate),
+  };
+  Local<Object> audioBufferObj = audioBufferConstructor->NewInstance(Isolate::GetCurrent()->GetCurrentContext(), sizeof(argv)/sizeof(argv[0]), argv).ToLocalChecked();
+
+  return audioBufferObj;
+}
+
+Local<Object> AudioContext::CreateEmptyBuffer(Local<Function> audioBufferConstructor, uint32_t sampleRate) {
+  Local<Value> argv[] = {
     JS_INT(sampleRate),
   };
   Local<Object> audioBufferObj = audioBufferConstructor->NewInstance(Isolate::GetCurrent()->GetCurrentContext(), sizeof(argv)/sizeof(argv[0]), argv).ToLocalChecked();
@@ -366,8 +376,21 @@ NAN_METHOD(AudioContext::CreateBuffer) {
 
     info.GetReturnValue().Set(audioBufferObj);
   } else {
-    Nan::ThrowError("invalid arguments");
+    Nan::ThrowError("AudioContext::CreateBuffer: invalid arguments");
   }
+}
+
+NAN_METHOD(AudioContext::CreateEmptyBuffer) {
+  // Nan::HandleScope scope;
+  
+  Local<Object> audioContextObj = info.This();
+  AudioContext *audioContext = ObjectWrap::Unwrap<AudioContext>(audioContextObj);
+
+  Local<Function> audioBufferConstructor = Local<Function>::Cast(JS_OBJ(audioContextObj->Get(JS_STR("constructor")))->Get(JS_STR("AudioBuffer")));
+  uint32_t sampleRate = (uint32_t)audioContext->audioContext->sampleRate();
+  Local<Object> audioBufferObj = audioContext->CreateEmptyBuffer(audioBufferConstructor, sampleRate);
+
+  info.GetReturnValue().Set(audioBufferObj);
 }
 
 NAN_METHOD(AudioContext::CreateBufferSource) {

--- a/deps/exokit-bindings/webaudiocontext/src/AudioSourceNode.cpp
+++ b/deps/exokit-bindings/webaudiocontext/src/AudioSourceNode.cpp
@@ -47,8 +47,9 @@ NAN_METHOD(AudioSourceNode::New) {
 
         audioSourceNode->context.Reset(audioContextObj);
         audioSourceNode->audioNode = audio->audioNode;
-        
-        audio->Reparent();
+
+        AudioContext *audioContext = ObjectWrap::Unwrap<AudioContext>(Local<Object>::Cast(audioContextObj));
+        audio->Reparent(audioContext);
 
         info.GetReturnValue().Set(audioSourceNodeObj);
       } else {

--- a/deps/exokit-bindings/webaudiocontext/src/AudioSourceNode.cpp
+++ b/deps/exokit-bindings/webaudiocontext/src/AudioSourceNode.cpp
@@ -47,6 +47,8 @@ NAN_METHOD(AudioSourceNode::New) {
 
         audioSourceNode->context.Reset(audioContextObj);
         audioSourceNode->audioNode = audio->audioNode;
+        
+        audio->Reparent();
 
         info.GetReturnValue().Set(audioSourceNodeObj);
       } else {

--- a/deps/exokit-bindings/webaudiocontext/src/GainNode.cpp
+++ b/deps/exokit-bindings/webaudiocontext/src/GainNode.cpp
@@ -32,7 +32,7 @@ void GainNode::InitializePrototype(Local<ObjectTemplate> proto) {
 }
 
 NAN_METHOD(GainNode::New) {
-  Nan::HandleScope scope;
+  // Nan::HandleScope scope;
 
   if (info[0]->IsObject() && JS_OBJ(JS_OBJ(info[0])->Get(JS_STR("constructor")))->Get(JS_STR("name"))->StrictEquals(JS_STR("AudioContext"))) {
     Local<Object> audioContextObj = Local<Object>::Cast(info[0]);

--- a/deps/exokit-bindings/webaudiocontext/src/PannerNode.cpp
+++ b/deps/exokit-bindings/webaudiocontext/src/PannerNode.cpp
@@ -46,7 +46,7 @@ void PannerNode::InitializePrototype(Local<ObjectTemplate> proto) {
 }
 
 NAN_METHOD(PannerNode::New) {
-  Nan::HandleScope scope;
+  // Nan::HandleScope scope;
 
   if (info[0]->IsObject() && JS_OBJ(JS_OBJ(info[0])->Get(JS_STR("constructor")))->Get(JS_STR("name"))->StrictEquals(JS_STR("AudioContext"))) {
     Local<Object> audioContextObj = Local<Object>::Cast(info[0]);

--- a/deps/exokit-bindings/webaudiocontext/src/StereoPannerNode.cpp
+++ b/deps/exokit-bindings/webaudiocontext/src/StereoPannerNode.cpp
@@ -31,7 +31,7 @@ void StereoPannerNode::InitializePrototype(Local<ObjectTemplate> proto) {
 }
 
 NAN_METHOD(StereoPannerNode::New) {
-  Nan::HandleScope scope;
+  // Nan::HandleScope scope;
 
   if (info[0]->IsObject() && JS_OBJ(JS_OBJ(info[0])->Get(JS_STR("constructor")))->Get(JS_STR("name"))->StrictEquals(JS_STR("AudioContext"))) {
     Local<Object> audioContextObj = Local<Object>::Cast(info[0]);

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "mkdirp": "^0.5.1",
     "murmurhash-js": "^1.0.0",
     "nan": "^2.14.0",
-    "native-audio-deps": "0.0.63",
+    "native-audio-deps": "0.0.64",
     "native-browser-deps": "0.0.16",
     "native-browser-deps-linux": "0.0.8",
     "native-browser-deps-macos": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "mkdirp": "^0.5.1",
     "murmurhash-js": "^1.0.0",
     "nan": "^2.14.0",
-    "native-audio-deps": "0.0.64",
+    "native-audio-deps": "0.0.65",
     "native-browser-deps": "0.0.16",
     "native-browser-deps-linux": "0.0.8",
     "native-browser-deps-macos": "0.0.1",

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2722,13 +2722,15 @@ class HTMLAudioElement extends HTMLMediaElement {
                   return Promise.reject(new Error(`audio src got invalid status code (url: ${JSON.stringify(src)}, code: ${res.status})`));
                 }
               })
-              .then(arrayBuffer => {
-                try {
-                  this.audio.load(arrayBuffer);
-                } catch(err) {
-                  throw new Error(`failed to decode audio: ${err.message} (url: ${JSON.stringify(src)}, size: ${arrayBuffer.byteLength})`);
-                }
-              })
+              .then(arrayBuffer => new Promise((accept, reject) => {
+                this.audio.load(arrayBuffer, err => {
+                  if (!err) {
+                    accept();
+                  } else {
+                    reject(new Error(`failed to decode audio: ${err.message} (url: ${JSON.stringify(src)}, size: ${arrayBuffer.byteLength})`));
+                  }
+                });
+              }))
               .then(() => {
                 this.readyState = HTMLMediaElement.HAVE_ENOUGH_DATA;
 

--- a/src/native-bindings.js
+++ b/src/native-bindings.js
@@ -402,31 +402,18 @@ if (bindings.nativeAudio) {
   bindings.nativeAudio.AudioContext = (OldAudioContext => class AudioContext extends OldAudioContext {
     decodeAudioData(arrayBuffer, successCallback, errorCallback) {
       return new Promise((resolve, reject) => {
-        try {
-          let audioBuffer = this._decodeAudioDataSync(arrayBuffer);
-          if (successCallback) {
-            process.nextTick(() => {
-              try {
-                successCallback(audioBuffer);
-              } catch(err) {
-                console.warn(err);
-              }
-            });
+        const audioBuffer = this.createEmptyBuffer();
+        audioBuffer.load(arrayBuffer, err => {
+          if (!err) {
+            resolve(audioBuffer);
+          } else {
+            reject(new Error(err));
           }
-          resolve(audioBuffer);
-        } catch(err) {
-          console.warn(err);
-          if (errorCallback) {
-            process.nextTick(() => {
-              try {
-                errorCallback(err);
-              } catch(err) {
-                console.warn(err);
-              }
-            });
-          }
-          reject(err);
-        }
+        });
+      }).then(audioBuffer => {
+        successCallback && successCallback(audioBuffer);
+      }).catch(err => {
+        errorCallback && errorCallback(err);
       });
     }
   })(bindings.nativeAudio.AudioContext);


### PR DESCRIPTION
This PR makes `HTMLAudioElement` and WebAudio's `AudioBuffer` decode on a separate thread (using FFMpeg as usual).

Previously this was not the case, meaning audio loaded on the main thread and locked things up for large tracks. That should now be fixed.

This also addresses a few race conditions in the `WebAudio` calling back to the main thread, improving `WebAudio` reliability for things like Moon Rider.

Related issue: https://github.com/exokitxr/exokit/issues/1078
Fixes https://github.com/exokitxr/exokit/issues/174