### PR TITLE
Reparent HTMLAudioElement

### DIFF
--- a/deps/exokit-bindings/webaudiocontext/include/Audio.h
+++ b/deps/exokit-bindings/webaudiocontext/include/Audio.h
@@ -23,7 +23,8 @@ public:
   void Play();
   void Pause();
   void Load(uint8_t *bufferValue, size_t bufferLength, Local<Function> cbFn);
-  void Reparent(AudioContext *newAudioContext);
+  shared_ptr<lab::AudioNode> Reparent(AudioContext *newSourceAudioContext);
+  lab::FinishableSourceNode *GetLocalAudioNode();
 
 protected:
   static NAN_METHOD(New);
@@ -44,16 +45,19 @@ protected:
 
   Nan::Persistent<Function> onended;
 
-  lab::AudioContext *audioContext;
-  Nan::Persistent<Function> cbFn;
-  shared_ptr<lab::AudioBus> audioBus;
-  std::string error;
-
   Audio();
   ~Audio();
 
-private:
+protected:
+
   shared_ptr<lab::FinishableSourceNode> audioNode;
+  shared_ptr<lab::FinishableSourceNode> sourceAudioNode;
+  lab::AudioContext *sourceAudioContext;
+  bool loaded;
+  bool sourced;
+  Nan::Persistent<Function> cbFn;
+  shared_ptr<lab::AudioBus> audioBus;
+  std::string error;
 
   friend class AudioSourceNode;
 };

--- a/deps/exokit-bindings/webaudiocontext/src/AudioSourceNode.cpp
+++ b/deps/exokit-bindings/webaudiocontext/src/AudioSourceNode.cpp
@@ -46,10 +46,9 @@ NAN_METHOD(AudioSourceNode::New) {
         audioSourceNode->Wrap(audioSourceNodeObj);
 
         audioSourceNode->context.Reset(audioContextObj);
-        audioSourceNode->audioNode = audio->audioNode;
-
+        
         AudioContext *audioContext = ObjectWrap::Unwrap<AudioContext>(Local<Object>::Cast(audioContextObj));
-        audio->Reparent(audioContext);
+        audioSourceNode->audioNode = audio->Reparent(audioContext);
 
         info.GetReturnValue().Set(audioSourceNodeObj);
       } else {


### PR DESCRIPTION
This adds support for reparenting a regular HTMLAudioElement which you play, into a `MediaElementAudioSourceNode` made from it -- which could be on a different `AudioContext`.