### PR TITLE
Linear render loop MSAA

### DIFF
--- a/deps/exokit-bindings/egl/src/egl.cc
+++ b/deps/exokit-bindings/egl/src/egl.cc
@@ -32,7 +32,31 @@ void Uninitialize() {
   eglTerminate(display);
 }
 
-NAN_METHOD(BlitFrameBuffer) {
+NAN_METHOD(BlitTopFrameBuffer) {
+  GLuint fbo1 = TO_UINT32(info[0]);
+  GLuint fbo2 = TO_UINT32(info[1]);
+  int sw = TO_INT32(info[2]);
+  int sh = TO_INT32(info[3]);
+  int dw = TO_INT32(info[4]);
+  int dh = TO_INT32(info[5]);
+  bool color = TO_BOOL(info[6]);
+  bool depth = TO_BOOL(info[7]);
+  bool stencil = TO_BOOL(info[8]);
+
+  glBindFramebuffer(GL_READ_FRAMEBUFFER, fbo1);
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fbo2);
+
+  glBlitFramebuffer(0, 0,
+    sw, sh,
+    0, 0,
+    dw, dh,
+    (color ? GL_COLOR_BUFFER_BIT : 0) |
+    (depth ? GL_DEPTH_BUFFER_BIT : 0) |
+    (stencil ? GL_STENCIL_BUFFER_BIT : 0),
+    (depth || stencil) ? GL_NEAREST : GL_LINEAR);
+}
+
+NAN_METHOD(BlitChildFrameBuffer) {
   Local<Object> glObj = Local<Object>::Cast(info[0]);
   GLuint fbo1 = TO_UINT32(info[1]);
   GLuint fbo2 = TO_UINT32(info[2]);
@@ -396,7 +420,8 @@ Local<Object> makeWindow() {
   Nan::SetMethod(target, "setCursorPosition", egl::SetCursorPosition);
   Nan::SetMethod(target, "getClipboard", egl::GetClipboard);
   Nan::SetMethod(target, "setClipboard", egl::SetClipboard);
-  Nan::SetMethod(target, "blitFrameBuffer", egl::BlitFrameBuffer);
+  Nan::SetMethod(target, "blitTopFrameBuffer", egl::BlitTopFrameBuffer);
+  Nan::SetMethod(target, "blitChildFrameBuffer", egl::BlitChildFrameBuffer);
   Nan::SetMethod(target, "setCurrentWindowContext", egl::SetCurrentWindowContext);
 
   return scope.Escape(target);

--- a/deps/exokit-bindings/glfw/src/glfw.cc
+++ b/deps/exokit-bindings/glfw/src/glfw.cc
@@ -799,7 +799,33 @@ void APIENTRY scrollCB(NATIVEwindow *window, double xoffset, double yoffset) {
   });
 }
 
