### PR TITLE
Add FPS cap for non-XR

### DIFF
--- a/docs/sdk/exokitCommandLineFlags.md
+++ b/docs/sdk/exokitCommandLineFlags.md
@@ -30,4 +30,4 @@ An example of how to use these flags:
 |`-u`|`--require`|Expose node require() on `window`|
 |`-n`|`--nogl`|Do not create GL contexts|
 |`-e`|`--headless`|Run in headless mode; do not create OS windows|
-|`-d <downloadDirectory>`|`--download`|Download site to `downloadDirectory`|
+|`-c`|`--uncapped`|Do not cap FPS to refresh rate of monitor in non-XR mode|

--- a/src/index.js
+++ b/src/index.js
@@ -1032,7 +1032,7 @@ const _startTopRenderLoop = () => {
 
         const now = Date.now();
         const timeDiff = now - lastFrameTime;
-        const waitTime = Math.max(expectedTimeDiff - timeDiff, 0);
+        const waitTime = Math.max(expectedTimeDiff - timeDiff, 0) / 2;
 
         setTimeout(accept, waitTime);
       });


### PR DESCRIPTION
This adds an FPS cap to the monitor's refresh rate in Exokit non-XR desktop mode. Mostly the point is to not burn CPU/GPU in testing.

The old behavior (uncapped) is still available under the `--uncapped`/`-c` flag for testing the fully unleashed FPS tick rate.