### PR TITLE
XMLHttpRequest based on fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "window-fetch": "0.0.11",
     "window-ls": "0.0.1",
     "window-selector": "0.0.7",
-    "window-xhr": "0.0.32",
+    "window-xhr": "0.0.33",
     "ws": "^6.2.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
This bumps `window-xhr` to ingest https://github.com/modulesio/window-xhr/pull/6.

The main reason is to centralize the network fetch logic in a single place (`fetch`), so that we can support use cases such as pluggable protocols: https://github.com/exokitxr/exokit/issues/1213