### PR TITLE
Worker: run importScripts after setup

### DIFF
--- a/src/Worker.js
+++ b/src/Worker.js
@@ -1,5 +1,3 @@
-(() => {
-
 const path = require('path');
 const fs = require('fs');
 const url = require('url');
@@ -62,5 +60,3 @@ vm.runInThisContext(exp, {
   filename: /^https?:/.test(filename) ? filename : 'data-url://',
 }); */
 importScripts(filename);
-
-})();

--- a/src/Worker.js
+++ b/src/Worker.js
@@ -59,4 +59,6 @@ process.on('unhandledRejection', _handleError);
 vm.runInThisContext(exp, {
   filename: /^https?:/.test(filename) ? filename : 'data-url://',
 }); */
-importScripts(filename);
+process.nexTick(() => { // importScripts will block, so make sure we are done setup first
+  importScripts(filename);
+});


### PR DESCRIPTION
Exokit sets up the JS context in `WindowBase` on the first tick, but `Worker` was running `importScripts` on the first tick, before the initialization completed.

Therefore defer the `importScripts` call until `process.nextTick`.