### PR TITLE
Add process to eventtarget.js

### DIFF
--- a/src/RTC/eventtarget.js
+++ b/src/RTC/eventtarget.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const process = require('process');
+const {process} = global;
 
 /**
  * @author mrdoob / http://mrdoob.com/

--- a/src/RTC/eventtarget.js
+++ b/src/RTC/eventtarget.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const process = require('process');
+
 /**
  * @author mrdoob / http://mrdoob.com/
  * @author Jesús Leganés Combarro "Piranna" <piranna@gmail.com>


### PR DESCRIPTION
This fixes the error `TypeError: Cannot read property 'nextTick' of undefined` when you use webrtc.

Full error:
```
TypeError: Cannot read property 'nextTick' of undefined
    at RTCPeerConnection.dispatchEvent (C:\Users\chris\github\studio\exokit\src\RTC\eventtarget.js:23:13)
    at PeerConnection.onicecandidate (C:\Users\chris\github\studio\exokit\src\RTC\peerconnection.js:84:10)
```