### PR TITLE
Do not pre-initialize composition shaders

### DIFF
--- a/deps/exokit-bindings/egl/src/egl.cc
+++ b/deps/exokit-bindings/egl/src/egl.cc
@@ -263,8 +263,6 @@ NAN_METHOD(InitWindow3D) {
   
   SetCurrentWindowContext(windowHandle);
 
-  windowsystembase::InitializeLocalGlState(gl);
-
   GLuint vao;
   glGenVertexArrays(1, &vao);
   glBindVertexArray(vao);

--- a/deps/exokit-bindings/glfw/src/glfw.cc
+++ b/deps/exokit-bindings/glfw/src/glfw.cc
@@ -1052,8 +1052,6 @@ NAN_METHOD(InitWindow3D) {
 
   SetCurrentWindowContext(windowHandle);
 
-  windowsystembase::InitializeLocalGlState(gl);
-
   GLuint vao;
   glGenVertexArrays(1, &vao);
   glBindVertexArray(vao);

--- a/deps/exokit-bindings/webglcontext/include/webgl.h
+++ b/deps/exokit-bindings/webglcontext/include/webgl.h
@@ -85,6 +85,11 @@ enum GlKey {
   GL_KEY_PLANE,
 };
 
+class GlShader {
+public:
+  virtual ~GlShader() = 0;
+};
+
 void flipImageData(char *dstData, char *srcData, size_t width, size_t height, size_t pixelSize);
 
 class ViewportState {

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -36,6 +36,8 @@ void unregisterGLObj(GLuint obj); */
 
 #define JS_GL_CONSTANT(name) JS_GL_SET_CONSTANT(#name, GL_ ## name)
 
+GlShader::~GlShader() {}
+
 template<NAN_METHOD(F)>
 NAN_METHOD(glCallWrap) {
   Local<Object> glObj = info.This();
@@ -1179,7 +1181,12 @@ WebGLRenderingContext::WebGLRenderingContext() :
   activeTexture(GL_TEXTURE0)
   {}
 
-WebGLRenderingContext::~WebGLRenderingContext() {}
+WebGLRenderingContext::~WebGLRenderingContext() {
+  for (auto iter = keys.begin(); iter != keys.end(); iter++) {
+    GlShader *glShader = (GlShader *)iter->second;
+    delete glShader;
+  }
+}
 
 NAN_METHOD(WebGLRenderingContext::New) {
   WebGLRenderingContext *gl = new WebGLRenderingContext();

--- a/deps/exokit-bindings/windowsystem/include/windowsystem.h
+++ b/deps/exokit-bindings/windowsystem/include/windowsystem.h
@@ -28,7 +28,7 @@ enum class LayerType {
 
 class LayerSpec {
 public:
-  LayerType type;
+  LayerType layerType;
   int width;
   int height;
   GLuint msTex;
@@ -40,8 +40,13 @@ public:
   float *projection[2];
 };
 
-class ComposeSpec {
+class ComposeGlShader : public GlShader {
 public:
+  ComposeGlShader();
+  virtual ~ComposeGlShader();
+
+  static GlKey key;
+
   GLuint blitFbos[2];
   GLuint composeVao;
   GLuint composeProgram;
@@ -54,8 +59,13 @@ public:
   GLuint indexBuffer;
 };
 
-class PlaneSpec {
+class PlaneGlShader : public GlShader {
 public:
+  PlaneGlShader();
+  virtual ~PlaneGlShader();
+
+  static GlKey key;
+
   GLuint planeVao;
   GLuint planeProgram;
   GLint positionLocation;
@@ -68,8 +78,7 @@ public:
   GLuint indexBuffer;
 };
 
-void InitializeLocalGlState(WebGLRenderingContext *gl);
-void CreateRenderTarget(WebGLRenderingContext *gl, int width, int height, GLuint sharedColorTex, GLuint sharedDepthStencilTex, GLuint sharedMsColorTex, GLuint sharedMsDepthStencilTex, GLuint *pfbo, GLuint *pcolorTex, GLuint *pdepthStencilTex, GLuint *pmsFbo, GLuint *pmsColorTex, GLuint *pmsDepthStencilTex);
+bool CreateRenderTarget(WebGLRenderingContext *gl, int width, int height, GLuint sharedColorTex, GLuint sharedDepthStencilTex, GLuint sharedMsColorTex, GLuint sharedMsDepthStencilTex, GLuint *pfbo, GLuint *pcolorTex, GLuint *pdepthStencilTex, GLuint *pmsFbo, GLuint *pmsColorTex, GLuint *pmsDepthStencilTex);
 NAN_METHOD(CreateRenderTarget);
 NAN_METHOD(ResizeRenderTarget);
 NAN_METHOD(DestroyRenderTarget);

--- a/deps/exokit-bindings/windowsystem/src/windowsystem.cc
+++ b/deps/exokit-bindings/windowsystem/src/windowsystem.cc
@@ -78,6 +78,115 @@ void main() {\n\
 }\n\
 ";
 
+ComposeGlShader::ComposeGlShader() {
+  glGenFramebuffers(2, this->blitFbos);
+
+  glGenVertexArrays(1, &this->composeVao);
+
+  // vertex array
+  glBindVertexArray(this->composeVao);
+
+  // vertex shader
+  GLuint composeVertex = glCreateShader(GL_VERTEX_SHADER);
+  glShaderSource(composeVertex, 1, &composeVsh, NULL);
+  glCompileShader(composeVertex);
+  GLint success;
+  glGetShaderiv(composeVertex, GL_COMPILE_STATUS, &success);
+  if (!success) {
+    char infoLog[4096];
+    GLsizei length;
+    glGetShaderInfoLog(composeVertex, sizeof(infoLog), &length, infoLog);
+    infoLog[length] = '\0';
+    exout << "ML compose vertex shader compilation failed:\n" << infoLog << std::endl;
+    return;
+  };
+
+  // fragment shader
+  GLuint composeFragment = glCreateShader(GL_FRAGMENT_SHADER);
+  glShaderSource(composeFragment, 1, &composeFsh, NULL);
+  glCompileShader(composeFragment);
+  glGetShaderiv(composeFragment, GL_COMPILE_STATUS, &success);
+  if (!success) {
+    char infoLog[4096];
+    GLsizei length;
+    glGetShaderInfoLog(composeFragment, sizeof(infoLog), &length, infoLog);
+    infoLog[length] = '\0';
+    exout << "ML compose fragment shader compilation failed:\n" << infoLog << std::endl;
+    return;
+  };
+
+  // shader program
+  this->composeProgram = glCreateProgram();
+  glAttachShader(this->composeProgram, composeVertex);
+  glAttachShader(this->composeProgram, composeFragment);
+  glLinkProgram(this->composeProgram);
+  glGetProgramiv(this->composeProgram, GL_LINK_STATUS, &success);
+  if (!success) {
+    char infoLog[4096];
+    GLsizei length;
+    glGetShaderInfoLog(this->composeProgram, sizeof(infoLog), &length, infoLog);
+    infoLog[length] = '\0';
+    exout << "ML compose program linking failed\n" << infoLog << std::endl;
+    return;
+  }
+
+  this->positionLocation = glGetAttribLocation(this->composeProgram, "position");
+  if (this->positionLocation == -1) {
+    exout << "ML compose program failed to get attrib location for 'position'" << std::endl;
+    return;
+  }
+  this->uvLocation = glGetAttribLocation(this->composeProgram, "uv");
+  if (this->uvLocation == -1) {
+    exout << "ML compose program failed to get attrib location for 'uv'" << std::endl;
+    return;
+  }
+  this->texLocation = glGetUniformLocation(this->composeProgram, "tex");
+  if (this->texLocation == -1) {
+    exout << "ML compose program failed to get uniform location for 'tex'" << std::endl;
+    return;
+  }
+  this->depthTexLocation = glGetUniformLocation(this->composeProgram, "depthTex");
+  if (this->depthTexLocation == -1) {
+    exout << "ML compose program failed to get uniform location for 'depthTex'" << std::endl;
+    return;
+  }
+
+  // delete the shaders as they're linked into our program now and no longer necessery
+  glDeleteShader(composeVertex);
+  glDeleteShader(composeFragment);
+
+  glGenBuffers(1, &this->positionBuffer);
+  glBindBuffer(GL_ARRAY_BUFFER, this->positionBuffer);
+  static const float positions[] = {
+    -1.0f, 1.0f,
+    1.0f, 1.0f,
+    -1.0f, -1.0f,
+    1.0f, -1.0f,
+  };
+  glBufferData(GL_ARRAY_BUFFER, sizeof(positions), positions, GL_STATIC_DRAW);
+  glEnableVertexAttribArray(this->positionLocation);
+  glVertexAttribPointer(this->positionLocation, 2, GL_FLOAT, false, 0, 0);
+
+  glGenBuffers(1, &this->uvBuffer);
+  glBindBuffer(GL_ARRAY_BUFFER, this->uvBuffer);
+  static const float uvs[] = {
+    0.0f, 1.0f,
+    1.0f, 1.0f,
+    0.0f, 0.0f,
+    1.0f, 0.0f,
+  };
+  glBufferData(GL_ARRAY_BUFFER, sizeof(uvs), uvs, GL_STATIC_DRAW);
+  glEnableVertexAttribArray(this->uvLocation);
+  glVertexAttribPointer(this->uvLocation, 2, GL_FLOAT, false, 0, 0);
+
+  glGenBuffers(1, &this->indexBuffer);
+  static const uint16_t indices[] = {0, 2, 1, 2, 3, 1};
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->indexBuffer);
+  glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices, GL_STATIC_DRAW);
+}
+ComposeGlShader::~ComposeGlShader() {}
+GlKey ComposeGlShader::key = GlKey::GL_KEY_COMPOSE;
+
 const char *planeVsh = ""
 #ifdef ANDROID
 "#version 300 es\n"
@@ -112,7 +221,119 @@ void main() {\n\
 }\n\
 ";
 
-void InitializeLocalGlState(WebGLRenderingContext *gl) {
+PlaneGlShader::PlaneGlShader() {
+  glGenVertexArrays(1, &this->planeVao);
+
+  // vertex array
+  glBindVertexArray(this->planeVao);
+
+  // vertex shader
+  GLuint planeVertex = glCreateShader(GL_VERTEX_SHADER);
+  glShaderSource(planeVertex, 1, &planeVsh, NULL);
+  glCompileShader(planeVertex);
+  GLint success;
+  glGetShaderiv(planeVertex, GL_COMPILE_STATUS, &success);
+  if (!success) {
+    char infoLog[4096];
+    GLsizei length;
+    glGetShaderInfoLog(planeVertex, sizeof(infoLog), &length, infoLog);
+    infoLog[length] = '\0';
+    exout << "plane vertex shader compilation failed:\n" << infoLog << std::endl;
+    return;
+  };
+
+  // fragment shader
+  GLuint planeFragment = glCreateShader(GL_FRAGMENT_SHADER);
+  glShaderSource(planeFragment, 1, &planeFsh, NULL);
+  glCompileShader(planeFragment);
+  glGetShaderiv(planeFragment, GL_COMPILE_STATUS, &success);
+  if (!success) {
+    char infoLog[4096];
+    GLsizei length;
+    glGetShaderInfoLog(planeFragment, sizeof(infoLog), &length, infoLog);
+    infoLog[length] = '\0';
+    exout << "plane fragment shader compilation failed:\n" << infoLog << std::endl;
+    return;
+  };
+
+  // shader program
+  this->planeProgram = glCreateProgram();
+  glAttachShader(this->planeProgram, planeVertex);
+  glAttachShader(this->planeProgram, planeFragment);
+  glLinkProgram(this->planeProgram);
+  glGetProgramiv(this->planeProgram, GL_LINK_STATUS, &success);
+  if (!success) {
+    char infoLog[4096];
+    GLsizei length;
+    glGetShaderInfoLog(this->planeProgram, sizeof(infoLog), &length, infoLog);
+    infoLog[length] = '\0';
+    exout << "plane program linking failed\n" << infoLog << std::endl;
+    return;
+  }
+
+  this->positionLocation = glGetAttribLocation(this->planeProgram, "position");
+  if (this->positionLocation == -1) {
+    exout << "plane program failed to get attrib location for 'position'" << std::endl;
+    return;
+  }
+  this->uvLocation = glGetAttribLocation(this->planeProgram, "uv");
+  if (this->uvLocation == -1) {
+    exout << "plane program failed to get attrib location for 'uv'" << std::endl;
+    return;
+  }
+  this->modelViewMatrixLocation = glGetUniformLocation(this->planeProgram, "modelViewMatrix");
+  if (this->modelViewMatrixLocation == -1) {
+    exout << "plane program failed to get uniform location for 'modelViewMatrix'" << std::endl;
+    return;
+  }
+  this->projectionMatrixLocation = glGetUniformLocation(this->planeProgram, "projectionMatrix");
+  if (this->projectionMatrixLocation == -1) {
+    exout << "plane program failed to get uniform location for 'projectionMatrix'" << std::endl;
+    return;
+  }
+  this->texLocation = glGetUniformLocation(this->planeProgram, "tex");
+  if (this->texLocation == -1) {
+    exout << "plane program failed to get uniform location for 'tex'" << std::endl;
+    return;
+  }
+
+  // delete the shaders as they're linked into our program now and no longer necessery
+  glDeleteShader(planeVertex);
+  glDeleteShader(planeFragment);
+
+  glGenBuffers(1, &this->positionBuffer);
+  glBindBuffer(GL_ARRAY_BUFFER, this->positionBuffer);
+  static const float positions[] = {
+    -1.0f, 1.0f,
+    1.0f, 1.0f,
+    -1.0f, -1.0f,
+    1.0f, -1.0f,
+  };
+  glBufferData(GL_ARRAY_BUFFER, sizeof(positions), positions, GL_STATIC_DRAW);
+  glEnableVertexAttribArray(this->positionLocation);
+  glVertexAttribPointer(this->positionLocation, 2, GL_FLOAT, false, 0, 0);
+
+  glGenBuffers(1, &this->uvBuffer);
+  glBindBuffer(GL_ARRAY_BUFFER, this->uvBuffer);
+  static const float uvs[] = {
+    0.0f, 0.0f,
+    1.0f, 0.0f,
+    0.0f, 1.0f,
+    1.0f, 1.0f,
+  };
+  glBufferData(GL_ARRAY_BUFFER, sizeof(uvs), uvs, GL_STATIC_DRAW);
+  glEnableVertexAttribArray(this->uvLocation);
+  glVertexAttribPointer(this->uvLocation, 2, GL_FLOAT, false, 0, 0);
+
+  glGenBuffers(1, &this->indexBuffer);
+  static const uint16_t indices[] = {0, 2, 1, 2, 3, 1};
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->indexBuffer);
+  glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices, GL_STATIC_DRAW);
+}
+PlaneGlShader::~PlaneGlShader() {}
+GlKey PlaneGlShader::key = GlKey::GL_KEY_PLANE;
+
+/* void InitializeLocalGlState(WebGLRenderingContext *gl) {
   // compose
   {
     ComposeSpec *composeSpec = new ComposeSpec();
@@ -350,7 +571,7 @@ void InitializeLocalGlState(WebGLRenderingContext *gl) {
   } else {
     glBindBuffer(GL_ARRAY_BUFFER, 0);
   }
-}
+} */
 
 constexpr GLint MAX_TEXTURE_SIZE = 4096;
 constexpr GLint NUM_SAMPLES = 4;
@@ -538,6 +759,33 @@ NAN_METHOD(ResizeRenderTarget) {
   result->Set(4, JS_INT(msColorTex));
   result->Set(5, JS_INT(msDepthStencilTex));
   info.GetReturnValue().Set(result);
+}
+
+template <typename T>
+T *getGlShader(WebGLRenderingContext *gl) {
+  const GlKey &key = T::key;
+  auto iter = gl->keys.find(key);
+  if (iter != gl->keys.end()) {
+    return (T *)iter->second;
+  } else {
+    T *t = new T();
+
+    {
+      if (gl->HasVertexArrayBinding()) {
+        glBindVertexArray(gl->GetVertexArrayBinding());
+      } else {
+        glBindVertexArray(gl->defaultVao);
+      }
+      if (gl->HasBufferBinding(GL_ARRAY_BUFFER)) {
+        glBindBuffer(GL_ARRAY_BUFFER, gl->GetBufferBinding(GL_ARRAY_BUFFER));
+      } else {
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
+      }
+    }
+
+    gl->keys[key] = t;
+    return t;
+  }
 }
 
 NAN_METHOD(DestroyRenderTarget) {
@@ -768,13 +1016,15 @@ NAN_METHOD(DeleteSync) {
   } */
 }
 
-void BlitLayer(ComposeSpec *composeSpec, PlaneSpec *planeSpec, const LayerSpec &layer) {
-  if (layer.type == LayerType::IFRAME_3D || layer.type == LayerType::RAW_CANVAS) {
-    glBindFramebuffer(GL_READ_FRAMEBUFFER, composeSpec->blitFbos[0]);
+void BlitLayer(WebGLRenderingContext *gl, const LayerSpec &layer) {
+  if (layer.layerType == LayerType::IFRAME_3D || layer.layerType == LayerType::RAW_CANVAS) {
+    ComposeGlShader *composeGlShader = getGlShader<ComposeGlShader>(gl);
+
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, composeGlShader->blitFbos[0]);
     glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D_MULTISAMPLE, layer.msTex, 0);
     glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D_MULTISAMPLE, layer.msDepthTex, 0);
 
-    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, composeSpec->blitFbos[1]);
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, composeGlShader->blitFbos[1]);
     glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, layer.tex, 0);
     glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, layer.depthTex, 0);
 
@@ -789,39 +1039,43 @@ void BlitLayer(ComposeSpec *composeSpec, PlaneSpec *planeSpec, const LayerSpec &
   }
 }
 
-void ComposeLayer(ComposeSpec *composeSpec, PlaneSpec *planeSpec, const LayerSpec &layer) {
-  if (layer.type == LayerType::IFRAME_3D || layer.type == LayerType::IFRAME_3D_REPROJECT || layer.type == LayerType::RAW_CANVAS) {
-    glBindVertexArray(composeSpec->composeVao);
-    glUseProgram(composeSpec->composeProgram);
+void ComposeLayer(WebGLRenderingContext *gl, const LayerSpec &layer) {
+  if (layer.layerType == LayerType::IFRAME_3D || layer.layerType == LayerType::IFRAME_3D_REPROJECT || layer.layerType == LayerType::RAW_CANVAS) {
+    ComposeGlShader *composeGlShader = getGlShader<ComposeGlShader>(gl);
+
+    glBindVertexArray(composeGlShader->composeVao);
+    glUseProgram(composeGlShader->composeProgram);
 
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, layer.tex);
-    glUniform1i(composeSpec->texLocation, 0);
+    glUniform1i(composeGlShader->texLocation, 0);
 
     glActiveTexture(GL_TEXTURE1);
     glBindTexture(GL_TEXTURE_2D, layer.depthTex);
-    glUniform1i(composeSpec->depthTexLocation, 1);
+    glUniform1i(composeGlShader->depthTexLocation, 1);
 
     glViewport(0, 0, layer.width, layer.height);
     glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, 0);
   } else {
-    glBindVertexArray(planeSpec->planeVao);
-    glUseProgram(planeSpec->planeProgram);
+    PlaneGlShader *planeGlShader = getGlShader<PlaneGlShader>(gl);
+
+    glBindVertexArray(planeGlShader->planeVao);
+    glUseProgram(planeGlShader->planeProgram);
 
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, layer.tex);
-    glUniform1i(planeSpec->texLocation, 0);
+    glUniform1i(planeGlShader->texLocation, 0);
 
     {
-      glUniformMatrix4fv(planeSpec->modelViewMatrixLocation, 1, false, layer.modelView[0]);
-      glUniformMatrix4fv(planeSpec->projectionMatrixLocation, 1, false, layer.projection[0]);
+      glUniformMatrix4fv(planeGlShader->modelViewMatrixLocation, 1, false, layer.modelView[0]);
+      glUniformMatrix4fv(planeGlShader->projectionMatrixLocation, 1, false, layer.projection[0]);
 
       glViewport(layer.viewports[0][0], layer.viewports[0][1], layer.viewports[0][2], layer.viewports[0][3]);
       glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, 0);
     }
     {
-      glUniformMatrix4fv(planeSpec->modelViewMatrixLocation, 1, false, layer.modelView[1]);
-      glUniformMatrix4fv(planeSpec->projectionMatrixLocation, 1, false, layer.projection[1]);
+      glUniformMatrix4fv(planeGlShader->modelViewMatrixLocation, 1, false, layer.modelView[1]);
+      glUniformMatrix4fv(planeGlShader->projectionMatrixLocation, 1, false, layer.projection[1]);
 
       glViewport(layer.viewports[1][0], layer.viewports[1][1], layer.viewports[1][2], layer.viewports[1][3]);
       glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, 0);
@@ -830,17 +1084,14 @@ void ComposeLayer(ComposeSpec *composeSpec, PlaneSpec *planeSpec, const LayerSpe
 }
 
 void ComposeLayers(WebGLRenderingContext *gl, GLuint fbo, const std::vector<LayerSpec> &layers) {
-  ComposeSpec *composeSpec = (ComposeSpec *)(gl->keys[GlKey::GL_KEY_COMPOSE]);
-  PlaneSpec *planeSpec = (PlaneSpec *)(gl->keys[GlKey::GL_KEY_PLANE]);
-
   for (size_t i = 0; i < layers.size(); i++) {
-    BlitLayer(composeSpec, planeSpec, layers[i]);
+    BlitLayer(gl, layers[i]);
   }
 
   glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fbo);
   glClear(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT|GL_STENCIL_BUFFER_BIT);
   for (size_t i = 0; i < layers.size(); i++) {
-    ComposeLayer(composeSpec, planeSpec, layers[i]);
+    ComposeLayer(gl, layers[i]);
   }
 
   if (gl->HasFramebufferBinding(GL_READ_FRAMEBUFFER)) {


### PR DESCRIPTION
Prior to the `recomposite` branch, Exokit would use shaders to perform composition for reality tabs.

These were pre-initialized on each context, which has some overhead (and context destruction consequences if it's bugged, which it was a few times).

This codepath doesn't need to run at all with the new branch, so this PR makes these shaders/GL objects dynamically constructed when we call into the old composition pipeline. We currently do not do that (anymore) in this branch, since we don't need to, but the option is there. We might gut this code entirely eventually, but until then it should have no GL overhead.

The end result of this PR should be slightly faster GL context initialization, for all contexts.