### PR TITLE
Browser texture binding cleanup

### DIFF
--- a/deps/exokit-bindings/browser/src/browser-desktop.cpp
+++ b/deps/exokit-bindings/browser/src/browser-desktop.cpp
@@ -212,7 +212,8 @@ EmbeddedBrowser createEmbedded(
 // #endif
       }
       
-      glFinish();
+      glFlush();
+      // glFinish();
 
       /* glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
       glPixelStorei(GL_UNPACK_SKIP_PIXELS, 0);

--- a/deps/exokit-bindings/browser/src/browser-desktop.cpp
+++ b/deps/exokit-bindings/browser/src/browser-desktop.cpp
@@ -183,8 +183,6 @@ EmbeddedBrowser createEmbedded(
       glBindTexture(GL_TEXTURE_2D, tex);
 
       if (*textureWidth != width || *textureHeight != height) {
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR); // XXX save/restore these
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
         glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
         glPixelStorei(GL_UNPACK_SKIP_PIXELS, 0);
         glPixelStorei(GL_UNPACK_SKIP_ROWS, 0);

--- a/deps/exokit-bindings/browser/src/browser.cpp
+++ b/deps/exokit-bindings/browser/src/browser.cpp
@@ -20,8 +20,8 @@ Browser::Browser(WebGLRenderingContext *gl, int width, int height, float scale) 
 
   glGenTextures(1, &tex);
   glBindTexture(GL_TEXTURE_2D, tex);
-  /* glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR); // XXX save/restore these
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR); */
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR); // XXX save/restore these
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 }
 
 Browser::~Browser() {}

--- a/deps/exokit-bindings/browser/src/browser.cpp
+++ b/deps/exokit-bindings/browser/src/browser.cpp
@@ -15,11 +15,13 @@ namespace browser {
 // Browser
 
 Browser::Browser(WebGLRenderingContext *gl, int width, int height, float scale) : gl(gl), window(nullptr), width(width), height(height), scale(scale), tex(0), textureWidth(0), textureHeight(0) {
-  windowsystem::SetCurrentWindowContext(gl->windowHandle);
+  window = windowsystem::CreateWindowHandle(1, 1, false);
+  windowsystem::SetCurrentWindowContext(window);
 
   glGenTextures(1, &tex);
-  
-  window = windowsystem::CreateWindowHandle(1, 1, false);
+  glBindTexture(GL_TEXTURE_2D, tex);
+  /* glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR); // XXX save/restore these
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR); */
 }
 
 Browser::~Browser() {}


### PR DESCRIPTION
This cleans up an invalid texture binding race in CEF browser loading. It manifested most clearly when loading studio -- the framebuffer texture would become warped on startup and absorb the options of the CEF texture generated by the browser binding.

The solution here is to make sure we switch away contexts and bind the new texture on creating a new CEF context. For some reason that fixes the state bleeding and studio initializes cleanly.