### PR TITLE
Fresh canvas contexts

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2342,23 +2342,22 @@ class HTMLCanvasElement extends HTMLElement {
 
       this._context = new GlobalContext.CanvasRenderingContext2D(this);
     } else if (contextType === 'webgl' || contextType === 'experimental-webgl' || contextType === 'webgl2' || contextType === 'xrpresent') {
-      if (this._context && this._context.constructor && this._context.constructor.name !== 'WebGLRenderingContext' && this._context.constructor.name !== 'WebGL2RenderingContext') {
+      if (this._context) {
         this._context.destroy();
         this._context = null;
       }
-      if (this._context === null) {
-        const window = this.ownerDocument.defaultView;
 
-        if (!window[symbols.optionsSymbol].args || window[symbols.optionsSymbol].args.webgl === '1') {
-          if (contextType === 'webgl' || contextType === 'experimental-webgl' || contextType === 'xrpresent') {
-            this._context = new GlobalContext.WebGLRenderingContext(this, attrs);
-          }
+      const window = this.ownerDocument.defaultView;
+
+      if (!window[symbols.optionsSymbol].args || window[symbols.optionsSymbol].args.webgl === '1') {
+        if (contextType === 'webgl' || contextType === 'experimental-webgl' || contextType === 'xrpresent') {
+          this._context = new GlobalContext.WebGLRenderingContext(this, attrs);
+        }
+      } else {
+        if (contextType === 'webgl' || contextType === 'experimental-webgl') {
+          this._context = new GlobalContext.WebGLRenderingContext(this, attrs);
         } else {
-          if (contextType === 'webgl' || contextType === 'experimental-webgl') {
-            this._context = new GlobalContext.WebGLRenderingContext(this, attrs);
-          } else {
-            this._context = new GlobalContext.WebGL2RenderingContext(this, attrs);
-          }
+          this._context = new GlobalContext.WebGL2RenderingContext(this, attrs);
         }
       }
     } else {

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2335,13 +2335,12 @@ class HTMLCanvasElement extends HTMLElement {
 
   getContext(contextType, attrs = {}) {
     if (contextType === '2d') {
-      if (this._context && this._context.constructor && this._context.constructor.name !== 'CanvasRenderingContext2D') {
+      if (this._context) {
         this._context.destroy();
         this._context = null;
       }
-      if (this._context === null) {
-        this._context = new GlobalContext.CanvasRenderingContext2D(this);
-      }
+
+      this._context = new GlobalContext.CanvasRenderingContext2D(this);
     } else if (contextType === 'webgl' || contextType === 'experimental-webgl' || contextType === 'webgl2' || contextType === 'xrpresent') {
       if (this._context && this._context.constructor && this._context.constructor.name !== 'WebGLRenderingContext' && this._context.constructor.name !== 'WebGL2RenderingContext') {
         this._context.destroy();


### PR DESCRIPTION
Exokit used to re-use the GL context when requested multiple times via `getContext`. The problem with this is it does not clear the previous GL state -- in particular the previous context's image buffer will remain.

For some THREE.js optimization cases, such as texture resizes, we will not request a fresh `canvas` (only a fresh `context`), leading to visual bugs.

This PR makes it so that each call to `getContext` gives a fresh context, fixing this loophole.

Fixes https://github.com/exokitxr/exokit/issues/1186.