-NAN_METHOD(BlitFrameBuffer) {
+NAN_METHOD(BlitTopFrameBuffer) {
+  GLuint fbo1 = TO_UINT32(info[0]);
+  GLuint fbo2 = TO_UINT32(info[1]);
+  int sw = TO_UINT32(info[2]);
+  int sh = TO_UINT32(info[3]);
+  int dw = TO_UINT32(info[4]);
+  int dh = TO_UINT32(info[5]);
+  bool color = TO_BOOL(info[6]);
+  bool depth = TO_BOOL(info[7]);
+  bool stencil = TO_BOOL(info[8]);
+
+  glBindFramebuffer(GL_READ_FRAMEBUFFER, fbo1);
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fbo2);
+
+  glBlitFramebuffer(
+    0, 0,
+    sw, sh,
+    0, 0,
+    dw, dh,
+    (color ? GL_COLOR_BUFFER_BIT : 0) |
+    (depth ? GL_DEPTH_BUFFER_BIT : 0) |
+    (stencil ? GL_STENCIL_BUFFER_BIT : 0),
+    (depth || stencil) ? GL_NEAREST : GL_LINEAR
+  );
+}
+
+NAN_METHOD(BlitChildFrameBuffer) {
   Local<Object> glObj = Local<Object>::Cast(info[0]);
   GLuint fbo1 = TO_UINT32(info[1]);
   GLuint fbo2 = TO_UINT32(info[2]);
@@ -1663,7 +1689,8 @@ Local<Object> makeWindow() {
   Nan::SetMethod(target, "setCursorPosition", glfw::SetCursorPosition);
   Nan::SetMethod(target, "getClipboard", glfw::GetClipboard);
   Nan::SetMethod(target, "setClipboard", glfw::SetClipboard);
-  Nan::SetMethod(target, "blitFrameBuffer", glfw::BlitFrameBuffer);
+  Nan::SetMethod(target, "blitTopFrameBuffer", glfw::BlitTopFrameBuffer);
+  Nan::SetMethod(target, "blitChildFrameBuffer", glfw::BlitChildFrameBuffer);
   Nan::SetMethod(target, "setCurrentWindowContext", glfw::SetCurrentWindowContext);
 #ifdef TARGET_OS_MAC
   Nan::SetMethod(target, "pollEvents", glfw::PollEvents);

--- a/deps/oculus-mobile/include/oculus-context.h
+++ b/deps/oculus-mobile/include/oculus-context.h
@@ -35,9 +35,12 @@ public:
   ovrMobile *ovrState;
   bool running;
   ANativeWindow *androidNativeWindow;
-  std::vector<GLuint> framebuffers;
+  GLuint fbo;
   ovrTextureSwapChain *colorSwapChain;
   std::vector<GLuint> depthTextures;
+  GLuint msFbo;
+  std::vector<GLuint> msColorTextures;
+  std::vector<GLuint> msDepthTextures;
   int swapChainLength;
   int swapChainIndex;
   bool hasSwapChain;

--- a/deps/oculus/include/oculus-bindings.h
+++ b/deps/oculus/include/oculus-bindings.h
@@ -6,9 +6,12 @@
 
 using namespace v8;
 
-/// inline IVRSystem *Oculus_Init( EVRInitError *peError, EVRApplicationType eApplicationType );
+namespace oculusvr {
+
 NAN_METHOD(Oculus_Init);
 NAN_METHOD(Oculus_IsHmdPresent);
+
+};
 
 Local<Object> makeOculusVR();
 

--- a/deps/oculus/include/ovrsession.h
+++ b/deps/oculus/include/ovrsession.h
@@ -10,12 +10,14 @@
 typedef struct SwapChain {
   ovrTextureSwapChain ColorTextureChain;
   ovrTextureSwapChain DepthTextureChain;
+  std::vector<GLuint> msColorTextureChain;
+  std::vector<GLuint> msDepthTextureChain;
 } EyeSwapChain;
 
 namespace oculusvr {
-  class OculusVRPosRes;
-  void RunResInMainThread(uv_async_t *handle);
-}
+
+class OculusVRPosRes;
+void RunResInMainThread(uv_async_t *handle);
 
 class OculusVRPosRes {
 public:
@@ -69,7 +71,9 @@ private:
   /// Reference to wrapped ovrSession instance.
   ovrSession *session;
   ovrHmdDesc hmdDesc;
+  ovrTimewarpProjectionDesc timewarpProjectionDesc;
   GLuint fbo;
+  GLuint msFbo;
   EyeSwapChain swapChain;
   bool swapChainValid;
   ovrPosef eyeRenderPoses[2];
@@ -77,6 +81,8 @@ private:
   int frameIndex;
   double sensorSampleTime;
   bool hmdMounted;
+};
+
 };
 
 #endif

--- a/deps/oculus/src/oculus-bindings.cpp
+++ b/deps/oculus/src/oculus-bindings.cpp
@@ -11,6 +11,8 @@
 
 using namespace v8;
 
+namespace oculusvr {
+
 bool oculusInitialized = false;
 
 NAN_METHOD(Oculus_Init)
@@ -36,11 +38,13 @@ NAN_METHOD(Oculus_IsHmdPresent)
   info.GetReturnValue().Set(Nan::New<Boolean>(detectResult.IsOculusHMDConnected));
 }
 
+};
+
 Local<Object> makeOculusVR() {
   v8::EscapableHandleScope scope(Isolate::GetCurrent());
 
   Local<Object> exports = Object::New(Isolate::GetCurrent());
-  Nan::SetMethod(exports, "Oculus_Init", Oculus_Init);
-  Nan::SetMethod(exports, "Oculus_IsHmdPresent", Oculus_IsHmdPresent);
+  Nan::SetMethod(exports, "Oculus_Init", oculusvr::Oculus_Init);
+  Nan::SetMethod(exports, "Oculus_IsHmdPresent", oculusvr::Oculus_IsHmdPresent);
   return scope.Escape(exports);
 }

