### PR TITLE
Bugfix timers dropping

### DIFF
--- a/src/Window.js
+++ b/src/Window.js
@@ -403,9 +403,9 @@ class DataTransferItem {
 }
 
 let rafIndex = 0;
-const _findFreeSlot = a => {
+const _findFreeSlot = (a, startIndex = 0) => {
   let i;
-  for (i = 0; i < a.length; i++) {
+  for (i = startIndex; i < a.length; i++) {
     if (a[i] === null) {
       break;
     }
@@ -553,10 +553,7 @@ const _makeRequestAnimationFrame = window => (fn, priority = 0) => {
   window.alert = console.log;
   window.setTimeout = (setTimeout => (fn, timeout, args) => {
     fn = fn.bind.apply(fn, [window].concat(args));
-    let id = _findFreeSlot(timeouts);
-    if (id === 0) {
-      id++;
-    }
+    const id = _findFreeSlot(timeouts, 1);
     timeouts[id] = fn;
     fn[symbols.timeoutSymbol] = setTimeout(fn, timeout, args);
     return id;
@@ -573,10 +570,7 @@ const _makeRequestAnimationFrame = window => (fn, priority = 0) => {
       interval = 10;
     }
     fn = fn.bind.apply(fn, [window].concat(args));
-    let id = _findFreeSlot(intervals);
-    if (id === 0) {
-      id++;
-    }
+    const id = _findFreeSlot(intervals, 1);
     intervals[id] = fn;
     fn[symbols.timeoutSymbol] = setInterval(fn, interval, args);
     return id;

--- a/src/Window.js
+++ b/src/Window.js
@@ -1010,8 +1010,8 @@ const _makeRequestAnimationFrame = window => (fn, priority = 0) => {
 
   const rafCbs = [];
   window[symbols.rafCbsSymbol] = rafCbs;
-  const timeouts = [];
-  const intervals = [];
+  const timeouts = [null];
+  const intervals = [null];
   const localCbs = [];
   const prevSyncs = [];
   const _cacheLocalCbs = cbs => {

--- a/src/Window.js
+++ b/src/Window.js
@@ -554,7 +554,9 @@ const _makeRequestAnimationFrame = window => (fn, priority = 0) => {
   window.setTimeout = (setTimeout => (fn, timeout, args) => {
     fn = fn.bind.apply(fn, [window].concat(args));
     let id = _findFreeSlot(timeouts);
-    id++;
+    if (id === 0) {
+      id++;
+    }
     timeouts[id] = fn;
     fn[symbols.timeoutSymbol] = setTimeout(fn, timeout, args);
     return id;
@@ -572,7 +574,9 @@ const _makeRequestAnimationFrame = window => (fn, priority = 0) => {
     }
     fn = fn.bind.apply(fn, [window].concat(args));
     let id = _findFreeSlot(intervals);
-    id++;
+    if (id === 0) {
+      id++;
+    }
     intervals[id] = fn;
     fn[symbols.timeoutSymbol] = setInterval(fn, interval, args);
     return id;


### PR DESCRIPTION
Exokit optimizes the timers allocation to reuse array slots. Additionally, the timer ids returned to `window` from `setTimeout`/`setInterval` need to be integers starting at `1` -- contrary to node which returns objects.

The bug here was that we were blindly incrementing the returned id in all cases, which allowed it to collide. This meant that `clearTimeout` could, for example, clear the wrong timeout, leading to really weird bugs.

Partial fix for https://github.com/exokitxr/exokit/issues/1217.