### PR TITLE
Add reconfigurable launch arguments in main.cpp

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -408,7 +408,7 @@ int main(int argc, char **argv) {
 
         offset += strlen(srcArgString) + 1;
       } else {
-        LOG_ERROR("node command line arguments overflow");
+        LOG_ERROR("node command line arguments overflow: %d", offset);
 
         abort();
       }

--- a/main.cpp
+++ b/main.cpp
@@ -388,8 +388,10 @@ int main(int argc, char **argv) {
 
     result = node::Start(argc, argv);
   } else { // get default launch args
+    // get the requested launch arguments list
     const std::vector<const char *> defaultArguments = getDefaultArguments();
 
+    // construct real argv layout that node expects
     size_t argc = defaultArguments.size();
     std::unique_ptr<char *> argv(argc);
 

--- a/main.cpp
+++ b/main.cpp
@@ -393,7 +393,8 @@ int main(int argc, char **argv) {
 
     // construct real argv layout that node expects
     size_t argc = defaultArguments.size();
-    std::unique_ptr<char *> argv(argc);
+    std::unique_ptr<char *> argv;
+    argv.resize(argc);
 
     char argsString[4096];
     int offset = 0;

--- a/main.cpp
+++ b/main.cpp
@@ -26,6 +26,8 @@ namespace node {
   int Start(int argc, char* argv[]);
 }
 
+#include "build/libexokit/dlibs.h"
+
 std::vector<const char *> getDefaultArguments() {
   const char *launchUrl;
   if (access("/package/app/index.html", F_OK) != -1) {
@@ -45,8 +47,6 @@ std::vector<const char *> getDefaultArguments() {
   };
   return result;
 }
-
-#include "build/libexokit/dlibs.h"
 
 #ifdef ANDROID
 

--- a/main.cpp
+++ b/main.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <string>
 // #include <sstream>
+#include <vector>
 #include <map>
 #include <thread>
 #include <v8.h>

--- a/main.cpp
+++ b/main.cpp
@@ -408,7 +408,7 @@ int main(int argc, char **argv) {
 
         offset += strlen(srcArgString) + 1;
       } else {
-        LOG_ERROR("node command line arguments overflow %d %d %d %d", i, srcArgSize, offset, sizeof(argsString));
+        LOG_ERROR("node command line arguments overflow");
 
         abort();
       }

--- a/main.cpp
+++ b/main.cpp
@@ -397,7 +397,7 @@ int main(int argc, char **argv) {
 
     char argsString[4096];
     int offset = 0;
-    for (size_t i = 0; i < defualtArguments.size(); i++) {
+    for (size_t i = 0; i < defaultArguments.size(); i++) {
       const char *srcArgString = defaultArguments[i];
       char *dstArgString = argsString + offset;
       size_t srcArgSize = strlen(srcArgString) + 1;

--- a/main.cpp
+++ b/main.cpp
@@ -393,8 +393,7 @@ int main(int argc, char **argv) {
 
     // construct real argv layout that node expects
     size_t argc = defaultArguments.size();
-    std::unique_ptr<char *> argv;
-    argv.resize(argc);
+    std::vector<char *> argv(argc);
 
     char argsString[4096];
     int offset = 0;
@@ -415,7 +414,7 @@ int main(int argc, char **argv) {
       }
     }
 
-    result = node::Start(argc, argv.get());
+    result = node::Start(argc, argv.data());
   }
 
   LOG_INFO("exit code %d", result);

--- a/main.cpp
+++ b/main.cpp
@@ -25,12 +25,27 @@ namespace node {
   int Start(int argc, char* argv[]);
 }
 
-#include "build/libexokit/dlibs.h"
+std::vector<const char *> getDefaultArguments() {
+  const char *launchUrl;
+  if (access("/package/app/index.html", F_OK) != -1) {
+    launchUrl = "/package/app/index.html";
+  } else {
+    launchUrl = "/package/examples/realitytabs.html";
+  }
 
-namespace node {
-  extern std::map<std::string, std::pair<void *, bool>> dlibs;
-  int Start(int argc, char* argv[]);
+  std::vector<const char *> result = {
+    "node",
+#ifndef ANDROID
+    ".",
+#else
+    "/package",
+#endif
+    launchUrl,
+  };
+  return result;
 }
+
+#include "build/libexokit/dlibs.h"
 
 #ifdef ANDROID
 
@@ -341,7 +356,7 @@ int main(int argc, char **argv) {
 
   int result;
   const char *argsEnv = getenv("ARGS");
-  if (argsEnv) {
+  if (argsEnv) { // get args from launch command
     char args[4096];
     strncpy(args, argsEnv, sizeof(args));
 
@@ -371,39 +386,32 @@ int main(int argc, char **argv) {
     }
 
     result = node::Start(argc, argv);
-  } else {
-    const char *jsString;
-    if (access("/package/app/index.html", F_OK) != -1) {
-      jsString = "/package/app/index.html";
-    } else {
-      jsString = "/package/examples/realitytabs.html";
+  } else { // get default launch args
+    const std::vector<const char *> defaultArguments = getDefaultArguments();
+
+    size_t argc = defaultArguments.size();
+    std::unique_ptr<char *> argv(argc);
+
+    char argsString[4096];
+    int offset = 0;
+    for (size_t i = 0; i < defualtArguments.size(); i++) {
+      const char *srcArgString = defaultArguments[i];
+      char *dstArgString = argsString + offset;
+      size_t srcArgSize = strlen(srcArgString) + 1;
+      if ((offset + srcArgSize) < sizeof(argsString)) {
+        memcpy(dstArgString, srcArgString, srcArgSize);
+
+        argv[i] = dstArgString;
+
+        offset += strlen(srcArgString) + 1;
+      } else {
+        LOG_ERROR("node command line arguments overflow %d %d %d %d", i, srcArgSize, offset, sizeof(argsString));
+
+        abort();
+      }
     }
 
-    const char *nodeString = "node";
-#ifndef ANDROID
-    const char *dotString = ".";
-#else
-    const char *dotString = "/package";
-#endif
-    char argsString[4096];
-    int i = 0;
-
-    char *nodeArg = argsString + i;
-    strncpy(nodeArg, nodeString, sizeof(argsString) - i);
-    i += strlen(nodeString) + 1;
-
-    char *dotArg = argsString + i;
-    strncpy(dotArg, dotString, sizeof(argsString) - i);
-    i += strlen(dotString) + 1;
-
-    char *jsArg = argsString + i;
-    strncpy(jsArg, jsString, sizeof(argsString) - i);
-    i += strlen(jsString) + 1;
-
-    char *argv[] = {nodeArg, dotArg, jsArg};
-    size_t argc = sizeof(argv) / sizeof(argv[0]);
-
-    result = node::Start(argc, argv);
+    result = node::Start(argc, argv.get());
   }
 
   LOG_INFO("exit code %d", result);


### PR DESCRIPTION
This allows one to set a different site + arguments that Exokit will use on startup, in `main.cpp`.

This is useful when creating standalone apps where you cannot pass command line arguments manually.