### PR TITLE
Added onbeforeload flag

### DIFF
--- a/docs/sdk/exokitCommandLineFlags.md
+++ b/docs/sdk/exokitCommandLineFlags.md
@@ -31,3 +31,4 @@ An example of how to use these flags:
 |`-n`|`--nogl`|Do not create GL contexts|
 |`-e`|`--headless`|Run in headless mode; do not create OS windows|
 |`-c`|`--uncapped`|Do not cap FPS to refresh rate of monitor in non-XR mode|
+|    |`--onbeforeload`|Run a script before each JS context loads|

--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -78,7 +78,7 @@ EventEmitter.call(global);
 class Worker extends EventTarget {
   constructor(src) {
     super();
-    
+
     if (src instanceof Blob) {
       src = 'data:application/javascript,' + src.buffer.toString('utf8');
     } else {
@@ -133,7 +133,7 @@ class Worker extends EventTarget {
 (self => {
   self.btoa = btoa;
   self.atob = atob;
-  
+
   self.Event = Event;
   self.KeyboardEvent = KeyboardEvent;
   self.MouseEvent = MouseEvent;
@@ -143,7 +143,7 @@ class Worker extends EventTarget {
   self.PromiseRejectionEvent = PromiseRejectionEvent;
   self.CustomEvent = CustomEvent;
   self.EventTarget = EventTarget;
-  
+
   self.URL = URL;
 
   self.fetch = (u, options) => {
@@ -226,9 +226,9 @@ class Worker extends EventTarget {
       },
     },
   };
-  
+
   self.Worker = Worker;
-  
+
   self.postMessage = (message, transferList) => parentPort.postMessage({
     method: 'postMessage',
     message,
@@ -374,6 +374,13 @@ process.on('unhandledRejection', err => {
 
 if (initModule) {
   require(initModule);
+}
+
+// Run a script for each new JS context before the page/worker JS loads
+const onBeforeLoad = args.args.onBeforeLoad
+if(onBeforeLoad) {
+  const finalScript = path.resolve(process.cwd(), onBeforeLoad)
+  require(finalScript)
 }
 
 if (!args.require) {

--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -377,9 +377,9 @@ if (initModule) {
 }
 
 // Run a script for each new JS context before the page/worker JS loads
-const onBeforeLoad = args.args.onBeforeLoad
-if(onBeforeLoad) {
-  const finalScript = path.resolve(process.cwd(), onBeforeLoad)
+const onbeforeload = args.args.onbeforeload
+if(onbeforeload) {
+  const finalScript = path.resolve(process.cwd(), onbeforeload)
   require(finalScript)
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -108,6 +108,7 @@ const args = (() => {
         'xr',
         'size',
         'replace',
+        'onbeforeload'
       ],
       alias: {
         v: 'version',
@@ -149,6 +150,7 @@ const args = (() => {
       nogl: minimistArgs.nogl,
       headless: minimistArgs.headless,
       uncapped: minimistArgs.uncapped,
+      onBeforeLoad: minimistArgs.onbeforeload || false
     };
   } else {
     return {};
@@ -1044,7 +1046,7 @@ const _startTopRenderLoop = () => {
       }
     };
     _updateMeshing();
-    
+
     const _updatePlanes = () => {
       if (xrState.planeTracking[0] && !topVrPresentState.planeTracker) {
         _startFakePlaneTracker();
@@ -1094,7 +1096,7 @@ const _startTopRenderLoop = () => {
       }
     };
     _updateHandTracking();
-    
+
     const _updateEyeTracking = () => {
       if (xrState.eyeTracking[0]) {
         const blink = (Date.now() % 2000) < 200;

--- a/src/index.js
+++ b/src/index.js
@@ -150,7 +150,7 @@ const args = (() => {
       nogl: minimistArgs.nogl,
       headless: minimistArgs.headless,
       uncapped: minimistArgs.uncapped,
-      onBeforeLoad: minimistArgs.onbeforeload || false
+      onbeforeload: minimistArgs.onbeforeload
     };
   } else {
     return {};


### PR DESCRIPTION
Closes #1166 

Adds a new CLI flag, `--onbeforeload` which will invoke a Node script after each new JS context is initialized (workers/frames), but before the third party JS loads.

The script is resolved relative to `process.cwd()` so stuff like `exokit --onbeforeload ../foobar.js` is valid.