### PR TITLE
Realitytabs.html  texture mipmapping 

### DIFF
--- a/examples/realitytabs.html
+++ b/examples/realitytabs.html
@@ -928,11 +928,11 @@ const _makeRig = () => {
         THREE.UVMapping,
         THREE.ClampToEdgeWrapping,
         THREE.ClampToEdgeWrapping,
-        THREE.NearestFilter,
+        THREE.LinearMipMapLinearFilter,
         THREE.NearestFilter,
         THREE.RGBAFormat,
         THREE.UnsignedByteType,
-        1
+        16
       );
       texture.needsUpdate = true;
       const material = new THREE.MeshBasicMaterial({
@@ -1158,11 +1158,11 @@ const _makeRig = () => {
         THREE.UVMapping,
         THREE.ClampToEdgeWrapping,
         THREE.ClampToEdgeWrapping,
-        THREE.NearestFilter,
+        THREE.LinearMipMapLinearFilter,
         THREE.NearestFilter,
         THREE.RGBAFormat,
         THREE.UnsignedByteType,
-        1
+        16
       );
       texture.needsUpdate = true;
       const material = new THREE.MeshBasicMaterial({
@@ -1258,11 +1258,11 @@ const _makeRig = () => {
         THREE.UVMapping,
         THREE.ClampToEdgeWrapping,
         THREE.ClampToEdgeWrapping,
-        THREE.NearestFilter,
+        THREE.LinearMipMapLinearFilter,
         THREE.NearestFilter,
         THREE.RGBAFormat,
         THREE.UnsignedByteType,
-        1
+        16
       );
       texture.needsUpdate = true;
       const material = new THREE.MeshBasicMaterial({
@@ -1539,11 +1539,11 @@ const _makeRig = () => {
         THREE.UVMapping,
         THREE.ClampToEdgeWrapping,
         THREE.ClampToEdgeWrapping,
-        THREE.NearestFilter,
+        THREE.LinearMipMapLinearFilter,
         THREE.NearestFilter,
         THREE.RGBAFormat,
         THREE.UnsignedByteType,
-        1
+        16
       );
       const material = new THREE.MeshBasicMaterial({
         map: texture,
@@ -1569,11 +1569,11 @@ const _makeRig = () => {
             THREE.UVMapping,
             THREE.ClampToEdgeWrapping,
             THREE.ClampToEdgeWrapping,
-            THREE.NearestFilter,
+            THREE.LinearMipMapLinearFilter,
             THREE.NearestFilter,
             THREE.RGBAFormat,
             THREE.UnsignedByteType,
-            1
+            16
           );
           const material = new THREE.MeshBasicMaterial({
             map: texture,

--- a/examples/realitytabs.html
+++ b/examples/realitytabs.html
@@ -929,7 +929,7 @@ const _makeRig = () => {
         THREE.ClampToEdgeWrapping,
         THREE.ClampToEdgeWrapping,
         THREE.LinearMipMapLinearFilter,
-        THREE.NearestFilter,
+        THREE.LinearFilter,
         THREE.RGBAFormat,
         THREE.UnsignedByteType,
         16
@@ -1159,7 +1159,7 @@ const _makeRig = () => {
         THREE.ClampToEdgeWrapping,
         THREE.ClampToEdgeWrapping,
         THREE.LinearMipMapLinearFilter,
-        THREE.NearestFilter,
+        THREE.LinearFilter,
         THREE.RGBAFormat,
         THREE.UnsignedByteType,
         16
@@ -1259,7 +1259,7 @@ const _makeRig = () => {
         THREE.ClampToEdgeWrapping,
         THREE.ClampToEdgeWrapping,
         THREE.LinearMipMapLinearFilter,
-        THREE.NearestFilter,
+        THREE.LinearFilter,
         THREE.RGBAFormat,
         THREE.UnsignedByteType,
         16
@@ -1540,7 +1540,7 @@ const _makeRig = () => {
         THREE.ClampToEdgeWrapping,
         THREE.ClampToEdgeWrapping,
         THREE.LinearMipMapLinearFilter,
-        THREE.NearestFilter,
+        THREE.LinearFilter,
         THREE.RGBAFormat,
         THREE.UnsignedByteType,
         16
@@ -1570,7 +1570,7 @@ const _makeRig = () => {
             THREE.ClampToEdgeWrapping,
             THREE.ClampToEdgeWrapping,
             THREE.LinearMipMapLinearFilter,
-            THREE.NearestFilter,
+            THREE.LinearFilter,
             THREE.RGBAFormat,
             THREE.UnsignedByteType,
             16


### PR DESCRIPTION
This increases the mipmap+filter quality for the `realitytabs.html` instructions texture.

Note: increasing Texture.minFilter to LinearMipMapLinearFilter results in:
```
THREE.WebGLRenderer: Texture is not power of two. Texture.minFilter should be se
t to THREE.NearestFilter or THREE.LinearFilter.
```