### PR TITLE
WorkerGlobalScope globals

### DIFF
--- a/src/Window.js
+++ b/src/Window.js
@@ -654,7 +654,6 @@ const _makeOnRequestHitTest = window => (origin, direction, cb) => nativeMl.Requ
   window.indexedDB = indexedDB;
   window.performance = performance;
   window.screen = new Screen(window);
-  window.urls = urls; // XXX non-standard
   window.scrollTo = function(x = 0, y = 0) {
     this.scrollX = x;
     this.scrollY = y;

--- a/src/Window.js
+++ b/src/Window.js
@@ -2,14 +2,11 @@ const events = require('events');
 const {EventEmitter} = events;
 const path = require('path');
 const fs = require('fs');
-const url = require('url');
 const http = require('http');
 const https = require('https');
-const crypto = require('crypto');
 const os = require('os');
 const {parentPort} = require('worker_threads');
 const util = require('util');
-const {URL} = url;
 const {TextEncoder, TextDecoder} = util;
 const {XRRigidTransform} = require('./XR.js');
 const {performance} = require('perf_hooks');
@@ -25,19 +22,11 @@ const {
   },
 } = require('worker_threads');
 
-const {WorkerVm} = require('./WindowVm.js');
-const {FileReader} = require('./File.js');
-
 const mkdirp = require('mkdirp');
 const ws = require('ws');
-const {XMLHttpRequest: XMLHttpRequestBase, FormData} = require('window-xhr');
-
-const fetch = require('window-fetch');
-const {Request, Response, Headers, Blob} = fetch;
 
 const core = require('./core.js');
 
