### PR TITLE
Bugfix wrong VR.js isPresenting reference

### DIFF
--- a/src/VR.js
+++ b/src/VR.js
@@ -113,7 +113,7 @@ class GamepadHapticActuator {
   }
   set type(type) {}
   pulse(value, duration) {
-    if (GlobalContext.vrPresentState.isPresenting) {
+    if (GlobalContext.xrState.isPresenting[0]) {
       value = Math.min(Math.max(value, 0), 1);
       const deviceIndex = GlobalContext.vrPresentState.system.GetTrackedDeviceIndexForControllerRole(this.index + 1);
 


### PR DESCRIPTION
`isPresenting` moved to the global `xrState` a while ago, but the VR.js haptics code was referencing the old code.