### PR TITLE
Do not wait for frames hitting fps target

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1030,16 +1030,19 @@ const _startTopRenderLoop = () => {
   };
   const _waitGetPosesFake = async () => {
     if (!args.uncapped) {
-      await new Promise((accept, reject) => {
-        const fps = nativeBindings.nativeWindow.getRefreshRate();
-        const expectedTimeDiff = 1000 / fps;
+      const fps = nativeBindings.nativeWindow.getRefreshRate();
+      const expectedTimeDiff = 1000 / fps;
 
-        const now = Date.now();
-        const timeDiff = now - lastFrameTime;
-        const waitTime = Math.max(expectedTimeDiff - timeDiff, 0) / 2;
+      const now = Date.now();
+      const timeDiff = now - lastFrameTime;
+      const waitTime = Math.max(expectedTimeDiff - timeDiff, 0) / 2;
+      lastFrameTime = now;
 
-        setTimeout(accept, waitTime);
-      });
+      if (waitTime > 0) {
+        await new Promise((accept, reject) => {
+          setTimeout(accept, waitTime);
+        });
+      }
     }
 
     const _updateMeshing = () => {
@@ -1309,8 +1312,6 @@ const _startTopRenderLoop = () => {
     }
 
     await _submitFrame();
-
-    lastFrameTime = Date.now()
 
     if (args.performance) {
       const now = Date.now();


### PR DESCRIPTION
Exokit has an internal FPS limiter based on the monitor setup used, in the 2D case.

However, we were computing the FPS wait time incorrectly, resulting in waits when we don't need to wait. This was due to remembering the "last frame time" at the wrong point in the render loop.