--- a/deps/oculus/src/ovrsession.cpp
+++ b/deps/oculus/src/ovrsession.cpp
@@ -13,29 +13,33 @@ using namespace v8;
 using namespace OVR;
 
 namespace oculusvr {
-  uv_sem_t reqSem;
-  uv_async_t resAsync;
-  std::mutex reqMutex;
-  std::mutex resMutex;
-  std::deque<std::function<void()>> reqCbs;
-  std::deque<std::function<void()>> resCbs;
-  std::thread reqThread;
 
-  void RunResInMainThread(uv_async_t *handle) {
-    Nan::HandleScope scope;
+constexpr float NEAR_CLIP = 0.2f;
+constexpr float FAR_CLIP = 1000.0f;
+constexpr int NUM_SAMPLES = 4;
 
-    std::function<void()> resCb;
-    {
-      std::lock_guard<std::mutex> lock(resMutex);
+uv_sem_t reqSem;
+uv_async_t resAsync;
+std::mutex reqMutex;
+std::mutex resMutex;
+std::deque<std::function<void()>> reqCbs;
+std::deque<std::function<void()>> resCbs;
+std::thread reqThread;
 
-      resCb = resCbs.front();
-      resCbs.pop_front();
-    }
-    if (resCb) {
-      resCb();
-    }
+void RunResInMainThread(uv_async_t *handle) {
+  Nan::HandleScope scope;
+
+  std::function<void()> resCb;
+  {
+    std::lock_guard<std::mutex> lock(resMutex);
+
+    resCb = resCbs.front();
+    resCbs.pop_front();
   }
-};
+  if (resCb) {
+    resCb();
+  }
+}
 
 OculusVRPosRes::OculusVRPosRes(Local<Function> cb) : cb(cb) {}
 
@@ -244,7 +248,7 @@ NAN_METHOD(OVRSession::GetPose) {
       leftViewMatrix.SetTranslation(session->eyeRenderPoses[0].Position);
       leftViewMatrix.Invert();
 
-      Matrix4f leftProjectionMatrix = ovrMatrix4f_Projection(session->hmdDesc.DefaultEyeFov[0], 0.2f, 1000.0f, ovrProjection_None);
+      Matrix4f leftProjectionMatrix = ovrMatrix4f_Projection(session->hmdDesc.DefaultEyeFov[0], NEAR_CLIP, FAR_CLIP, ovrProjection_None);
 
       rollPitchYaw = Matrix4f(session->eyeRenderPoses[1].Orientation);
       up = Vector3f(0, 1, 0);
@@ -254,7 +258,7 @@ NAN_METHOD(OVRSession::GetPose) {
       Matrix4f rightViewMatrix = Matrix4f(session->eyeRenderPoses[1].Orientation);
       rightViewMatrix.SetTranslation(session->eyeRenderPoses[1].Position);
       rightViewMatrix.Invert();
-      Matrix4f rightProjectionMatrix = ovrMatrix4f_Projection(session->hmdDesc.DefaultEyeFov[1], 0.2f, 1000.0f, ovrProjection_None);
+      Matrix4f rightProjectionMatrix = ovrMatrix4f_Projection(session->hmdDesc.DefaultEyeFov[1], NEAR_CLIP, FAR_CLIP, ovrProjection_None);
 
       for (unsigned int v = 0; v < 4; v++) {
         for (unsigned int u = 0; u < 4; u++) {
@@ -418,13 +422,13 @@ NAN_METHOD(OVRSession::Submit) {
   ovr_CommitTextureSwapChain(*session->session, session->swapChain.ColorTextureChain);
   ovr_CommitTextureSwapChain(*session->session, session->swapChain.DepthTextureChain);
 
-  ovrTimewarpProjectionDesc posTimewarpProjectionDesc = {};
-
   // Distortion, Present and flush/sync
   ovrLayerEyeFovDepth ld = {};
   ld.Header.Type = ovrLayerType_EyeFovDepth;
   ld.Header.Flags = ovrLayerFlag_TextureOriginAtBottomLeft;   // Because OpenGL.
-  ld.ProjectionDesc = posTimewarpProjectionDesc;
+  /* ovrTimewarpProjectionDesc timewarpProjectionDesc = {};
+  ld.ProjectionDesc = timewarpProjectionDesc; */
+  ld.ProjectionDesc = session->timewarpProjectionDesc;
 
   for (int eye = 0; eye < 2; eye++) {
     ld.ColorTexture[eye] = eye == 0 ? session->swapChain.ColorTextureChain : nullptr;
@@ -447,24 +451,35 @@ NAN_METHOD(OVRSession::Submit) {
   glBindFramebuffer(GL_DRAW_FRAMEBUFFER, session->fbo);
 
   GLuint colorTex;
+  int curColorIndex;
   {
-    int curIndex;
-    ovr_GetTextureSwapChainCurrentIndex(*session->session, session->swapChain.ColorTextureChain, &curIndex);
-    ovr_GetTextureSwapChainBufferGL(*session->session, session->swapChain.ColorTextureChain, curIndex, &colorTex);
+    ovr_GetTextureSwapChainCurrentIndex(*session->session, session->swapChain.ColorTextureChain, &curColorIndex);
+    ovr_GetTextureSwapChainBufferGL(*session->session, session->swapChain.ColorTextureChain, curColorIndex, &colorTex);
     glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, colorTex, 0);
   }
   GLuint depthStencilTex;
+  int curDepthIndex;
   {
-    int curIndex;
-    ovr_GetTextureSwapChainCurrentIndex(*session->session, session->swapChain.DepthTextureChain, &curIndex);
-    ovr_GetTextureSwapChainBufferGL(*session->session, session->swapChain.DepthTextureChain, curIndex, &depthStencilTex);
+    ovr_GetTextureSwapChainCurrentIndex(*session->session, session->swapChain.DepthTextureChain, &curDepthIndex);
+    ovr_GetTextureSwapChainBufferGL(*session->session, session->swapChain.DepthTextureChain, curDepthIndex, &depthStencilTex);
     glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, depthStencilTex, 0);
   }
 
-  Local<Array> array = Array::New(Isolate::GetCurrent(), 3);
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, session->msFbo);
+
+  GLuint msColorTex = session->swapChain.msColorTextureChain[curColorIndex];
+  glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D_MULTISAMPLE, msColorTex, 0);
+
+  GLuint msDepthStencilTex = session->swapChain.msDepthTextureChain[curDepthIndex];
+  glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D_MULTISAMPLE, msDepthStencilTex, 0);
+
+  Local<Array> array = Array::New(Isolate::GetCurrent(), 6);
   array->Set(0, JS_INT(session->fbo));
   array->Set(1, JS_INT(colorTex));
   array->Set(2, JS_INT(depthStencilTex));
+  array->Set(3, JS_INT(session->msFbo));
+  array->Set(4, JS_INT(msColorTex));
+  array->Set(5, JS_INT(msDepthStencilTex));
   info.GetReturnValue().Set(array);
 }
 
@@ -504,6 +519,8 @@ void OVRSession::ResetSession() {
 
   this->session = session;
   this->hmdDesc = ovr_GetHmdDesc(*this->session);
+  Matrix4f projectionMatrix = ovrMatrix4f_Projection(this->hmdDesc.DefaultEyeFov[0], NEAR_CLIP, FAR_CLIP, ovrProjection_None);
+  this->timewarpProjectionDesc = ovrTimewarpProjectionDesc_FromProjection(projectionMatrix, ovrProjection_None);
   
   if (hadSwapChain) {
     ResetSwapChain();
@@ -514,7 +531,8 @@ void OVRSession::ResetSwapChain() {
   if (this->swapChainValid) {
     DestroySwapChain();
   }
-  
+
+  // HMD
   // Framebuffer
   glGenFramebuffers(1, &this->fbo);
 
@@ -564,10 +582,28 @@ void OVRSession::ResetSwapChain() {
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-      
     }
   }
-  
+
+  // Multisample
+  // Framebuffer
+  glGenFramebuffers(1, &this->msFbo);
+
+  this->swapChain.msColorTextureChain.resize(length);
+  glGenTextures(this->swapChain.msColorTextureChain.size(), this->swapChain.msColorTextureChain.data());
+  this->swapChain.msDepthTextureChain.resize(length);
+  glGenTextures(this->swapChain.msDepthTextureChain.size(), this->swapChain.msDepthTextureChain.data());
+
+  for (int i = 0; i < length; i++) {
+    glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, this->swapChain.msColorTextureChain[i]);
+    glTexParameteri(GL_TEXTURE_2D_MULTISAMPLE, GL_TEXTURE_MAX_LEVEL, 0);
+    glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, NUM_SAMPLES, GL_RGBA8, this->swapChainMetrics[0], this->swapChainMetrics[1], true);
+
+    glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, this->swapChain.msDepthTextureChain[i]);
+    glTexParameteri(GL_TEXTURE_2D_MULTISAMPLE, GL_TEXTURE_MAX_LEVEL, 0);
+    glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, NUM_SAMPLES, GL_DEPTH24_STENCIL8, this->swapChainMetrics[0], this->swapChainMetrics[1], true);
+  }
+
   this->swapChainValid = true;
 }
 
