### PR TITLE
Capture Buffer global in local closures in src

### DIFF
--- a/src/DevTools.js
+++ b/src/DevTools.js
@@ -1,5 +1,8 @@
 const url = require('url');
 const http = require('http');
+
+const {Buffer} = global;
+
 const htermRepl = require('hterm-repl');
 
 const DOM = require('./DOM');

--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -17,6 +17,8 @@ const {
   parentPort,
 } = require('worker_threads');
 
+const {Buffer} = global;
+
 const {CustomEvent, DragEvent, ErrorEvent, Event, EventTarget, KeyboardEvent, MessageEvent, MouseEvent, WheelEvent, PromiseRejectionEvent} = require('./Event');
 const {FileReader} = require('./File.js');
 const {XMLHttpRequest, FormData} = require('window-xhr');

--- a/src/electron-vm.js
+++ b/src/electron-vm.js
@@ -6,6 +6,8 @@ const child_process = require('child_process');
 const os = require('os');
 const {TextEncoder} = require('util');
 
+const {Buffer} = global;
+
 const bindings = require('./native-bindings');
 const electron = !bindings.nativePlatform ? require('electron') : null;
 const keycode = require('keycode');


### PR DESCRIPTION
This fixes the case where user code has redefined `Buffer` to be their own Web polyfill.