### PR TITLE
Bugfix macOS GLsync

### DIFF
--- a/deps/exokit-bindings/util/include/defines.h
+++ b/deps/exokit-bindings/util/include/defines.h
@@ -29,8 +29,8 @@ private:
 };
 
 Local<Array> pointerToArray(void *ptr);
-void *arrayToPointer(Local<Array> array);
-void *arrayToPointer(Local<Uint32Array> array);
+uintptr_t arrayToPointer(Local<Array> array);
+uintptr_t arrayToPointer(Local<Uint32Array> array);
 
 template <typename T> struct V8TypedArrayTraits;
 template<> struct V8TypedArrayTraits<Float32Array> { typedef float value_type; };

--- a/deps/exokit-bindings/util/src/defines.cc
+++ b/deps/exokit-bindings/util/src/defines.cc
@@ -8,12 +8,10 @@ Local<Array> pointerToArray(void *ptr) {
   return result;
 }
 
-void *arrayToPointer(Local<Array> array) {
-  uintptr_t n = ((uintptr_t)TO_UINT32(array->Get(0)) << 32) | (uintptr_t)TO_UINT32(array->Get(1));
-  return (void *)n;
+uintptr_t arrayToPointer(Local<Array> array) {
+  return ((uintptr_t)TO_UINT32(array->Get(0)) << 32) | (uintptr_t)TO_UINT32(array->Get(1));
 }
 
-void *arrayToPointer(Local<Uint32Array> array) {
-  uintptr_t n = ((uintptr_t)TO_UINT32(array->Get(0)) << 32) | (uintptr_t)TO_UINT32(array->Get(1));
-  return (void *)n;
+uintptr_t arrayToPointer(Local<Uint32Array> array) {
+  return ((uintptr_t)TO_UINT32(array->Get(0)) << 32) | (uintptr_t)TO_UINT32(array->Get(1));
 }

--- a/deps/exokit-bindings/windowsystem/src/windowsystem.cc
+++ b/deps/exokit-bindings/windowsystem/src/windowsystem.cc
@@ -1045,24 +1045,30 @@ NAN_METHOD(GetSync) {
 }
 
 NAN_METHOD(WaitSync) {
-  // if (info[0]->IsArray()) {
+  if (info[0]->IsArray()) {
     Local<Array> syncArray = Local<Array>::Cast(info[0]);
-    GLsync sync = (GLsync)arrayToPointer(syncArray);
-    glWaitSync(sync, 0, GL_TIMEOUT_IGNORED);
+    uintptr_t syncPtr = arrayToPointer(syncArray);
+    if (syncPtr > 0) { // macOS returns GLsync zero and crashes when used
+      GLsync sync = reinterpret_cast<GLsync>(syncPtr);
+      glWaitSync(sync, 0, GL_TIMEOUT_IGNORED);
+    }
     // glDeleteSync(sync);
-  /* } else {
+  } else {
     Nan::ThrowError("WaitSync: invalid arguments");
-  } */
+  }
 }
 
 NAN_METHOD(DeleteSync) {
-  // if (info[0]->IsArray()) {
+  if (info[0]->IsArray()) {
     Local<Array> syncArray = Local<Array>::Cast(info[0]);
-    GLsync sync = (GLsync)arrayToPointer(syncArray);
-    glDeleteSync(sync);
-  /* } else {
+    uintptr_t syncPtr = arrayToPointer(syncArray);
+    if (syncPtr > 0) { // macOS returns GLsync zero and crashes when used
+      GLsync sync = reinterpret_cast<GLsync>(syncPtr);
+      glDeleteSync(sync);
+    }
+  } else {
     Nan::ThrowError("DeleteSync: invalid arguments");
-  } */
+  }
 }
 
 void BlitLayer(WebGLRenderingContext *gl, const LayerSpec &layer) {

--- a/deps/exokit-bindings/windowsystem/src/windowsystem.cc
+++ b/deps/exokit-bindings/windowsystem/src/windowsystem.cc
@@ -1045,7 +1045,7 @@ NAN_METHOD(GetSync) {
 }
 
 NAN_METHOD(WaitSync) {
-  if (info[0]->IsArray()) {
+  // if (info[0]->IsArray()) {
     Local<Array> syncArray = Local<Array>::Cast(info[0]);
     uintptr_t syncPtr = arrayToPointer(syncArray);
     if (syncPtr > 0) { // macOS returns GLsync zero and crashes when used
@@ -1053,22 +1053,22 @@ NAN_METHOD(WaitSync) {
       glWaitSync(sync, 0, GL_TIMEOUT_IGNORED);
     }
     // glDeleteSync(sync);
-  } else {
+  /* } else {
     Nan::ThrowError("WaitSync: invalid arguments");
-  }
+  } */
 }
 
 NAN_METHOD(DeleteSync) {
-  if (info[0]->IsArray()) {
+  // if (info[0]->IsArray()) {
     Local<Array> syncArray = Local<Array>::Cast(info[0]);
     uintptr_t syncPtr = arrayToPointer(syncArray);
     if (syncPtr > 0) { // macOS returns GLsync zero and crashes when used
       GLsync sync = reinterpret_cast<GLsync>(syncPtr);
       glDeleteSync(sync);
     }
-  } else {
+  /* } else {
     Nan::ThrowError("DeleteSync: invalid arguments");
-  }
+  } */
 }
 
 void BlitLayer(WebGLRenderingContext *gl, const LayerSpec &layer) {


### PR DESCRIPTION
Our usage of GLsync in the new composition model did not work well with MacOS.

It turns out that MacOS will return GLsync zero in some cases -- but no `glGetError()` -- and then it will crash if you actually try to use that value to resolve the sync. This seems to follow the OpenGL loophole where [`glFenceSync` is allowed to return zero on failure](https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glFenceSync.xhtml) but I've only ever seen that happen on MacOS.

This PR fixes that case by ignoring sync wait calls that return zero values.