### PR TITLE
VR entry request routing

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2063,8 +2063,6 @@ class HTMLIFrameElement extends HTMLSrcableElement {
                     this.setAttribute('src', href);
                   },
                   onrequest(req) {
-                    req.keypath.push(GlobalContext.id);
-                    console.log('iframe route req', req, contentWindow.id, GlobalContext.id); // XXX
                     parentPort.postMessage(req);
                   },
                 });

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const url = require('url');
 const vm = require('vm');
 const util = require('util');
+const {parentPort} = require('worker_threads');
 
 const {process} = global;
 
@@ -2062,7 +2063,8 @@ class HTMLIFrameElement extends HTMLSrcableElement {
                     this.setAttribute('src', href);
                   },
                   onrequest(req) {
-                    req.keypath.push(contentWindow.id);
+                    req.keypath.push(GlobalContext.id);
+                    console.log('iframe route req', req, contentWindow.id, GlobalContext.id); // XXX
                     parentPort.postMessage(req);
                   },
                 });

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2061,6 +2061,10 @@ class HTMLIFrameElement extends HTMLSrcableElement {
 
                     this.setAttribute('src', href);
                   },
+                  onrequest(req) {
+                    req.keypath.push(contentWindow.id);
+                    parentPort.postMessage(req);
+                  },
                 });
 
                 this.contentWindow = contentWindow;

--- a/src/Window.js
+++ b/src/Window.js
@@ -1183,6 +1183,7 @@ const _makeOnRequestHitTest = window => (origin, direction, cb) => nativeMl.Requ
           parentPort.postMessage({
             method: 'request',
             type: 'requestPresent',
+            keypath: [],
           });
         });
       // }
@@ -1211,6 +1212,7 @@ const _makeOnRequestHitTest = window => (origin, direction, cb) => nativeMl.Requ
           parentPort.postMessage({
             method: 'request',
             type: 'exitPresent',
+            keypath: [],
           });
         });
       // }

--- a/src/Window.js
+++ b/src/Window.js
@@ -1294,13 +1294,33 @@ global.onrunasync = method => {
     const res = JSON.parse(method);
     return global.tickAnimationFrame(res);
   } else if (/^\{"method":"response"/.test(method)) {
-    if (vrPresentState.responseAccepts.length > 0) {
-      const res = JSON.parse(method);
+    const res = JSON.parse(method);
+    const {keypath} = res;
 
-      vrPresentState.responseAccepts.shift()(res);
-      return Promise.resolve();
+    if (keypath.length === 0) {
+      if (vrPresentState.responseAccepts.length > 0) {
+        const res = JSON.parse(method);
+
+        vrPresentState.responseAccepts.shift()(res);
+
+        return Promise.resolve();
+      } else {
+        return Promise.reject(new Error(`unexpected response at window ${method}`));
+      }
     } else {
-      return Promise.reject(new Error(`unexpected window response ${method}`));
+      const windowId = keypath.pop();
+      const window = windows.find(window => window.id === windowId);
+
+      if (window) {
+        window.runAsync(JSON.stringify({
+          method: 'response',
+          keypath,
+        }));
+
+        return Promise.resolve();
+      } else {
+        return Promise.reject(new Error(`response for unknown window ${method} ${JSON.stringify(windows.map(window => window.id))}`));
+      }
     }
   } else if (/^\{"method":"eval"/.test(method)) {
     return Promise.resolve(eval(JSON.parse(method).scriptString));

--- a/src/WindowVm.js
+++ b/src/WindowVm.js
@@ -45,6 +45,9 @@ class WorkerVm extends EventEmitter {
         }
       }
     });
+    worker.on('request', req => {
+      this.emit('request', req);
+    });
     worker.on('error', err => {
       this.emit('error', err);
     });
@@ -182,6 +185,7 @@ const _makeWindow = (options = {}, handlers = {}) => {
       });
   });
   window.on('request', req => {
+    req.keypath = [id];
     options.onrequest && options.onrequest(req);
   });
   window.on('error', err => {

--- a/src/WindowVm.js
+++ b/src/WindowVm.js
@@ -185,7 +185,7 @@ const _makeWindow = (options = {}, handlers = {}) => {
       });
   });
   window.on('request', req => {
-    req.keypath = [id];
+    req.keypath.push(id);
     options.onrequest && options.onrequest(req);
   });
   window.on('error', err => {

--- a/src/WindowVm.js
+++ b/src/WindowVm.js
@@ -17,7 +17,7 @@ class WorkerVm extends EventEmitter {
     worker.on('message', m => {
       switch (m.method) {
         case 'request': {
-          GlobalContext.handleRequest(m, this);
+          worker.emit('request', m);
           break;
         }
         case 'response': {
@@ -180,6 +180,11 @@ const _makeWindow = (options = {}, handlers = {}) => {
       .catch(err => {
         console.warn(err.stack);
       });
+  });
+  window.on('request', req => {
+    if (GlobalContext.handleRequest) {
+      GlobalContext.handleRequest();
+    options.onrequest && options.onrequest(req);
   });
   window.on('error', err => {
     console.warn(err.stack);

--- a/src/WindowVm.js
+++ b/src/WindowVm.js
@@ -182,8 +182,6 @@ const _makeWindow = (options = {}, handlers = {}) => {
       });
   });
   window.on('request', req => {
-    if (GlobalContext.handleRequest) {
-      GlobalContext.handleRequest();
     options.onrequest && options.onrequest(req);
   });
   window.on('error', err => {

--- a/src/core.js
+++ b/src/core.js
@@ -74,6 +74,7 @@ exokit.load = (src, options = {}) => {
         args: options.args,
         replacements: options.replacements,
         onnavigate: options.onnavigate,
+        onrequest: options.onrequest,
       });
     });
 };

--- a/src/index.js
+++ b/src/index.js
@@ -413,7 +413,6 @@ const _handleRequest = ({type, keypath}) => {
     xrState.hmdType[0] = 0;
   }
 
-  console.log('got key path top', keypath); // XXX
   const windowId = keypath.pop();
   const window = windows.find(window => window.id === windowId);
   if (window) {

--- a/src/index.js
+++ b/src/index.js
@@ -413,6 +413,7 @@ const _handleRequest = ({type, keypath}) => {
     xrState.hmdType[0] = 0;
   }
 
+  console.log('got key path top', keypath); // XXX
   const windowId = keypath.pop();
   const window = windows.find(window => window.id === windowId);
   if (window) {


### PR DESCRIPTION
The linear render strategy involves changing VR entry to be a request-response architecture, as well as allowing multiple `requestPresent` VR entry (A-Frame does this).

However, these requests were not being properly routed up the render tree. This PR fixes that.