### PR TITLE
Bugfix haptic pulse support

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2062,6 +2062,13 @@ class HTMLIFrameElement extends HTMLSrcableElement {
 
                     this.setAttribute('src', href);
                   },
+                  onhapticpulse(event) {
+                    parentPort.postMessage({
+                      method: 'emit',
+                      type: 'hapticPulse',
+                      event,
+                    });
+                  }
                 });
 
                 this.contentWindow = contentWindow;

--- a/src/VR.js
+++ b/src/VR.js
@@ -1,4 +1,6 @@
 const {EventEmitter} = require('events');
+const {parentPort} = require('worker_threads');
+
 const {Event} = require('./Event');
 const symbols = require('./symbols');
 const THREE = require('../lib/three-min.js');
@@ -113,19 +115,15 @@ class GamepadHapticActuator {
   }
   set type(type) {}
   pulse(value, duration) {
-    if (GlobalContext.xrState.isPresenting[0]) {
-      value = Math.min(Math.max(value, 0), 1);
-      const deviceIndex = GlobalContext.vrPresentState.system.GetTrackedDeviceIndexForControllerRole(this.index + 1);
-
-      const startTime = Date.now();
-      const _recurse = () => {
-        if ((Date.now() - startTime) < duration) {
-          GlobalContext.vrPresentState.system.TriggerHapticPulse(deviceIndex, 0, value * 4000);
-          setTimeout(_recurse, 50);
-        }
-      };
-      setTimeout(_recurse, 50);
-    }
+    parentPort.postMessage({
+      method: 'emit',
+      type: 'hapticPulse',
+      event: {
+        index: this.index,
+        value,
+        duration,
+      },
+    });
   }
 }
 class Gamepad {

--- a/src/WindowVm.js
+++ b/src/WindowVm.js
@@ -40,7 +40,7 @@ class WorkerVm extends EventEmitter {
           break;
         }
         default: {
-          throw new Error(`worker got unknown message type '${m.method}'`);
+          throw new Error(`worker got unknown message: '${JSON.stringify(m)}'`);
           break;
         }
       }

--- a/src/WindowVm.js
+++ b/src/WindowVm.js
@@ -181,6 +181,9 @@ const _makeWindow = (options = {}, handlers = {}) => {
         console.warn(err.stack);
       });
   });
+  window.on('hapticPulse', e => {
+    options.onhapticpulse && options.onhapticpulse(e);
+  });
   window.on('error', err => {
     console.warn(err.stack);
   });

--- a/src/index.js
+++ b/src/index.js
@@ -416,6 +416,24 @@ const _handleRequest = ({req: {type}, window}) => {
     method: 'response',
   }));
 };
+const handleHapticPulse = ({index, value, duration}) => {
+  if (topVrPresentState.hmdType === 'openvr') {
+    value = Math.min(Math.max(value, 0), 1);
+    const deviceIndex = topVrPresentState.vrSystem.GetTrackedDeviceIndexForControllerRole(index + 1);
+
+    const startTime = Date.now();
+    const _recurse = () => {
+      if ((Date.now() - startTime) < duration) {
+        topVrPresentState.vrSystem.TriggerHapticPulse(deviceIndex, 0, value * 4000);
+        setTimeout(_recurse, 50);
+      }
+    };
+    setTimeout(_recurse, 50);
+  } else {
+    console.warn(`ignoring haptic pulse: ${index}/${value}/${duration}`);
+    // TODO: handle the other HMD cases...
+  }
+};
 
 const _startTopRenderLoop = () => {
   const timestamps = {
@@ -1083,6 +1101,7 @@ const _start = () => {
         args,
         replacements,
         onnavigate: _onnavigate,
+        onhapticpulse: handleHapticPulse,
       });
     };
     _onnavigate(u);
@@ -1105,6 +1124,7 @@ const _start = () => {
     let window = core.make('', {
       dataPath,
       onnavigate: _onnavigate,
+      onhapticpulse: handleHapticPulse,
     });
 
     const prompt = '[x] ';


### PR DESCRIPTION
Exokit's OpenVR binding has supported haptics since forever, but it regressed in window parallelization, where the data flow for VR contexts is much more isolated.

This reroutes the haptic pulse activations to reach `index.js`, handles them there, and opens up the code path for other VR system bindings to handle haptics there too.