### PR TITLE
HTMLAudioElement/HTMLVideoElement loaded events

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2740,6 +2740,7 @@ class HTMLAudioElement extends HTMLMediaElement {
                 progressEvent.lengthComputable = true;
                 this._emit(progressEvent);
 
+                this._dispatchEventOnDocumentReady(new Event('loadeddata', {target: this}));
                 this._dispatchEventOnDocumentReady(new Event('canplay', {target: this}));
                 this._dispatchEventOnDocumentReady(new Event('canplaythrough', {target: this}));
                 
@@ -2850,6 +2851,7 @@ class HTMLVideoElement extends HTMLMediaElement {
           
           this.readyState = 'complete';
 
+          this._dispatchEventOnDocumentReady(new Event('loadeddata', {target: this}));
           this._dispatchEventOnDocumentReady(new Event('canplay', {target: this}));
           this._dispatchEventOnDocumentReady(new Event('canplaythrough', {target: this}));
 

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2741,6 +2741,7 @@ class HTMLAudioElement extends HTMLMediaElement {
                 this._emit(progressEvent);
 
                 this._dispatchEventOnDocumentReady(new Event('loadeddata', {target: this}));
+                this._dispatchEventOnDocumentReady(new Event('loadedmetadata', {target: this}));
                 this._dispatchEventOnDocumentReady(new Event('canplay', {target: this}));
                 this._dispatchEventOnDocumentReady(new Event('canplaythrough', {target: this}));
                 
@@ -2852,6 +2853,7 @@ class HTMLVideoElement extends HTMLMediaElement {
           this.readyState = 'complete';
 
           this._dispatchEventOnDocumentReady(new Event('loadeddata', {target: this}));
+          this._dispatchEventOnDocumentReady(new Event('loadedmetadata', {target: this}));
           this._dispatchEventOnDocumentReady(new Event('canplay', {target: this}));
           this._dispatchEventOnDocumentReady(new Event('canplaythrough', {target: this}));
 


### PR DESCRIPTION
There are `loadeddata` and `loadedmetadata` for media elements that we forgot to emit when we finish loading media. This PR adds them.

Moon Rider was depending on these.