### PR TITLE
window.matchMedia method

### DIFF
--- a/src/Window.js
+++ b/src/Window.js
@@ -532,6 +532,10 @@ const _makeRequestAnimationFrame = window => (fn, priority = 0) => {
       })
     }
   };
+  window.matchMedia = media => ({
+    media,
+    matches: false,
+  });
 
   // WebVR enabled.
   if (['all', 'webvr'].includes(options.args.xr)) {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia

Adds a basic `window.matchMedia` method to cover the cases of applications requesting it.

Fixes https://github.com/exokitxr/exokit/issues/1204.