### PR TITLE
Clean up requestPresent

### DIFF
--- a/src/VR.js
+++ b/src/VR.js
@@ -640,7 +640,7 @@ const hmdTypeIndexMap = (() => {
   });
   return result;
 })();
-const lookupHMDTypeIndex = s => hmdTypeIndexMap[k];
+const lookupHMDTypeIndex = s => hmdTypeIndexMap[s];
 const hmdTypeStringMap = (() => {
   const result = {};
   hmdTypes.forEach((t, i) => {
@@ -648,7 +648,7 @@ const hmdTypeStringMap = (() => {
   });
   return result;
 })();
-const lookupHMDTypeString = i => hmdTypeStringMap[k];
+const lookupHMDTypeString = i => hmdTypeStringMap[i];
 
 const createVRDisplay = () => new FakeVRDisplay();
 

--- a/src/VR.js
+++ b/src/VR.js
@@ -626,6 +626,29 @@ const getHMDType = () => {
     return null;
   }
 };
+const hmdTypes = [
+  'fake',
+  'oculus',
+  'openvr',
+  'oculusMobile',
+  'magicleap',
+];
+const hmdTypeIndexMap = (() => {
+  const result = {};
+  hmdTypes.forEach((t, i) => {
+    result[t] = i;
+  });
+  return result;
+})();
+const lookupHMDTypeIndex = s => hmdTypeIndexMap[k];
+const hmdTypeStringMap = (() => {
+  const result = {};
+  hmdTypes.forEach((t, i) => {
+    result[i] = t;
+  });
+  return result;
+})();
+const lookupHMDTypeString = i => hmdTypeStringMap[k];
 
 const createVRDisplay = () => new FakeVRDisplay();
 

--- a/src/VR.js
+++ b/src/VR.js
@@ -713,6 +713,8 @@ module.exports = {
   Gamepad,
   GamepadButton,
   getHMDType,
+  lookupHMDTypeString,
+  lookupHMDTypeIndex,
   createVRDisplay,
   getGamepads
 };

--- a/src/Window.js
+++ b/src/Window.js
@@ -72,6 +72,7 @@ const {
   GamepadButton,
   getGamepads,
   getHMDType,
+  lookupHMDTypeString,
 } = require('./VR.js');
 
 const {maxNumTrackers} = require('./constants');
@@ -1382,16 +1383,17 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
   const _makeMrDisplays = () => {
     const _onrequestpresent = async () => {
       if (!xrState.isPresenting[0]) {
-        const {hmdType} = await new Promise((accept, reject) => {
+        await new Promise((accept, reject) => {
           vrPresentState.responseAccept = accept;
 
-          xrState.vrRequest[1] = GlobalContext.id;
-          xrState.vrRequest[0] = 1; // requestPresent
+          parentPort.postMessage({
+            method: 'request',
+            type: 'requestPresent,
+          });
         });
-
-        vrPresentState.hmdType = hmdType;
-        GlobalContext.clearGamepads();
       }
+      vrPresentState.hmdType = lookupHMDTypeString(vrPresentState.hmdType[0]);
+      GlobalContext.clearGamepads();
     };
     const _onmakeswapchain = context => {
       const windowHandle = context.getWindowHandle();

--- a/src/Window.js
+++ b/src/Window.js
@@ -1388,11 +1388,11 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
 
           parentPort.postMessage({
             method: 'request',
-            type: 'requestPresent,
+            type: 'requestPresent',
           });
         });
       }
-      vrPresentState.hmdType = lookupHMDTypeString(vrPresentState.hmdType[0]);
+      vrPresentState.hmdType = lookupHMDTypeString(xrState.hmdType[0]);
       GlobalContext.clearGamepads();
     };
     const _onmakeswapchain = context => {

--- a/src/WindowVm.js
+++ b/src/WindowVm.js
@@ -16,6 +16,10 @@ class WorkerVm extends EventEmitter {
     });
     worker.on('message', m => {
       switch (m.method) {
+        case 'request': {
+          GlobalContext.handleRequest(m, this);
+          break;
+        }
         case 'response': {
           const fn = this.queue[m.requestKey];
 

--- a/src/index.js
+++ b/src/index.js
@@ -295,33 +295,11 @@ const topVrPresentState = {
   hasPose: false,
 };
 
-const _startTopRenderLoop = () => {
-  const timestamps = {
-    frames: 0,
-    last: Date.now(),
-    idle: 0,
-    wait: 0,
-    events: 0,
-    media: 0,
-    user: 0,
-    submit: 0,
-    total: 0,
-  };
-  const TIMESTAMP_FRAMES = 100;
-  const childSyncs = [];
-
-  if (nativeBindings.nativeWindow.pollEvents) {
-    setInterval(() => {
-      nativeBindings.nativeWindow.pollEvents();
-    }, 1000/60); // XXX make this run at the native frame rate
-  }
-
-  const _handleRequestPresent = async () => {
-    const vrRequestMethod = xrState.vrRequest[0];
-
-    if (vrRequestMethod === 1) { // requestPresent
+const handleRequest = ({type}, window) () => {
+  if (!topVrPresentState.hmdType) {
+    if (type === 'requestPresent') {
       const hmdType = getHMDType();
-      console.log('request present', hmdType); // XXX
+      // console.log('request present', hmdType);
 
       if (!topVrPresentState.windowHandle) {
         topVrPresentState.windowHandle = nativeBindings.nativeWindow.createWindowHandle(1, 1, false);
@@ -407,21 +385,9 @@ const _startTopRenderLoop = () => {
 
       topVrPresentState.hmdType = hmdType;
 
-      const windowId = xrState.vrRequest[1];
-      const window = windows.find(window => window.id === windowId);
-
       xrState.isPresenting[0] = 1;
-      xrState.vrRequest.fill(0);
-
-      if (window) {
-        window.runAsync(JSON.stringify({
-          method: 'response',
-          hmdType,
-        }));
-      } else {
-        console.warn(`no top level window to respond to for request present: ${hmdType} ${windowId} ${JSON.stringify(windows.map(window => window.id))}`);
-      }
-    } else if (vrRequestMethod === 2) { // exitPresent
+      xrState.hmdType[0] = lookupHMDTypeIndex(hmdType);
+    } else if (type === 'exitPresent') {
       if (topVrPresentState.hmdType === 'fake') {
         // XXX destroy fbo
       } else {
@@ -430,17 +396,38 @@ const _startTopRenderLoop = () => {
 
       topVrPresentState.hmdType = null;
 
-      const windowId = xrState.vrRequest[1];
-      const window = windows.find(window => window.id === windowId);
-
       xrState.isPresenting[0] = 0;
-      xrState.vrRequest.fill(0);
-
-      window.runAsync(JSON.stringify({
-        method: 'response',
-      }));
+      xrState.hmdType[0] = 0;
     }
+  }
+
+  window.runAsync(JSON.stringify({
+    method: 'response',
+  }));
+};
+GlobalContext.handleRequest = handleRequest;
+
+const _startTopRenderLoop = () => {
+  const timestamps = {
+    frames: 0,
+    last: Date.now(),
+    idle: 0,
+    wait: 0,
+    events: 0,
+    media: 0,
+    user: 0,
+    submit: 0,
+    total: 0,
   };
+  const TIMESTAMP_FRAMES = 100;
+  const childSyncs = [];
+
+  if (nativeBindings.nativeWindow.pollEvents) {
+    setInterval(() => {
+      nativeBindings.nativeWindow.pollEvents();
+    }, 1000/60); // XXX make this run at the native frame rate
+  }
+
   const _waitGetPoses = () => {
     if (topVrPresentState.hmdType === 'oculus') {
       return _waitGetPosesOculus();
@@ -877,7 +864,6 @@ const _startTopRenderLoop = () => {
       timestamps.last = now;
     }
 
-    await _handleRequestPresent();
     await _waitGetPoses();
 
     _computeDerivedGamepadsData();

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ const {defaultEyeSeparation, maxNumTrackers} = require('./constants.js');
 const symbols = require('./symbols');
 const THREE = require('../lib/three-min.js');
 
-const {getHMDType} = require('./VR.js');
+const {getHMDType, lookupHMDTypeIndex} = require('./VR.js');
 
 const nativeBindings = require(path.join(__dirname, 'native-bindings.js'));
 
@@ -274,7 +274,7 @@ const xrState = (() => {
     return result;
   })();
   result.id = _makeTypedArray(Uint32Array, 1);
-  result.vrRequest = _makeTypedArray(Uint32Array, 2);
+  result.hmdType = _makeTypedArray(Uint32Array, 1);
   result.tex = _makeTypedArray(Uint32Array, 1);
   result.depthTex = _makeTypedArray(Uint32Array, 1);
   result.fakeVrDisplayEnabled = _makeTypedArray(Uint32Array, 1);

--- a/src/index.js
+++ b/src/index.js
@@ -295,7 +295,7 @@ const topVrPresentState = {
   hasPose: false,
 };
 
-const handleRequest = ({type}, window) () => {
+const handleRequest = ({type}, window) => {
   if (!topVrPresentState.hmdType) {
     if (type === 'requestPresent') {
       const hmdType = getHMDType();


### PR DESCRIPTION
This moves the top-level `requestPresent` logic to a message-passing style from the lower window, instead of using shared memory checked at the top level render loop.

This is cleaner, but mostly just a prerequisite for testing other render loop strategies.

Notably this is also how the `studio` branch request presenting works.