### PR TITLE
Bugfix GL_FRAMEBUFFER framebuffer binding setting

### DIFF
--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -3186,8 +3186,8 @@ NAN_METHOD(WebGLRenderingContext::BindFramebuffer) {
 
   gl->SetFramebufferBinding(target, framebuffer);
   if (target == GL_FRAMEBUFFER) {
-    gl->SetFramebufferBinding(target == GL_DRAW_FRAMEBUFFER, framebuffer);
-    gl->SetFramebufferBinding(target == GL_READ_FRAMEBUFFER, framebuffer);
+    gl->SetFramebufferBinding(GL_DRAW_FRAMEBUFFER, framebuffer);
+    gl->SetFramebufferBinding(GL_READ_FRAMEBUFFER, framebuffer);
   }
 }
 


### PR DESCRIPTION
Exokit tracks the currently bound GL framebuffer for playing tricks with the framebuffers, like reality tabs composition.

A corner case is binding `GL_FRAMEBUFFER`, which is supposed to bind both `GL_READ_FRAMEBUFFER` and  `GL_DRAW_FRAMEBUFFER`. This was not done correctly -- we were using a boolean where it did not belong.

This PR fixes that tracking by using the correct constants.