@@ -575,6 +611,9 @@ void OVRSession::DestroySwapChain() {
   glDeleteFramebuffers(1, &this->fbo);
   ovr_DestroyTextureSwapChain(*this->session, this->swapChain.ColorTextureChain);
   ovr_DestroyTextureSwapChain(*this->session, this->swapChain.DepthTextureChain);
+  glDeleteFramebuffers(1, &this->msFbo);
+  glDeleteTextures(this->swapChain.msColorTextureChain.size(), this->swapChain.msColorTextureChain.data());
+  glDeleteTextures(this->swapChain.msDepthTextureChain.size(), this->swapChain.msDepthTextureChain.data());
   
   this->swapChainValid = false;
 }
@@ -610,24 +649,35 @@ NAN_METHOD(OVRSession::CreateSwapChain) {
   glBindFramebuffer(GL_DRAW_FRAMEBUFFER, session->fbo);
 
   GLuint colorTex;
+  int curColorIndex;
   {
-    int curIndex;
-    ovr_GetTextureSwapChainCurrentIndex(*session->session, session->swapChain.ColorTextureChain, &curIndex);
-    ovr_GetTextureSwapChainBufferGL(*session->session, session->swapChain.ColorTextureChain, curIndex, &colorTex);
+    ovr_GetTextureSwapChainCurrentIndex(*session->session, session->swapChain.ColorTextureChain, &curColorIndex);
+    ovr_GetTextureSwapChainBufferGL(*session->session, session->swapChain.ColorTextureChain, curColorIndex, &colorTex);
     glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, colorTex, 0);
   }
   GLuint depthStencilTex;
