### PR TITLE
<script> .src path resolution

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1742,7 +1742,12 @@ class HTMLScriptElement extends HTMLLoadableElement {
   }
 
   get src() {
-    return this.getAttribute('src') || '';
+    const src = this.getAttribute('src');
+    if (src) {
+      return _normalizeUrl(src, this.ownerDocument.defaultView[symbols.optionsSymbol].baseUrl);
+    } else {
+      return '';
+    }
   }
   set src(src) {
     src = src + '';

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1729,7 +1729,7 @@ class HTMLScriptElement extends HTMLLoadableElement {
       }
     });
     this.on('attached', () => {
-      if (this.src && this.isRunnable() && this.isConnected && !this.readyState) {
+      if (this.getAttribute('src') && this.isRunnable() && this.isConnected && !this.readyState) {
         const async = this.getAttribute('async');
         _loadRun(async !== null ? async !== 'false' : true);
       }

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1743,11 +1743,7 @@ class HTMLScriptElement extends HTMLLoadableElement {
 
   get src() {
     const src = this.getAttribute('src');
-    if (src) {
-      return _normalizeUrl(src, this.ownerDocument.defaultView[symbols.optionsSymbol].baseUrl);
-    } else {
-      return '';
-    }
+    return src ? _normalizeUrl(src, this.ownerDocument.defaultView[symbols.optionsSymbol].baseUrl) : '';
   }
   set src(src) {
     src = src + '';


### PR DESCRIPTION
Fixes https://github.com/exokitxr/exokit/issues/1223.

This PR makes Exokit run the full `<script>` `.src` base url resolution algorithm for `HTMLScriptElement`, like other browsers.