### PR TITLE
[Quest] Multiview attempt bump SDK version to 28

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,19 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
-    // Sceneform libraries use language constructs from Java 8.
-    // Add these compile options if targeting minSdkVersion < 26.
-    compileOptions {
-        sourceCompatibility 1.8
-        targetCompatibility 1.8
-    }
-
+    compileSdkVersion 28
 
     defaultConfig {
         applicationId = 'com.webmr.exokit'
-        minSdkVersion 21
-        targetSdkVersion 21
+        minSdkVersion 28
+        targetSdkVersion 28
         externalNativeBuild {
             cmake {
                 arguments '-DANDROID_STL=c++_static'


### PR DESCRIPTION
From my testing, only `libGLESv3.so` from platform version `28` has the multiview extension available.