+  int curDepthIndex;
   {
-    int curIndex;
-    ovr_GetTextureSwapChainCurrentIndex(*session->session, session->swapChain.DepthTextureChain, &curIndex);
-    ovr_GetTextureSwapChainBufferGL(*session->session, session->swapChain.DepthTextureChain, curIndex, &depthStencilTex);
+    ovr_GetTextureSwapChainCurrentIndex(*session->session, session->swapChain.DepthTextureChain, &curDepthIndex);
+    ovr_GetTextureSwapChainBufferGL(*session->session, session->swapChain.DepthTextureChain, curDepthIndex, &depthStencilTex);
     glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, depthStencilTex, 0);
   }
+  
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, session->msFbo);
 
-  Local<Array> array = Array::New(Isolate::GetCurrent(), 3);
+  GLuint msColorTex = session->swapChain.msColorTextureChain[curColorIndex];
+  glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D_MULTISAMPLE, msColorTex, 0);
+
+  GLuint msDepthStencilTex = session->swapChain.msDepthTextureChain[curDepthIndex];
+  glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D_MULTISAMPLE, msDepthStencilTex, 0);
+
+  Local<Array> array = Array::New(Isolate::GetCurrent(), 6);
   array->Set(0, JS_INT(session->fbo));
   array->Set(1, JS_INT(colorTex));
   array->Set(2, JS_INT(depthStencilTex));
+  array->Set(3, JS_INT(session->msFbo));
+  array->Set(4, JS_INT(msColorTex));
+  array->Set(5, JS_INT(msDepthStencilTex));
   info.GetReturnValue().Set(array);
 }
 
@@ -638,3 +688,5 @@ NAN_METHOD(OVRSession::ExitPresent) {
   ovr_DestroyTextureSwapChain(*session->session, session->swapChain.ColorTextureChain);
   ovr_DestroyTextureSwapChain(*session->session, session->swapChain.DepthTextureChain);
 }
+
+};

