### PR TITLE
Bugfix HTMLAudioElement constructor src argument loading

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2697,12 +2697,9 @@ class HTMLAudioElement extends HTMLMediaElement {
   constructor(window, attrs = [], value = '') {    
     if (typeof attrs === 'string') {
       const src = attrs;
-      return new HTMLAudioElement(window, [
-        {
-          name: 'src',
-          value: src + '',
-        },
-      ], '', null);
+      const audio = new HTMLAudioElement(window, [], '', null);
+      audio.src = src + '';
+      return audio;
     } else {
       super(window, 'AUDIO', attrs, value);
 


### PR DESCRIPTION
`HTMLAudioElement` accepts `src` as an argument. This is supposed to be equivalent to setting `.src`.

Although Exokit did support this, initializing `.src` this way did not trigger loading the resource.

This PR fixes the `.src` setting to be an actual set which triggers the load.