### PR TITLE
Oculus desktop load hmd pose

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -655,9 +655,6 @@ const _startTopRenderLoop = () => {
       xrState.leftProjectionMatrix.set(localFloat32Array2);
       xrState.rightViewMatrix.set(localFloat32Array3);
       xrState.rightProjectionMatrix.set(localFloat32Array4);
-
-      localVector.toArray(xrState.position);
-      localQuaternion.toArray(xrState.orientation);
     };
     _loadHmd();
 


### PR DESCRIPTION
We were overwriting the (correctly loaded) pose data on the main render loop.

Fixes https://github.com/exokitxr/exokit/issues/1178.