### PR TITLE
OpenVR tracker naming

### DIFF
--- a/src/VR.js
+++ b/src/VR.js
@@ -656,7 +656,7 @@ const controllerIDs = {
   fake: 'OpenVR Gamepad',
   openvr: 'OpenVR Gamepad',
   // oculusMobile: 'Oculus Go',
-  openvrTracker: 'Tracker',
+  openvrTracker: 'OpenVR Tracker',
   oculusLeft: 'Oculus Touch (Left)',
   oculusRight: 'Oculus Touch (Right)',
   oculusMobileLeft: 'Oculus Touch (Left)',


### PR DESCRIPTION
Fixes https://aframe-tracker-test.glitch.me/.

That glitch was not picking up the OpenVR trackers because they were not called "OpenVR".

I think it's reasonable to call the gamepad nid "OpenVR Tracker", similar to how it's done with gamepads. We were doing this before but this regressed with the paralellization refactor. This PR restores the compatible vendorized name.