### PR TITLE
Handle invalid WebAudio decodeAudioData

### DIFF
--- a/deps/exokit-bindings/webaudiocontext/src/AudioBuffer.cpp
+++ b/deps/exokit-bindings/webaudiocontext/src/AudioBuffer.cpp
@@ -188,7 +188,14 @@ NAN_METHOD(AudioBuffer::Load) {
 
       audioBuffer->Load(arrayBuffer, arrayBufferView->ByteOffset(), arrayBufferView->ByteLength(), cbFn);
     } else {
-      Nan::ThrowError("invalid arguments");
+      Local<Object> asyncObject = Nan::New<Object>();
+      AsyncResource asyncResource(Isolate::GetCurrent(), asyncObject, "AudioBuffer::Load");
+
+      Local<Function> cbFn = Local<Function>::Cast(info[1]);
+      Local<Value> argv[] = {
+        JS_STR("invalid buffer"),
+      };
+      asyncResource.MakeCallback(cbFn, sizeof(argv)/sizeof(argv[0]), argv);
     }
   } else {
     Nan::ThrowError("invalid arguments");

--- a/src/native-bindings.js
+++ b/src/native-bindings.js
@@ -411,11 +411,8 @@ if (bindings.nativeAudio) {
           }
         });
       });
-      result.then(audioBuffer => {
-        successCallback && successCallback(audioBuffer);
-      }).catch(err => {
-        errorCallback && errorCallback(err);
-      });
+      successCallback && result.then(successCallback);
+      errorCallback && result.catch(errorCallback);
       return result;
     }
   })(bindings.nativeAudio.AudioContext);

--- a/src/native-bindings.js
+++ b/src/native-bindings.js
@@ -403,16 +403,21 @@ if (bindings.nativeAudio) {
     decodeAudioData(arrayBuffer, successCallback, errorCallback) {
       const result = new Promise((accept, reject) => {
         const audioBuffer = this.createEmptyBuffer();
-        audioBuffer.load(arrayBuffer, err => {
-          if (!err) {
+        audioBuffer.load(arrayBuffer, errorString => {
+          if (!errorString) {
+            if (successCallback) {
+              successCallback(audioBuffer);
+            }
             accept(audioBuffer);
           } else {
-            reject(new Error(err));
+            const err = new Error(errorString);
+            if (errorCallback) {
+              errorCallback(err);
+            }
+            reject(err);
           }
         });
       });
-      successCallback && result.then(successCallback);
-      errorCallback && result.catch(errorCallback);
       return result;
     }
   })(bindings.nativeAudio.AudioContext);

--- a/src/native-bindings.js
+++ b/src/native-bindings.js
@@ -401,20 +401,22 @@ GlobalContext.WebGL2RenderingContext = bindings.nativeGl2;
 if (bindings.nativeAudio) {
   bindings.nativeAudio.AudioContext = (OldAudioContext => class AudioContext extends OldAudioContext {
     decodeAudioData(arrayBuffer, successCallback, errorCallback) {
-      return new Promise((resolve, reject) => {
+      const result = new Promise((accept, reject) => {
         const audioBuffer = this.createEmptyBuffer();
         audioBuffer.load(arrayBuffer, err => {
           if (!err) {
-            resolve(audioBuffer);
+            accept(audioBuffer);
           } else {
             reject(new Error(err));
           }
         });
-      }).then(audioBuffer => {
+      });
+      result.then(audioBuffer => {
         successCallback && successCallback(audioBuffer);
       }).catch(err => {
         errorCallback && errorCallback(err);
       });
+      return result;
     }
   })(bindings.nativeAudio.AudioContext);
   bindings.nativeAudio.PannerNode.setPath(path.join(require.resolve('native-audio-deps').slice(0, -'index.js'.length), 'assets', 'hrtf'));

--- a/tests/unit/audio.test.js
+++ b/tests/unit/audio.test.js
@@ -38,7 +38,9 @@ helpers.describeSkipCI('audio', () => {
   it('handles invalid audio context data', async () => {
     return await window.evalAsync(`new Promise((accept, reject) => {
       let context = new window.AudioContext();
-      context.decodeAudioData('foo').catch(() => {
+      context.decodeAudioData('foo').then(() => {
+        reject(new Error('invalid audio data succeeded'));
+      }).catch(() => {
         accept();
       });
     })`);


### PR DESCRIPTION
We were handling type errors incorrectly in the `decodeAudioData` method, and `AudioBuffer` in general.

Namely, due to internal Promise/callback support for this method, errors were caught and returned as successes from the Promise result. The tests also were not set up to treat successfully loading a bad buffer as a test failure, which it should be.

This PR fixes both cases.