--- a/src/Window.js
+++ b/src/Window.js
@@ -210,12 +210,6 @@ const mlPresentState = {
 };
 GlobalContext.mlPresentState = mlPresentState;
 
-/* const _getVrGlContext = () => contexts.find(context => context.contextId === vrPresentState.glContextId);
-const _getOculusVrGlContext = () => vrPresentState.oculusSystem ? contexts.find(context => context.contextId === vrPresentState.glContextId) : undefined;
-const _getOpenVrGlContext = () => vrPresentState.system ? contexts.find(context => context.contextId === vrPresentState.glContextId) : undefined;
-const _getOculusMobileVrGlContext = () => oculusMobileVrPresentState.vrContext ? contexts.find(context => context.contextId === oculusMobileVrPresentState.glContextId) : undefined;
-const _getMlGlContext = () => contexts.find(context => context.contextId === mlPresentState.mlGlContextId); */
-
 class CustomElementRegistry {
   constructor(window) {
     this._window = window;

--- a/src/Window.js
+++ b/src/Window.js
@@ -180,22 +180,11 @@ const contexts = [];
 GlobalContext.contexts = contexts;
 
 const vrPresentState = {
-  /* vrContext: null,
-  system: null,
-  oculusSystem: null,
-  compositor: null,
-  glContextId: 0, */
   hmdType: null,
   vrContext: null,
   glContext: null,
   fbo: 0,
   msFbo: 0,
-  msTex: 0,
-  msDepthTex: 0,
-  // tex: null,
-  // depthTex: null,
-  // hasPose: false,
-  // lmContext: null,
   layers: [],
   responseAccepts: [],
 };

--- a/src/index.js
+++ b/src/index.js
@@ -274,6 +274,7 @@ const xrState = (() => {
   result.hmdType = _makeTypedArray(Uint32Array, 1);
   result.tex = _makeTypedArray(Uint32Array, 1);
   result.depthTex = _makeTypedArray(Uint32Array, 1);
+  result.aaEnabled = _makeTypedArray(Uint32Array, 1);
   result.fakeVrDisplayEnabled = _makeTypedArray(Uint32Array, 1);
   result.blobId = _makeTypedArray(Uint32Array, 1);
 

--- a/src/index.js
+++ b/src/index.js
@@ -274,6 +274,8 @@ const xrState = (() => {
   result.hmdType = _makeTypedArray(Uint32Array, 1);
   result.tex = _makeTypedArray(Uint32Array, 1);
   result.depthTex = _makeTypedArray(Uint32Array, 1);
+  result.msTex = _makeTypedArray(Uint32Array, 1);
+  result.msDepthTex = _makeTypedArray(Uint32Array, 1);
   result.aaEnabled = _makeTypedArray(Uint32Array, 1);
   result.fakeVrDisplayEnabled = _makeTypedArray(Uint32Array, 1);
   result.blobId = _makeTypedArray(Uint32Array, 1);
@@ -286,8 +288,7 @@ const topVrPresentState = {
   hmdType: null,
   windowHandle: null,
   fbo: 0,
-  tex: 0,
-  depthTex: 0,
+  msFbo: 0,
   vrContext: null,
   vrSystem: null,
   vrCompositor: null,
@@ -319,13 +320,14 @@ const _handleRequest = ({type, keypath}) => {
       const width = xrState.renderWidth[0]*2;
       const height = xrState.renderHeight[0];
 
-      const [fbo, tex, depthTex] = nativeBindings.nativeWindow.createVrTopRenderTarget(width, height);
+      const [fbo, tex, depthTex, msFbo, msTex, msDepthTex] = nativeBindings.nativeWindow.createVrTopRenderTarget(width, height);
 
       topVrPresentState.fbo = fbo;
+      topVrPresentState.msFbo = msFbo;
       xrState.tex[0] = tex;
       xrState.depthTex[0] = depthTex;
-      // xrState.renderWidth[0] = halfWidth;
-      // xrState.renderHeight[0] = height;
+      xrState.msTex[0] = msTex;
+      xrState.msDepthTex[0] = msDepthTex;
     } else if (hmdType === 'oculus') {
       const system = topVrPresentState.oculusSystem || nativeBindings.nativeOculusVR.Oculus_Init();
       // const lmContext = topVrPresentState.lmContext || (nativeBindings.nativeLm && new nativeBindings.nativeLm());
@@ -335,18 +337,20 @@ const _handleRequest = ({type, keypath}) => {
       const {width: halfWidth, height} = system.GetRecommendedRenderTargetSize();
       const width = halfWidth * 2;
 
-      const [fbo, tex, depthTex] = system.CreateSwapChain(width, height);
+      const [fbo, tex, depthTex, msFbo, msTex, msDepthTex] = system.CreateSwapChain(width, height);
 
       topVrPresentState.fbo = fbo;
+      topVrPresentState.msFbo = msFbo;
       xrState.tex[0] = tex;
       xrState.depthTex[0] = depthTex;
+      xrState.msTex[0] = msTex;
+      xrState.msDepthTex[0] = msDepthTex;
       xrState.renderWidth[0] = halfWidth;
       xrState.renderHeight[0] = height;
     } else if (hmdType === 'openvr') {
       const vrContext = nativeBindings.nativeOpenVR.getContext();
       const system = nativeBindings.nativeOpenVR.VR_Init(nativeBindings.nativeOpenVR.EVRApplicationType.Scene);
       const compositor = vrContext.compositor.NewCompositor();
-
       // const lmContext = topVrPresentState.lmContext || (nativeLm && new nativeLm());
 
       topVrPresentState.vrContext = vrContext;
@@ -356,11 +360,16 @@ const _handleRequest = ({type, keypath}) => {
       const {width: halfWidth, height} = system.GetRecommendedRenderTargetSize();
       const width = halfWidth * 2;
 
-      const [fbo, tex, depthTex] = nativeBindings.nativeWindow.createVrTopRenderTarget(width, height);
+      const [fbo, tex, depthTex, msFbo, msTex, msDepthTex] = nativeBindings.nativeWindow.createVrTopRenderTarget(width, height);
+      
+      console.log('top vr render target', fbo, tex, depthTex, msFbo, msTex, msDepthTex);
 
       topVrPresentState.fbo = fbo;
+      topVrPresentState.msFbo = msFbo;
       xrState.tex[0] = tex;
       xrState.depthTex[0] = depthTex;
+      xrState.msTex[0] = msTex;
+      xrState.msDepthTex[0] = msDepthTex;
       xrState.renderWidth[0] = halfWidth;
       xrState.renderHeight[0] = height;
     } else if (hmdType === 'oculusMobile') {
@@ -371,11 +380,14 @@ const _handleRequest = ({type, keypath}) => {
       const {width: halfWidth, height} = vrContext.GetRecommendedRenderTargetSize();
       const width = halfWidth * 2;
 
-      const [fbo, tex, depthTex] = vrContext.CreateSwapChain(width, height);
+      const [fbo, tex, depthTex, msFbo, msTex, msDepthTex] = vrContext.CreateSwapChain(width, height);
 
       topVrPresentState.fbo = fbo;
+      topVrPresentState.msFbo = msFbo;
       xrState.tex[0] = tex;
       xrState.depthTex[0] = depthTex;
+      xrState.msTex[0] = msTex;
+      xrState.msDepthTex[0] = msDepthTex;
       xrState.renderWidth[0] = halfWidth;
       xrState.renderHeight[0] = height;
     } else if (hmdType === 'magicleap') {
@@ -385,11 +397,14 @@ const _handleRequest = ({type, keypath}) => {
       const {width: halfWidth, height} = topVrPresentState.vrContext.GetSize();
       const width = halfWidth * 2;
 
-      const [fbo, tex, depthTex] = nativeBindings.nativeWindow.createVrTopRenderTarget(width, height);
+      const [fbo, tex, depthTex, msFbo, msTex, msDepthTex] = nativeBindings.nativeWindow.createVrTopRenderTarget(width, height);
 
       topVrPresentState.fbo = fbo;
+      topVrPresentState.msFbo = msFbo;
       xrState.tex[0] = tex;
       xrState.depthTex[0] = depthTex;
+      xrState.msTex[0] = msTex;
+      xrState.msDepthTex[0] = msDepthTex;
       xrState.renderWidth[0] = halfWidth;
       xrState.renderHeight[0] = height;
     } else {
@@ -867,7 +882,7 @@ const _startTopRenderLoop = () => {
   };
   const _clearXrFramebuffer = () => {
     if (topVrPresentState.hmdType !== null) {
-      nativeBindings.nativeWindow.clearFramebuffer(topVrPresentState.fbo);
+      nativeBindings.nativeWindow.clearFramebuffer(xrState.aaEnabled[0] ? topVrPresentState.msFbo : topVrPresentState.fbo);
     }
   };
   const _tickAnimationFrame = window => window.runAsync(JSON.stringify({
@@ -892,22 +907,47 @@ const _startTopRenderLoop = () => {
       }
     });
   const _tickAnimationFrames = () => Promise.all(windows.map(_tickAnimationFrame));
+  const _blitXrFbo = () => {
+    if (xrState.aaEnabled[0]) {
+      const width = xrState.renderWidth[0]*2;
+      const height = xrState.renderHeight[0];
+      nativeBindings.nativeWindow.blitTopFrameBuffer(topVrPresentState.msFbo, topVrPresentState.fbo, width, height, width, height, true, false, false); // XXX
+    }
+  };
   const _submitFrame = async () => {
+    if (topVrPresentState.hmdType) {
+      _blitXrFbo();
+    }
     if (topVrPresentState.hasPose) {
-      if (topVrPresentState.hmdType === 'oculus') {
-        const [fbo, tex, depthTex] = topVrPresentState.vrContext.Submit();
-        topVrPresentState.fbo = fbo;
-        xrState.tex[0] = tex;
-        xrState.depthTex[0] = depthTex;
-      } else if (topVrPresentState.hmdType === 'openvr') {
-        topVrPresentState.vrCompositor.Submit(xrState.tex[0]);
-      } else if (topVrPresentState.hmdType === 'oculusMobile') {
-        const [fbo, tex, depthTex] = topVrPresentState.vrContext.Submit();
-        topVrPresentState.fbo = fbo;
-        xrState.tex[0] = tex;
-        xrState.depthTex[0] = depthTex;
-      } else if (topVrPresentState.hmdType === 'magicleap') {
-        topVrPresentState.vrContext.SubmitFrame(topVrPresentState.fbo, xrState.renderWidth[0]*2, xrState.renderHeight[0]);
+      switch (topVrPresentState.hmdType) {
+        case 'oculus': {
+          const [fbo, tex, depthTex, msFbo, msTex, msDepthTex] = topVrPresentState.vrContext.Submit();
+          topVrPresentState.fbo = fbo;
+          topVrPresentState.msFbo = msFbo;
+          xrState.tex[0] = tex;
+          xrState.depthTex[0] = depthTex;
+          xrState.msTex[0] = msTex;
+          xrState.msDepthTex[0] = msDepthTex;
+          break;
+        }
+        case 'openvr': {
+          topVrPresentState.vrCompositor.Submit(xrState.tex[0]);
+          break;
+        }
+        case 'oculusMobile': {
+          const [fbo, tex, depthTex, msFbo, msTex, msDepthTex] = topVrPresentState.vrContext.Submit();
+          topVrPresentState.fbo = fbo;
+          topVrPresentState.msFbo = msFbo;
+          xrState.tex[0] = tex;
+          xrState.depthTex[0] = depthTex;
+          xrState.msTex[0] = msTex;
+          xrState.msDepthTex[0] = msDepthTex;
+          break;
+        }
+        case 'magicleap': {
+          topVrPresentState.vrContext.SubmitFrame(topVrPresentState.fbo, xrState.renderWidth[0]*2, xrState.renderHeight[0]);
+          break;
+        }
       }
 
       topVrPresentState.hasPose = false;

--- a/src/native-bindings.js
+++ b/src/native-bindings.js
@@ -310,6 +310,10 @@ const _onGl3DConstruct = (gl, canvas, attrs) => {
     
     gl.id = Atomics.add(GlobalContext.xrState.id, 0) + 1;
     GlobalContext.contexts.push(gl);
+
+    if (gl.attrs.antialias) {
+      GlobalContext.xrState.aaEnabled[0] = 1;
+    }
   } else {
     gl.destroy();
   }


### PR DESCRIPTION
The [linear walk render loop](https://github.com/exokitxr/exokit/pull/1104) for reality tabs has a different, minimal set of framebuffers optimized for a deep mobile rendering pipeline.

However, we lost antialiasing support: we have a single framebuffer in the chain, which is not multisampled.

This PR adds back a multisampled framebuffer path that works almost the same as the non-multisampled case, except with a final downsample before submit. Other than that, the same swapping discipline is followed, with triple-buffering of the multisampled framebuffers for Oculus.