### PR TITLE
Web Workers importScripts

### DIFF
--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -69,6 +69,7 @@ const _normalizeUrl = src => {
     return src;
   }
 };
+const SYNC_REQUEST_BUFFER_SIZE = 5 * 1024 * 1024; // TODO: we can make this unlimited with a streaming buffer + atomics loop
 function getScript(url) {
   let match;
   if (match = url.match(/^data:.+?(;base64)?,(.*)$/)) {
@@ -80,7 +81,7 @@ function getScript(url) {
   } else if (match = url.match(/^file:\/\/(.*)$/)) {
     return fs.readFileSync(match[1], 'utf8');
   } else {
-    const sab = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT*3 + 5 * 1024 * 1024);
+    const sab = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT*3 + SYNC_REQUEST_BUFFER_SIZE);
     const int32Array = new Int32Array(sab);
     const worker = new Worker(path.join(__dirname, 'request.js'), {
       workerData: {

--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -80,7 +80,7 @@ function getScript(url) {
   } else if (match = url.match(/^file:\/\/(.*)$/)) {
     return fs.readFileSync(match[1], 'utf8');
   } else {
-    const sab = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT*2 + 5 * 1024 * 1024);
+    const sab = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT*3 + 5 * 1024 * 1024);
     const int32Array = new Int32Array(sab);
     const worker = new Worker(path.join(__dirname, 'request.js'), {
       workerData: {
@@ -92,10 +92,10 @@ function getScript(url) {
       console.warn(err.stack);
     });
     Atomics.wait(int32Array, 0, 0);
-    const status = new Uint32Array(sab, 0, 1)[0];
-    const length = new Uint32Array(sab, Int32Array.BYTES_PER_ELEMENT, 1)[0];
-    const result = Buffer.from(sab, Int32Array.BYTES_PER_ELEMENT*2, length).toString('utf8');
-    if (status === 1) {
+    const status = new Uint32Array(sab, Int32Array.BYTES_PER_ELEMENT*1, 1)[0];
+    const length = new Uint32Array(sab, Int32Array.BYTES_PER_ELEMENT*2, 1)[0];
+    const result = Buffer.from(sab, Int32Array.BYTES_PER_ELEMENT*3, length).toString('utf8');
+    if (status >= 200 && status < 300) {
       return result;
     } else {
       throw new Error(`fetch ${url} failed (${JSON.stringify(status)}): ${result}`);

--- a/src/request.js
+++ b/src/request.js
@@ -1,0 +1,54 @@
+const {Console} = require('console');
+const stream = require('stream');
+const {
+  nativeConsole,
+} = require('./native-bindings');
+
+const consoleStream = new stream.Writable();
+consoleStream._write = (chunk, encoding, callback) => {
+  nativeConsole.Log(chunk);
+  callback();
+};
+consoleStream._writev = (chunks, callback) => {
+  for (let i = 0; i < chunks.length; i++) {
+    nativeConsole.Log(chunks[i]);
+  }
+  callback();
+};
+global.console = new Console(consoleStream);
+
+console.log('request inner 1');
+
+const fetch = require('window-fetch');
+const {workerData, parentPort} = require('worker_threads');
+const {url, int32Array} = workerData;
+
+console.log('request inner 2', url, int32Array.byteLength);
+
+(async () => {
+  const res = await fetch(url);
+  if (res.status >= 200 && res.status < 300) {
+    const arrayBuffer = await res.arrayBuffer();
+    const srcBuffer = new Uint8Array(arrayBuffer, 0, arrayBuffer.byteLength);
+    const dstBuffer = new Uint8Array(int32Array.buffer, int32Array.byteOffset + Int32Array.BYTES_PER_ELEMENT*3, int32Array.byteLength - Int32Array.BYTES_PER_ELEMENT*3);
+    if (dstBuffer.byteLength >= srcBuffer.byteLength) {
+      dstBuffer.set(srcBuffer);
+      int32Array[1] = res.status;
+      int32Array[2] = arrayBuffer.byteLength;
+    } else {
+      int32Array[1] = 0;
+      int32Array[2] = 0;
+    }
+  } else {
+    int32Array[1] = req.status;
+    int32Array[2] = 0;
+  }
+})().catch(err => {
+  console.warn('request error', err.stack);
+  
+  int32Array[1] = 0;
+  int32Array[2] = 0;
+}).finally(() => {
+  int32Array[0] = 1;
+  Atomics.notify(int32Array, 0);
+});

--- a/src/request.js
+++ b/src/request.js
@@ -17,13 +17,9 @@ consoleStream._writev = (chunks, callback) => {
 };
 global.console = new Console(consoleStream);
 
-console.log('request inner 1');
-
 const fetch = require('window-fetch');
 const {workerData, parentPort} = require('worker_threads');
 const {url, int32Array} = workerData;
-
-console.log('request inner 2', url, int32Array.byteLength);
 
 (async () => {
   const res = await fetch(url);


### PR DESCRIPTION
Web Worker `importScripts`, which allows one to perform synchronous injection of code from the network, is a pretty weird feature, since it's the only case (other than deprecated `XMLHttpRequest` sync mode) where you can write code that blocks on the network.

The way we do this in Exokit is create a sub-worker to a `request.js` script that blocks on atomics to do the actual request asynchronously in a separate thread. This works with no native modules, only regular Javascript + node.js features.

The bug here was that `request.js` was missing. This PR implements it and patches in the worker environment calls to capture the requests.