### PR TITLE
Bugfix native cache delete method

### DIFF
--- a/deps/exokit-bindings/cache/src/cache.cc
+++ b/deps/exokit-bindings/cache/src/cache.cc
@@ -80,7 +80,7 @@ Local<Object> Initialize(Isolate *isolate) {
   result->Set(JS_STR("set"), setFn);
   Local<FunctionTemplate> deleteFnTemplate = Nan::New<FunctionTemplate>(Delete);
   Local<Function> deleteFn = Nan::GetFunction(deleteFnTemplate).ToLocalChecked();
-  result->Set(JS_STR("delete"), setFn);
+  result->Set(JS_STR("delete"), deleteFn);
 
   return scope.Escape(result);
 }


### PR DESCRIPTION
As used in the `Blob` `revokeObjectUrl` implementation, the native cache delete method was referring to the wrong implementation (`set`) at the native level.

This PR updates the pointer to `delete`.