### PR TITLE
Bugfix bad trailing slash add

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1451,7 +1451,7 @@ const _start = () => {
     }
     u = u.replace(/^exokit:/, '');
     if (args.tab) {
-      u = u.replace(/\/?$/, '/');
+      // u = u.replace(/\/?$/, '/');
       u = `${realityTabsUrl}?t=${encodeURIComponent(u)}`
     }
     if (u && !url.parse(u).protocol) {


### PR DESCRIPTION
Fixes loading:

```node . -t https://immersive-web.github.io/webxr-samples/xr-presentation.html```