### PR TITLE
Remove sinon usage from HTMLAnchorElement test

### DIFF
--- a/tests/unit/dom/HTMLAnchorElement.test.js
+++ b/tests/unit/dom/HTMLAnchorElement.test.js
@@ -12,8 +12,6 @@ describe('HTMLAnchorElement', () => {
     return await window.evalAsync(`
       const assert = require('assert');
       window.assert = assert;
-      const sinon = require('sinon');
-      window.sinon = sinon;
 
       const el = document.createElement('a');
       window.el = el;
@@ -37,7 +35,7 @@ describe('HTMLAnchorElement', () => {
 
     it('can get location propert:ies', async () => {
       return await window.evalAsync(`
-        sinon.stub(window.location, 'toString').callsFake(() => 'https://foo.com');
+        window.location.toString = () => 'https://foo.com';
         el.href = 'https://bar.com:8080/corge?qux=1#qaz';
         assert.equal(el.hash, '#qaz');
         assert.equal(el.host, 'bar.com:8080');
@@ -54,14 +52,10 @@ describe('HTMLAnchorElement', () => {
 
     it('supports relative path on URL with path', async () => {
       return await window.evalAsync(`
-        sinon.stub(window.location, 'toString').callsFake(() => 'https://foo.com/baz/');
+        window.location.toString = () => 'https://foo.com/baz/';
         el.href = 'bar/';
         assert.equal(el.href, 'bar/');
-        assert.equal(el.host, 'foo.com');
-        assert.equal(el.hostname, 'foo.com');
         assert.equal(el.pathname, '/baz/bar/');
-        assert.equal(el.protocol, 'https:');
-        assert.equal(el.origin, 'https://foo.com');
       `);
     });
   });


### PR DESCRIPTION
Windows tests were failing due to lack of `process` global when `sinon` initializes:

```
  1) HTMLAnchorElement
       a
         supports relative path on URL with path:
     Error: the string "AssertionError [ERR_ASSERTION]: '/bar/' == '/baz/bar/'\n    at eval (eval at global.onrunasync (C:\\Users\\avaer\\Documents\\GitHub\\exokit\\src\\Window.js:1433:30), <anonymous>:4:16)\n    at global.onrunasync (C:\\Users\\avaer\\Documents\\GitHub\\exokit\\src\\Window.js:1433:30)\n    at MessagePort.<anonymous> (C:\\Users\\avaer\\Documents\\GitHub\\exokit\\src\\WindowBase.js:308:45)\n    at MessagePort.emit (events.js:196:13)\n    at MessagePort.EventEmitter.emit (domain.js:471:20)\n    at MessagePort.onmessage (internal/worker/io.js:68:8)" was thrown, throw an Error :)
      at thrown2Error (C:\Users\avaer\Documents\GitHub\exokit\node_modules\mocha\lib\runner.js:1014:10)
      at Runner.fail (C:\Users\avaer\Documents\GitHub\exokit\node_modules\mocha\lib\runner.js:294:11)
      at C:\Users\avaer\Documents\GitHub\exokit\node_modules\mocha\lib\runner.js:673:18
      at done (C:\Users\avaer\Documents\GitHub\exokit\node_modules\mocha\lib\runnable.js:334:5)
      at C:\Users\avaer\Documents\GitHub\exokit\node_modules\mocha\lib\runnable.js:398:11
```