### PR TITLE
HTMLLinkElement load emit timing

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1871,8 +1871,7 @@ class HTMLScriptElement extends HTMLLoadableElement {
 
   [symbols.runSymbol]() {
     if (this.isRunnable() && !this.readyState) {
-      const srcAttr = this.attributes.src;
-      if (srcAttr) {
+      if (this.attributes.src) {
         return this.loadRunNow();
       } else if (this.childNodes.length > 0) {
         return this.runNow();

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -254,7 +254,8 @@ class Node extends EventTarget {
           this.ownerDocument.removeEventListener('readystatechange', _readystatechange);
 
           process.nextTick(() => {
-            this.dispatchEvent.apply(this, args);
+            const el = args[0].target;
+            el.dispatchEvent.apply(el, args);
           });
         }
       };

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1631,36 +1631,48 @@ class HTMLLinkElement extends HTMLLoadableElement {
     this.stylesheet = null;
 
     this.on('attribute', (name, value) => {
-      if (name === 'href' && this.isRunnable()) {
-        this.readyState = 'loading';
-        
-        const url = value;
-        this.ownerDocument.defaultView.fetch(url)
-          .then(res => {
-            if (res.status >= 200 && res.status < 300) {
-              return res.text();
-            } else {
-              return Promise.reject(new Error('link href got invalid status code: ' + res.status + ' : ' + url));
-            }
-          })
-          .then(s => css.parse(s).stylesheet)
-          .then(stylesheet => {
-            this.stylesheet = stylesheet;
-            this.ownerDocument.defaultView[symbols.styleEpochSymbol]++;
-            
-            this.readyState = 'complete';
-            
-            this.dispatchEvent(new Event('load', {target: this}));
-          })
-          .catch(err => {
-            this.readyState = 'complete';
-            
-            const e = new ErrorEvent('error', {target: this});
-            e.message = err.message;
-            e.stack = err.stack;
-            this.dispatchEvent(e);
-          });
+      if (this.isRunnable() && !this.readyState) {
+        this.loadRunNow();
       }
+    });
+  }
+  
+  loadRunNow() {
+    this.readyState = 'loading';
+
+    const url = _mapUrl(this.href, this.ownerDocument.defaultView);
+    
+    return this.ownerDocument.resources.addResource((onprogress, cb) => {
+      this.ownerDocument.defaultView.fetch(url)
+        .then(res => {
+          if (res.status >= 200 && res.status < 300) {
+            return res.text();
+          } else {
+            return Promise.reject(new Error('link href got invalid status code: ' + res.status + ' : ' + url));
+          }
+        })
+        .then(s => css.parse(s).stylesheet)
+        .then(stylesheet => {
+          this.stylesheet = stylesheet;
+          this.ownerDocument.defaultView[symbols.styleEpochSymbol]++;
+          
+          this.readyState = 'complete';
+          
+          const e = new Event('load', {target: this});
+          this._dispatchEventOnDocumentReady(e);
+          
+          cb();
+        })
+        .catch(err => {
+          this.readyState = 'complete';
+          
+          const e = new ErrorEvent('error', {target: this});
+          e.message = err.message;
+          e.stack = err.stack;
+          this._dispatchEventOnDocumentReady(e);
+          
+          cb(err);
+        });
     });
   }
 
@@ -1689,19 +1701,16 @@ class HTMLLinkElement extends HTMLLoadableElement {
   }
 
   isRunnable() {
-    return this.rel === 'stylesheet';
+    return this.rel === 'stylesheet' && !!this.href;
   }
 
   [symbols.runSymbol]() {
-    let running = false;
     if (this.isRunnable() && !this.readyState) {
-      const hrefAttr = this.attributes.href;
-      if (hrefAttr) {
-        this._emit('attribute', 'href', hrefAttr.value);
-        running = true;
+      if (this.attributes.href) {
+        return this.loadRunNow();
       }
     }
-    return running ? _loadPromise(this) : Promise.resolve();
+    return Promise.resolve();
   }
 }
 module.exports.HTMLLinkElement = HTMLLinkElement;


### PR DESCRIPTION
This case was not properly triggering load events:

```
const link = document.createElement('link');
link.href = 'https://fonts.googleapis.com/css?family=Source+Code+Pro';
link.rel = 'stylesheet';
link.onload = () => {
  console.log('got load');
];
```

This was mainly because of the "run html" flow for `HTMLLinkElement`, which handled things synchronously on attribute set rather than working on the defer-emits-to-document-load model like `HTMLScriptElement`.

This PR makes `HTMLLinkElement` behave like `HTMLScriptElement` in that regard.

This was needed to boot cryptovoxels.