### PR TITLE
Add :scope selector support

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "window-classlist": "0.0.4",
     "window-fetch": "0.0.10",
     "window-ls": "0.0.1",
-    "window-selector": "0.0.6",
+    "window-selector": "0.0.7",
     "window-xhr": "0.0.30",
     "ws": "^6.2.0"
   },


### PR DESCRIPTION
This fixes Moon Rider, which was using `.querySelector(':scope > ...')`

Related: https://github.com/exokitxr/exokit/issues/1142