### PR TITLE
Layer tree walk

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -850,6 +850,7 @@ const _startTopRenderLoop = () => {
   const _tickAnimationFrames = () => Promise.all(windows.map(window => window.runAsync(JSON.stringify({
     method: 'tickAnimationFrame',
     syncs: topVrPresentState.hmdType !== null ? [nativeBindings.nativeWindow.getSync()] : [],
+    layered: true,
   })).then(syncs => {
     if (topVrPresentState.windowHandle) {
       // nativeBindings.nativeWindow.setCurrentWindowContext(topVrPresentState.windowHandle);


### PR DESCRIPTION
Our linear composition walk for reality tabs was not respecting the session `.layers` array.

This PR uses `tickAnimationFrame` to pass down a `layered` flag to the `window` subtrees that have a layered path back up to the top level XR session. If so, we bind the XR framebuffer to composite XR. Otherwise, we bind the default canvas framebuffer to composite a window.