-const WebSocket = require('ws/lib/websocket');
 const {
   /* getUserMedia,
   MediaStream,
@@ -78,7 +67,6 @@ const {
 const {maxNumTrackers} = require('./constants');
 const GlobalContext = require('./GlobalContext');
 const symbols = require('./symbols');
-const {urls} = require('./urls');
 
 const {
   nativeImage: Image,
@@ -140,7 +128,6 @@ const {
   DOMPoint,
   createImageBitmap,
 } = require('./DOM');
-const {CustomEvent, DragEvent, ErrorEvent, Event, EventTarget, KeyboardEvent, MessageEvent, MouseEvent, WheelEvent, PromiseRejectionEvent} = require('./Event');
 const {History} = require('./History');
 const {Location} = require('./Location');
 const XR = require('./XR');
@@ -148,8 +135,7 @@ const DevTools = require('./DevTools');
 const utils = require('./utils');
 const {_elementGetter, _elementSetter, _download} = utils;
 
-const btoa = s => Buffer.from(s, 'binary').toString('base64');
-const atob = s => Buffer.from(s, 'base64').toString('binary');
+setBaseUrl(options.baseUrl);
 
 const isMac = os.platform() === 'darwin';
 
@@ -463,50 +449,6 @@ class DataTransferItem {
   }
 }
 
-class Worker extends EventTarget {
-  constructor(src) {
-    super();
-
-    const worker = new WorkerVm({
-      initModule: path.join(__dirname, 'Worker.js'),
-      args: {
-        src,
-      },
-    });
-    worker.on('message', m => {
-      const e = new MessageEvent('message', {
-        data: m.message,
-      });
-      this.emit('message', e);
-    });
-    worker.on('error', err => {
-      this.emit('error', err);
-    });
-    this.worker = worker;
-  }
-
-  postMessage(message, transferList) {
-    this.worker.postMessage(message, transferList);
-  }
-
-  terminate() {
-    this.worker.destroy();
-  }
-
-  get onmessage() {
-    return this.listeners('message')[0];
-  }
-  set onmessage(onmessage) {
-    this.on('message', onmessage);
-  }
-  get onerror() {
-    return this.listeners('error')[0];
-  }
-  set onerror(onerror) {
-    this.on('error', onerror);
-  }
-}
-
 let rafIndex = 0;
 const _findFreeSlot = a => {
   let i;
@@ -528,8 +470,6 @@ const _makeRequestAnimationFrame = window => (fn, priority = 0) => {
   return id;
 };
 const _makeOnRequestHitTest = window => (origin, direction, cb) => nativeMl.RequestHitTest(origin, direction, cb, window);
-
-const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
 
 (window => {
   for (const k in EventEmitter.prototype) {
@@ -674,7 +614,6 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
     window.navigator.xr = new XR.XR(window);
   }
 
-  window.URL = URL;
   window.alert = console.log;
   window.setTimeout = (setTimeout => (fn, timeout, args) => {
     fn = fn.bind.apply(fn, [window].concat(args));
@@ -709,106 +648,6 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
       intervals[id] = null;
     }
   })(clearInterval);
-  const _maybeDownload = (m, u, data, bufferifyFn) => options.args.download ? _download(m, u, data, bufferifyFn, options.args.download) : data;
-  window.fetch = (u, options) => {
-    const _boundFetch = (u, options) => fetch(u, options)
-      .then(res => {
-        const method = (options && options.method) || 'GET';
-        res.arrayBuffer = (fn => function() {
-          return fn.apply(this, arguments)
-            .then(ab => _maybeDownload(method, u, ab, ab => Buffer.from(ab)));
-        })(res.arrayBuffer);
-        res.blob = (fn => function() {
-          return fn.apply(this, arguments)
-            .then(blob => _maybeDownload(method, u, blob, blob => blob.buffer));
-        })(res.blob);
-        res.json = (fn => function() {
-          return fn.apply(this, arguments)
-            .then(j => _maybeDownload(method, u, j, j => Buffer.from(JSON.stringify(j))));
-        })(res.json);
-        res.text = (fn => function() {
-          return fn.apply(this, arguments)
-            .then(t => _maybeDownload(method, u, t, t => Buffer.from(t, 'utf8')));
-        })(res.text);
-
-        return res;
-      });
-
-    if (typeof u === 'string') {
-      const blob = urls.get(u);
-      if (blob) {
-        return Promise.resolve(new Response(blob));
-      } else {
-        u = _normalizeUrl(u);
-        return _boundFetch(u, options);
-      }
-    } else {
-      return _boundFetch(u, options);
-    }
-  };
-  window.Request = Request;
-  window.Response = Response;
-  window.Headers = Headers;
-  window.Blob = Blob;
-  window.FormData = FormData;
-  window.XMLHttpRequest = (Old => {
-    class XMLHttpRequest extends Old {
-      open(method, url, async, username, password) {
-        url = _normalizeUrl(url);
-        return super.open(method, url, async, username, password);
-      }
-      get response() {
-        return _maybeDownload(this._properties.method, this._properties.uri, super.response, o => {
-          switch (this.responseType) {
-            case 'arraybuffer': return Buffer.from(o);
-            case 'blob': return o.buffer;
-            case 'json': return Buffer.from(JSON.stringify(o), 'utf8');
-            case 'text': return Buffer.from(o, 'utf8');
-            default: throw new Error(`cannot download responseType ${responseType}`);
-          }
-        });
-      }
-    }
-    for (const k in XMLHttpRequestBase) {
-      XMLHttpRequest[k] = XMLHttpRequestBase[k];
-    }
-    return XMLHttpRequest;
-  })(XMLHttpRequest);
-  window.WebSocket = WebSocket;
-  window.crypto = {
-    getRandomValues(typedArray) {
-      crypto.randomFillSync(Buffer.from(typedArray.buffer, typedArray.byteOffset, typedArray.byteLength));
-      return typedArray;
-    },
-
-    subtle: {
-      digest(algo, bytes) {
-        switch (algo) {
-          case 'SHA-1': {
-            algo = 'sha1';
-            break;
-          }
-          case 'SHA-256': {
-            algo = 'sha256';
-            break;
-          }
-          case 'SHA-384': {
-            algo = 'sha384';
-            break;
-          }
-          case 'SHA-512': {
-            algo = 'sha512';
-            break;
-          }
-          default: throw new Error(`unknown algorithm: ${algo}`);
-        }
-        const hash = crypto.createHash(algo).update(bytes).digest();
-        const result = new ArrayBuffer(hash.byteLength);
-        new Buffer(result).set(hash);
-        return Promise.resolve(result);
-      },
-    },
-  };
   window.event = new Event(); // XXX this needs to track the current event
   window.localStorage = new LocalStorage(path.join(options.dataPath, '.localStorage'));
   window.sessionStorage = new LocalStorage(path.join(options.dataPath, '.sessionStorage'));
@@ -1022,15 +861,6 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
     }
   };
   // window.Buffer = Buffer; // XXX non-standard
-  window.Event = Event;
-  window.KeyboardEvent = KeyboardEvent;
-  window.MouseEvent = MouseEvent;
-  window.WheelEvent = WheelEvent;
-  window.DragEvent = DragEvent;
-  window.MessageEvent = MessageEvent;
-  window.PromiseRejectionEvent = PromiseRejectionEvent;
-  window.CustomEvent = CustomEvent;
-  window.EventTarget = EventTarget;
   window.addEventListener = EventTarget.prototype.addEventListener.bind(window);
   window.removeEventListener = EventTarget.prototype.removeEventListener.bind(window);
   window.dispatchEvent = EventTarget.prototype.dispatchEvent.bind(window);
@@ -1048,7 +878,6 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
   window.MediaRecorder = MediaRecorder;
   window.DataTransfer = DataTransfer;
   window.DataTransferItem = DataTransferItem;
-  window.FileReader = FileReader;
   window.Screen = Screen;
   window.Gamepad = Gamepad;
   window.VRStageParameters = VRStageParameters;
@@ -1074,8 +903,6 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
     window.XRStageBounds = XR.XRStageBounds;
     window.XRStageBoundsPoint = XR.XRStageBoundsPoint;
   }
-  window.btoa = btoa;
-  window.atob = atob;
   window.TextEncoder = TextEncoder;
   window.TextDecoder = TextDecoder;
   window.AudioContext = AudioContext;
@@ -1090,20 +917,7 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
   window.PannerNode = PannerNode;
   window.StereoPannerNode = StereoPannerNode;
   window.createImageBitmap = createImageBitmap;
-  window.Worker = class extends Worker {
-    constructor(src) {
-      if (src instanceof Blob) {
-        super('data:application/javascript,' + src.buffer.toString('utf8'));
-      } else {
-        const blob = urls.get(src);
-        const normalizedSrc = blob ?
-          'data:application/octet-stream;base64,' + blob.buffer.toString('base64')
-        :
-          _normalizeUrl(src);
-        super(normalizedSrc);
-      }
-    }
-  };
+  window.Worker = Worker;
   window.requestAnimationFrame = _makeRequestAnimationFrame(window);
   window.cancelAnimationFrame = id => {
     const index = rafCbs.findIndex(r => r && r[symbols.idSymbol] === id);

--- a/src/Window.js
+++ b/src/Window.js
@@ -675,7 +675,6 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
   }
 
   window.URL = URL;
-  window.console = console;
   window.alert = console.log;
   window.setTimeout = (setTimeout => (fn, timeout, args) => {
     fn = fn.bind.apply(fn, [window].concat(args));

--- a/src/Window.js
+++ b/src/Window.js
@@ -1178,8 +1178,12 @@ const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
       window._emit('beforeunload');
       window._emit('unload');
 
-      window.windowEmit('navigate', {
-        href,
+      parentPort.postMessage({
+        method: 'emit',
+        type: 'navigate',
+        event: {
+          href,
+        },
       });
     }
   });

--- a/src/Window.js
+++ b/src/Window.js
@@ -143,7 +143,6 @@ const {
 const {CustomEvent, DragEvent, ErrorEvent, Event, EventTarget, KeyboardEvent, MessageEvent, MouseEvent, WheelEvent, PromiseRejectionEvent} = require('./Event');
 const {History} = require('./History');
 const {Location} = require('./Location');
-const {XMLHttpRequest} = require('./Network');
 const XR = require('./XR');
 const DevTools = require('./DevTools');
 const utils = require('./utils');

--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -3,10 +3,28 @@ const {EventEmitter} = require('events');
 const stream = require('stream');
 const path = require('path');
 const fs = require('fs');
+const url = require('url');
+const {URL} = url;
 const vm = require('vm');
 const util = require('util');
-const {Worker, workerData, parentPort} = require('worker_threads');
-const {MessageEvent} = require('./Event');
+const crypto = require('crypto');
+const {Worker: WorkerBase, workerData, parentPort} = require('worker_threads');
+
+const {CustomEvent, DragEvent, ErrorEvent, Event, EventTarget, KeyboardEvent, MessageEvent, MouseEvent, WheelEvent, PromiseRejectionEvent} = require('./Event');
+const {FileReader} = require('./File.js');
+const {XMLHttpRequest, FormData} = require('window-xhr');
+const fetch = require('window-fetch');
+const {Request, Response, Headers, Blob} = fetch;
+const WebSocket = require('ws/lib/websocket');
+
+const {WorkerVm} = require('./WindowVm');
+
+const btoa = s => Buffer.from(s, 'binary').toString('base64');
+const atob = s => Buffer.from(s, 'base64').toString('binary');
+
+const utils = require('./utils');
+const {urls} = require('./urls');
+
 const {
   nativeConsole,
 } = require('./native-bindings');
@@ -32,38 +50,202 @@ for (const k in EventEmitter.prototype) {
 }
 EventEmitter.call(global);
 
-global.postMessage = (message, transferList) => parentPort.postMessage({
-  method: 'postMessage',
-  message,
-}, transferList);
-Object.defineProperty(global, 'onmessage', {
-  get() {
-    return this.listeners('message')[0];
-  },
-  set(onmessage) {
-    global.on('message', onmessage);
-  },
-});
+class Worker extends EventTarget {
+  constructor(src) {
+    super();
+    
+    if (src instanceof Blob) {
+      src = 'data:application/javascript,' + src.buffer.toString('utf8');
+    } else {
+      const blob = urls.get(src);
+      src = blob ?
+        'data:application/octet-stream;base64,' + blob.buffer.toString('base64')
+      :
+        _normalizeUrl(src);
+    }
 
+    const worker = new WorkerVm({
+      initModule: path.join(__dirname, 'Worker.js'),
+      args: {
+        src,
+      },
+    });
+    worker.on('message', m => {
+      const e = new MessageEvent('message', {
+        data: m.message,
+      });
+      this.emit('message', e);
+    });
+    worker.on('error', err => {
+      this.emit('error', err);
+    });
+    this.worker = worker;
+  }
+
+  postMessage(message, transferList) {
+    this.worker.postMessage(message, transferList);
+  }
+
+  terminate() {
+    this.worker.destroy();
+  }
+
+  get onmessage() {
+    return this.listeners('message')[0];
+  }
+  set onmessage(onmessage) {
+    this.on('message', onmessage);
+  }
+  get onerror() {
+    return this.listeners('error')[0];
+  }
+  set onerror(onerror) {
+    this.on('error', onerror);
+  }
+}
+
+(self => {
+  self.btoa = btoa;
+  self.atob = atob;
+  
+  self.Event = Event;
+  self.KeyboardEvent = KeyboardEvent;
+  self.MouseEvent = MouseEvent;
+  self.WheelEvent = WheelEvent;
+  self.DragEvent = DragEvent;
+  self.MessageEvent = MessageEvent;
+  self.PromiseRejectionEvent = PromiseRejectionEvent;
+  self.CustomEvent = CustomEvent;
+  self.EventTarget = EventTarget;
+  
+  self.URL = URL;
+  
+  // const _maybeDownload = (m, u, data, bufferifyFn) => options.args.download ? _download(m, u, data, bufferifyFn, options.args.download) : data;
+  const _maybeDownload = (m, u, data, bufferifyFn) => data;
+  self.fetch = (u, options) => {
+    const _boundFetch = (u, options) => fetch(u, options)
+      .then(res => {
+        const method = (options && options.method) || 'GET';
+        res.arrayBuffer = (fn => function() {
+          return fn.apply(this, arguments)
+            .then(ab => _maybeDownload(method, u, ab, ab => Buffer.from(ab)));
+        })(res.arrayBuffer);
+        res.blob = (fn => function() {
+          return fn.apply(this, arguments)
+            .then(blob => _maybeDownload(method, u, blob, blob => blob.buffer));
+        })(res.blob);
+        res.json = (fn => function() {
+          return fn.apply(this, arguments)
+            .then(j => _maybeDownload(method, u, j, j => Buffer.from(JSON.stringify(j))));
+        })(res.json);
+        res.text = (fn => function() {
+          return fn.apply(this, arguments)
+            .then(t => _maybeDownload(method, u, t, t => Buffer.from(t, 'utf8')));
+        })(res.text);
+
+        return res;
+      });
+
+    if (typeof u === 'string') {
+      const blob = urls.get(u);
+      if (blob) {
+        return Promise.resolve(new Response(blob));
+      } else {
+        u = _normalizeUrl(u);
+        return _boundFetch(u, options);
+      }
+    } else {
+      return _boundFetch(u, options);
+    }
+  };
+  self.Request = Request;
+  self.Response = Response;
+  self.Headers = Headers;
+  self.Blob = Blob;
+  self.FormData = FormData;
+  self.XMLHttpRequest = (Old => {
+    class XMLHttpRequest extends Old {
+      open(method, url, async, username, password) {
+        url = _normalizeUrl(url);
+        return super.open(method, url, async, username, password);
+      }
+      get response() {
+        return _maybeDownload(this._properties.method, this._properties.uri, super.response, o => {
+          switch (this.responseType) {
+            case 'arraybuffer': return Buffer.from(o);
+            case 'blob': return o.buffer;
+            case 'json': return Buffer.from(JSON.stringify(o), 'utf8');
+            case 'text': return Buffer.from(o, 'utf8');
+            default: throw new Error(`cannot download responseType ${responseType}`);
+          }
+        });
+      }
+    }
+    for (const k in Old) {
+      XMLHttpRequest[k] = Old[k];
+    }
+    return XMLHttpRequest;
+  })(XMLHttpRequest);
+  self.WebSocket = WebSocket;
+  self.FileReader = FileReader;
+  self.crypto = {
+    getRandomValues(typedArray) {
+      crypto.randomFillSync(Buffer.from(typedArray.buffer, typedArray.byteOffset, typedArray.byteLength));
+      return typedArray;
+    },
+
+    subtle: {
+      digest(algo, bytes) {
+        switch (algo) {
+          case 'SHA-1': {
+            algo = 'sha1';
+            break;
+          }
+          case 'SHA-256': {
+            algo = 'sha256';
+            break;
+          }
+          case 'SHA-384': {
+            algo = 'sha384';
+            break;
+          }
+          case 'SHA-512': {
+            algo = 'sha512';
+            break;
+          }
+          default: throw new Error(`unknown algorithm: ${algo}`);
+        }
+        const hash = crypto.createHash(algo).update(bytes).digest();
+        const result = new ArrayBuffer(hash.byteLength);
+        new Buffer(result).set(hash);
+        return Promise.resolve(result);
+      },
+    },
+  };
+  
+  self.Worker = Worker;
+  
+  self.postMessage = (message, transferList) => parentPort.postMessage({
+    method: 'postMessage',
+    message,
+  }, transferList);
+  Object.defineProperty(self, 'onmessage', {
+    get() {
+      return this.listeners('message')[0];
+    },
+    set(onmessage) {
+      self.on('message', onmessage);
+    },
+  });
+})(global);
 
 let baseUrl = '';
 function setBaseUrl(newBaseUrl) {
   baseUrl = newBaseUrl;
 }
 global.setBaseUrl = setBaseUrl;
+const _normalizeUrl = src => utils._normalizeUrl(src, baseUrl);
 
-const _normalizeUrl = src => {
-  if (!/^(?:data|blob):/.test(src)) {
-    const match = baseUrl.match(/^(file:\/\/)(.*)$/);
-    if (match) {
-      return match[1] + path.join(match[2], src);
-    } else {
-      return new URL(src, baseUrl).href;
-    }
-  } else {
-    return src;
-  }
-};
 function getScript(url) {
   let match;
   if (match = url.match(/^data:.+?(;base64)?,(.*)$/)) {
@@ -77,7 +259,7 @@ function getScript(url) {
   } else {
     const sab = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT*2 + 5 * 1024 * 1024);
     const int32Array = new Int32Array(sab);
-    const worker = new Worker(path.join(__dirname, 'request.js'), {
+    const worker = new WorkerBase(path.join(__dirname, 'request.js'), {
       workerData: {
         url: _normalizeUrl(url),
         int32Array,

--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -45,11 +45,6 @@ Object.defineProperty(global, 'onmessage', {
   },
 });
 
-global.windowEmit = (type, event, transferList) => parentPort.postMessage({
-  method: 'emit',
-  type,
-  event,
-}, transferList);
 
 let baseUrl = '';
 function setBaseUrl(newBaseUrl) {

--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -12,8 +12,6 @@ const {
 } = require('./native-bindings');
 const {process} = global;
 
-// global initialization
-
 const consoleStream = new stream.Writable();
 consoleStream._write = (chunk, encoding, callback) => {
   nativeConsole.Log(chunk);
@@ -26,6 +24,8 @@ consoleStream._writev = (chunks, callback) => {
   callback();
 };
 global.console = new Console(consoleStream);
+
+// global initialization
 
 for (const k in EventEmitter.prototype) {
   global[k] = EventEmitter.prototype[k];

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,16 +25,20 @@ function _getBaseUrl(u) {
 }
 module.exports._getBaseUrl = _getBaseUrl;
 
-function _makeNormalizeUrl(baseUrl) {
-  return src => {
-    if (!/^[a-z]+:\/\//i.test(src)) {
-      src = new URL(src, baseUrl).href
+function _normalizeUrl(src, baseUrl) {
+  if (!/^(?:https?|data|blob):/.test(src)) {
+    const match = baseUrl.match(/^(file:\/\/)(.*)$/);
+    if (match) {
+      return match[1] + path.join(match[2], src);
+    } else {
+      return new URL(src, baseUrl).href
         .replace(/^(file:\/\/)\/([a-z]:.*)$/i, '$1$2');
     }
+  } else {
     return src;
-  };
+  }
 }
-module.exports._makeNormalizeUrl = _makeNormalizeUrl;
+module.exports._normalizeUrl = _normalizeUrl;
 
 const _makeHtmlCollectionProxy = (el, query) => new Proxy(el, {
   get(target, prop) {


### PR DESCRIPTION
Many of the top-level `window` objects in Exokit should be exposed in the [`WorkerGlobalScope`](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope).

Historically they were not, because we were not running Window and Worker scopes in the same way. However, after reality tabs paralellization these two code paths are the same and we can move the exposures into the proper place.

Many of the advanced site compatibilities we're tackling, such as Moon Rider and VR Land, depend on Worker being seeded with the correct globals, and this brings us much closer to the spec.

A few nice refactors came out of this as well, such as there being only one single "Base URL normalization" code path between scopes.