### PR TITLE
Unlock macos swap hacks

### DIFF
--- a/src/Window.js
+++ b/src/Window.js
@@ -1096,9 +1096,9 @@ const _makeRequestAnimationFrame = window => (fn, priority = 0) => {
     }
   };
   const _swapBuffers = (context, windowHandle) => {
-    /* if (isMac) {
+    if (isMac) {
       context.bindFramebufferRaw(context.FRAMEBUFFER, null);
-    } */
+    }
     nativeWindow.swapBuffers(windowHandle);
   };
   const _composeLocalLayers = layered => {
@@ -1112,9 +1112,9 @@ const _makeRequestAnimationFrame = window => (fn, priority = 0) => {
           const windowHandle = context.getWindowHandle();
 
           nativeWindow.setCurrentWindowContext(windowHandle);
-          /* if (isMac) {
+          if (isMac) {
             context.flush();
-          } */
+          }
 
           if (context === vrPresentState.glContext) {
             _composeXrContext(context, windowHandle);
@@ -1122,7 +1122,7 @@ const _makeRequestAnimationFrame = window => (fn, priority = 0) => {
             _composeNormalContext(context, windowHandle);
           }
 
-          /* if (isMac) {
+          if (isMac) {
             const drawFramebuffer = context.getBoundFramebuffer(context.DRAW_FRAMEBUFFER);
             if (drawFramebuffer) {
               context.bindFramebuffer(context.DRAW_FRAMEBUFFER, drawFramebuffer);
@@ -1132,7 +1132,7 @@ const _makeRequestAnimationFrame = window => (fn, priority = 0) => {
             if (readFramebuffer) {
               context.bindFramebuffer(context.READ_FRAMEBUFFER, readFramebuffer);
             }
-          } */
+          }
 
           context.clearDirty();
 


### PR DESCRIPTION
Fixes https://github.com/exokitxr/exokit/issues/1176.

MacOS does not allow swapping framebuffers unless the default framebuffer is bound. Currently we are not doing this, so MacOS was rendering "black".

We had hacks for enforcing this, which were commented out when we refactored the render loop to be a single linear walk (https://github.com/exokitxr/exokit/pull/1104).

This PR unlocks that code again to fix the macOS rendering case.