### PR TITLE
Bugfix baseUrl derivation

### DIFF
--- a/src/Location.js
+++ b/src/Location.js
@@ -1,6 +1,15 @@
 const {EventEmitter} = require('events');
 const url = require('url');
-const utils = require('./utils');
+
+const {
+  workerData: {
+    args: {
+      options: {
+        baseUrl,
+      },
+    },
+  },
+} = require('worker_threads');
 
 class Location extends EventEmitter {
   constructor(u) {
@@ -12,7 +21,7 @@ class Location extends EventEmitter {
   get href() { return this._url.href || ''; }
   set href(href) {
     const oldUrl = this._url;
-    const newUrl = new url.URL(href, utils._getBaseUrl(this._url.href));
+    const newUrl = new url.URL(href, baseUrl);
     this._url = newUrl;
     if (
       newUrl.origin !== oldUrl.origin ||

--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -93,6 +93,7 @@ class Worker extends EventTarget {
       initModule: path.join(__dirname, 'Worker.js'),
       args: {
         src,
+        baseUrl: utils._getBaseUrl(src, baseUrl),
         args,
         xrState: args.xrState,
       },

--- a/src/Worker.js
+++ b/src/Worker.js
@@ -3,7 +3,11 @@ const fs = require('fs');
 const url = require('url');
 const {URL} = url;
 const vm = require('vm');
-const {workerData: {args}} = require('worker_threads');
+const {
+  workerData: {
+    args,
+  },
+} = require('worker_threads');
 
 const {createImageBitmap} = require('./DOM.js');
 const fetch = require('window-fetch');
@@ -11,16 +15,7 @@ const {XMLHttpRequest} = require('window-xhr');
 const WebSocket = require('ws/lib/websocket');
 const {FileReader} = require('./File.js');
 
-const {src} = args;
-const baseUrl = (src => {
-  if (/^(?:https?|file):/.test(src)) {
-    const u = new URL(src);
-    u.pathname = path.dirname(u.pathname) + '/';
-    return u.href;
-  } else {
-    return 'file://' + process.cwd();
-  }
-})(src);
+const {src, baseUrl} = args;
 setBaseUrl(baseUrl);
 const _normalizeUrl = src => {
   if (!/^(?:file|data|blob):/.test(src)) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,7 +11,7 @@ function _getBaseUrl(u, currentBaseUrl = '') {
   let result;
   if (/^file:\/\//.test(u)) {
     result = u;
-  } else if (/^data:/.test(u)) {
+  } else if (/^(?:data|blob):/.test(u)) {
     result = currentBaseUrl;
   } else {
     const parsedUrl = url.parse(u);

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,26 +2,29 @@ const path = require('path');
 const fs = require('fs');
 const url = require('url');
 
-const symbols = require('./symbols');
 const mkdirp = require('mkdirp');
 const parseIntStrict = require('parse-int');
 
-function _getBaseUrl(u) {
-  let baseUrl;
-  if (/^file:\/\/(.*)$/.test(u)) {
-    baseUrl = u;
+const symbols = require('./symbols');
+
+function _getBaseUrl(u, currentBaseUrl = '') {
+  let result;
+  if (/^file:\/\//.test(u)) {
+    result = u;
+  } else if (/^data:/.test(u)) {
+    result = currentBaseUrl;
   } else {
     const parsedUrl = url.parse(u);
-    baseUrl = url.format({
+    result = url.format({
       protocol: parsedUrl.protocol || 'http:',
       host: parsedUrl.host || '127.0.0.1',
       pathname: parsedUrl.pathname.replace(/\/[^\/]*\.[^\/]*$/, '') || '/',
     });
   }
-  if (!/\/$/.test(baseUrl) && !/\./.test(baseUrl.match(/\/([^\/]*)$/)[1])) {
-    baseUrl = baseUrl + '/';
+  if (!/\/$/.test(result) && !/\./.test(result.match(/\/([^\/]*)$/)[1])) {
+    result += '/';
   }
-  return baseUrl;
+  return result;
 }
 module.exports._getBaseUrl = _getBaseUrl;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -21,7 +21,7 @@ function _getBaseUrl(u, currentBaseUrl = '') {
       pathname: parsedUrl.pathname.replace(/\/[^\/]*\.[^\/]*$/, '') || '/',
     });
   }
-  if (!/\/$/.test(result) && !/\./.test(result.match(/\/([^\/]*)$/)[1])) {
+  if (!/\/$/.test(result)) {
     result += '/';
   }
   return result;


### PR DESCRIPTION
Browsers derive worker `baseUrl` differently than for `Window`, specifically in the case where `data:` or `blob:` urls are concerned.

Exokit had several bugs here, fixed by this PR:

- Pass `baseUrl` from parent to worker
- Passthrough baseUrl for `Worker` `data:` and `blob:` source urls
- Workers baseUrl derivation should not be different from that of windows