### PR TITLE
VRDisplay isConnected flag

### DIFF
--- a/src/VR.js
+++ b/src/VR.js
@@ -181,6 +181,7 @@ class VRDisplay extends EventEmitter {
     this.displayName = displayName;
     this.window = window;
 
+    this.isConnected = true;
     this.isPresenting = false;
     this.capabilities = {
       canPresent: true,


### PR DESCRIPTION
Adds `VRDisplay.isConnected = true` flag, which A-Blast was checking.

This should be harmless -- we still only return the available headsets via `navigator.getVRDisplays()`.