### PR TITLE
Bugfix iframe navigation handling

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2198,7 +2198,7 @@ class HTMLIFrameElement extends HTMLSrcableElement {
                   htmlString,
                   hidden: true,
                   xrOffsetBuffer: this.xrOffset._buffer,
-                  onnavigate(href) {
+                  onnavigate: (href) => {
                     this.readyState = null;
 
                     this.setAttribute('src', href);


### PR DESCRIPTION
This method was bound to `window`, but we want to `setAttribute(src)` on the `iframe` when navigating its `src`.