### PR TITLE
XMLHttpRequest Blob support

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "window-fetch": "0.0.10",
     "window-ls": "0.0.1",
     "window-selector": "0.0.6",
-    "window-xhr": "0.0.29",
+    "window-xhr": "0.0.30",
     "ws": "^6.2.0"
   },
   "devDependencies": {

--- a/src/Window.js
+++ b/src/Window.js
@@ -133,7 +133,7 @@ const {Location} = require('./Location');
 const XR = require('./XR');
 const DevTools = require('./DevTools');
 const utils = require('./utils');
-const {_elementGetter, _elementSetter, _download} = utils;
+const {_elementGetter, _elementSetter} = utils;
 
 setBaseUrl(options.baseUrl);
 

--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -141,8 +141,13 @@ class Worker extends EventTarget {
   self.XMLHttpRequest = (Old => {
     class XMLHttpRequest extends Old {
       open(method, url, async, username, password) {
-        url = _normalizeUrl(url);
-        return super.open(method, url, async, username, password);
+        const blob = urls.get(u);
+        if (blob) {
+          return super.open(method, blob, async, username, password);
+        } else {
+          url = _normalizeUrl(url);
+          return super.open(method, url, async, username, password);
+        }
       }
       get response() {
         return switch (this.responseType) {

--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -152,7 +152,9 @@ class Worker extends EventTarget {
       get response() {
         return switch (this.responseType) {
           case 'arraybuffer': return Buffer.from(o);
-          case 'blob': return o.buffer;
+          case 'blob': return new Blob(o, {
+            type: this.getResponseHeader('content-type') || 'application/octet-stream',
+          });
           case 'json': return Buffer.from(JSON.stringify(o), 'utf8');
           case 'text': return Buffer.from(o, 'utf8');
           default: throw new Error(`cannot download responseType ${responseType}`);

--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -145,15 +145,13 @@ class Worker extends EventTarget {
         return super.open(method, url, async, username, password);
       }
       get response() {
-        return _maybeDownload(this._properties.method, this._properties.uri, super.response, o => {
-          switch (this.responseType) {
-            case 'arraybuffer': return Buffer.from(o);
-            case 'blob': return o.buffer;
-            case 'json': return Buffer.from(JSON.stringify(o), 'utf8');
-            case 'text': return Buffer.from(o, 'utf8');
-            default: throw new Error(`cannot download responseType ${responseType}`);
-          }
-        });
+        return switch (this.responseType) {
+          case 'arraybuffer': return Buffer.from(o);
+          case 'blob': return o.buffer;
+          case 'json': return Buffer.from(JSON.stringify(o), 'utf8');
+          case 'text': return Buffer.from(o, 'utf8');
+          default: throw new Error(`cannot download responseType ${responseType}`);
+        }
       }
     }
     for (const k in Old) {

--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -150,7 +150,7 @@ class Worker extends EventTarget {
         }
       }
       get response() {
-        return switch (this.responseType) {
+        switch (this.responseType) {
           case 'arraybuffer': return Buffer.from(o);
           case 'blob': return new Blob(o, {
             type: this.getResponseHeader('content-type') || 'application/octet-stream',

--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -119,7 +119,7 @@ class Worker extends EventTarget {
   self.EventTarget = EventTarget;
   
   self.URL = URL;
-  
+
   self.fetch = (u, options) => {
     if (typeof u === 'string') {
       const blob = urls.get(u);
@@ -127,10 +127,10 @@ class Worker extends EventTarget {
         return Promise.resolve(new Response(blob));
       } else {
         u = _normalizeUrl(u);
-        return _boundFetch(u, options);
+        return fetch(u, options);
       }
     } else {
-      return _boundFetch(u, options);
+      return fetch(u, options);
     }
   };
   self.Request = Request;

--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -150,14 +150,12 @@ class Worker extends EventTarget {
         }
       }
       get response() {
-        switch (this.responseType) {
-          case 'arraybuffer': return Buffer.from(o);
-          case 'blob': return new Blob(o, {
+        if (this.responseType === 'blob') {
+          return new Blob(super.response, {
             type: this.getResponseHeader('content-type') || 'application/octet-stream',
           });
-          case 'json': return Buffer.from(JSON.stringify(o), 'utf8');
-          case 'text': return Buffer.from(o, 'utf8');
-          default: throw new Error(`cannot download responseType ${responseType}`);
+        } else {
+          return super.response;
         }
       }
     }

--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -120,32 +120,7 @@ class Worker extends EventTarget {
   
   self.URL = URL;
   
-  // const _maybeDownload = (m, u, data, bufferifyFn) => options.args.download ? _download(m, u, data, bufferifyFn, options.args.download) : data;
-  const _maybeDownload = (m, u, data, bufferifyFn) => data;
   self.fetch = (u, options) => {
-    const _boundFetch = (u, options) => fetch(u, options)
-      .then(res => {
-        const method = (options && options.method) || 'GET';
-        res.arrayBuffer = (fn => function() {
-          return fn.apply(this, arguments)
-            .then(ab => _maybeDownload(method, u, ab, ab => Buffer.from(ab)));
-        })(res.arrayBuffer);
-        res.blob = (fn => function() {
-          return fn.apply(this, arguments)
-            .then(blob => _maybeDownload(method, u, blob, blob => blob.buffer));
-        })(res.blob);
-        res.json = (fn => function() {
-          return fn.apply(this, arguments)
-            .then(j => _maybeDownload(method, u, j, j => Buffer.from(JSON.stringify(j))));
-        })(res.json);
-        res.text = (fn => function() {
-          return fn.apply(this, arguments)
-            .then(t => _maybeDownload(method, u, t, t => Buffer.from(t, 'utf8')));
-        })(res.text);
-
-        return res;
-      });
-
     if (typeof u === 'string') {
       const blob = urls.get(u);
       if (blob) {

--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -141,7 +141,7 @@ class Worker extends EventTarget {
   self.XMLHttpRequest = (Old => {
     class XMLHttpRequest extends Old {
       open(method, url, async, username, password) {
-        const blob = urls.get(u);
+        const blob = urls.get(url);
         if (blob) {
           return super.open(method, blob, async, username, password);
         } else {

--- a/src/core.js
+++ b/src/core.js
@@ -4,7 +4,7 @@ const {URL} = url;
 const fetch = require('window-fetch');
 const GlobalContext = require('./GlobalContext');
 const symbols = require('./symbols');
-const {_getBaseUrl, _download} = require('./utils');
+const {_getBaseUrl} = require('./utils');
 const {_makeWindow} = require('./WindowVm');
 
 const exokit = module.exports;
@@ -38,13 +38,6 @@ exokit.load = (src, options = {}) => {
     .then(res => {
       if (res.status >= 200 && res.status < 300) {
         return res.text()
-          .then(t => {
-            if (options.args.download) {
-              return _download('GET', src, t, t => Buffer.from(t, 'utf8'), options.args.download);
-            } else {
-              return Promise.resolve(t);
-            }
-          })
           .then(htmlString => ({
             src,
             htmlString,
@@ -84,17 +77,6 @@ exokit.load = (src, options = {}) => {
       });
     });
 };
-exokit.download = (src, dst) => exokit.load(src, {
-  args: {
-    download: dst,
-    headless: true,
-  },
-})
-  .then(window => new Promise((accept, reject) => {
-    window.document.resources.addEventListener('drain', () => {
-      accept();
-    });
-  }));
 exokit.setArgs = newArgs => {
   GlobalContext.args = newArgs;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,6 @@ const args = (() => {
         'webgl',
         'xr',
         'size',
-        'download',
         'replace',
       ],
       alias: {
@@ -127,7 +126,6 @@ const args = (() => {
         u: 'require',
         n: 'nogl',
         e: 'headless',
-        d: 'download',
       },
     });
     return {
@@ -148,7 +146,6 @@ const args = (() => {
       require: minimistArgs.require,
       nogl: minimistArgs.nogl,
       headless: minimistArgs.headless,
-      download: minimistArgs.download !== undefined ? (minimistArgs.download || path.join(process.cwd(), 'downloads')) : undefined,
     };
   } else {
     return {};

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,30 +80,3 @@ const _elementSetter = (self, attribute, cb) => {
   }
 };
 module.exports._elementSetter = _elementSetter;
-
-const _download = (m, u, data, bufferifyFn, dstDir) => new Promise((accept, reject) => {
-  if (m === 'GET' && /^(?:https?|file):/.test(u)) {
-    const o = url.parse(u);
-    const d = path.resolve(path.join(__dirname, '..'), dstDir, o.host || '.');
-    const f = path.join(d, o.pathname === '/' ? 'index.html' : o.pathname);
-
-    console.log(`${u} -> ${f}`);
-
-    mkdirp(path.dirname(f), err => {
-      if (!err) {
-        fs.writeFile(f, bufferifyFn(data), err => {
-          if (!err) {
-            accept(data);
-          } else {
-            reject(err);
-          }
-        });
-      } else {
-        reject(err);
-      }
-    });
-  } else {
-    accept(data);
-  }
-});
-module.exports._download = _download;


### PR DESCRIPTION
XMLHttpRequest did not support support `blob://` URLs, and did not output proper `Blob` when `requestType === 'blob'`. This PR adds that support.

Note that `fetch` has supported for this for a long time, so we simply re-use that `Blob` implementation.

Ingests https://github.com/modulesio/window-xhr/pull/4.
Needed for https://github.com/exokitxr/exokit/issues/1078.