### PR TITLE
Bugfix VRDisplay near/far clip planes editability

### DIFF
--- a/src/VR.js
+++ b/src/VR.js
@@ -270,6 +270,19 @@ class VRDisplay extends EventEmitter {
     };
   }
 
+  get depthNear() {
+    return GlobalContext.xrState.depthNear[0];
+  }
+  set depthNear(depthNear) {
+    GlobalContext.xrState.depthNear[0] = depthNear;
+  }
+  get depthFar() {
+    return GlobalContext.xrState.depthFar[0];
+  }
+  set depthFar(depthFar) {
+    GlobalContext.xrState.depthFar[0] = depthFar;
+  }
+
   async requestPresent(layers) {
     await this.onrequestpresent();
     
@@ -376,19 +389,6 @@ class FakeVRDisplay extends VRDisplay {
     this._lastPresseds = [false, false];
 
     // this._frameData = new VRFrameData();
-  }
-
-  get depthNear() {
-    return GlobalContext.xrState.depthNear[0];
-  }
-  set depthNear(depthNear) {
-    GlobalContext.xrState.depthNear[0] = depthNear;
-  }
-  get depthFar() {
-    return GlobalContext.xrState.depthFar[0];
-  }
-  set depthFar(depthFar) {
-    GlobalContext.xrState.depthFar[0] = depthFar;
   }
 
   /* setSize(width, height) {


### PR DESCRIPTION
`VRDisplay.depth{Near,Far}` was exposed on `FakeVRDisplay` but not the parent `VRDisplay`. Therefore move it to the parent display.

This is used by some legacy WebVR experiences, which will look wrong without it.