### PR TITLE
Make iframe d=3 default

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2152,7 +2152,8 @@ class HTMLIFrameElement extends HTMLSrcableElement {
   }
 
   get d() {
-    return parseInt(this.getAttribute('d') || 1 + '', 10);
+    const d = parseInt(this.getAttribute('d') + '', 10);
+    return isFinite(d) ? d : 3;
   }
   set d(value) {
     if (typeof value === 'number' && isFinite(value)) {


### PR DESCRIPTION
The dimension was `1` before, which is not meaningful.

The dimension count is used to determine whether to hide the iframe.