### PR TITLE
Make Node insertBefore work with null reference node

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -864,7 +864,7 @@ class Element extends Node {
   insertBefore(childNode, nextSibling) {
     let index = this.childNodes.indexOf(nextSibling);
     if (index !== -1) {
-      index = 0;
+      index = this.childNodes.length;
     }
 
     this.childNodes.splice(index, 0, childNode);

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -862,18 +862,20 @@ class Element extends Node {
     }
   }
   insertBefore(childNode, nextSibling) {
-    const index = this.childNodes.indexOf(nextSibling);
+    let index = this.childNodes.indexOf(nextSibling);
     if (index !== -1) {
-      this.childNodes.splice(index, 0, childNode);
-      childNode.parentNode = this;
-
-      if (this._children) {
-        this._children.update();
-      }
-
-      this._emit('children', [childNode], [], this.childNodes[index - 1] || null, this.childNodes[index + 1] || null);
-      this.ownerDocument._emit('domchange');
+      index = 0;
     }
+
+    this.childNodes.splice(index, 0, childNode);
+    childNode.parentNode = this;
+
+    if (this._children) {
+      this._children.update();
+    }
+
+    this._emit('children', [childNode], [], this.childNodes[index - 1] || null, this.childNodes[index + 1] || null);
+    this.ownerDocument._emit('domchange');
   }
   insertAfter(childNode, nextSibling) {
     const index = this.childNodes.indexOf(nextSibling);


### PR DESCRIPTION
React and React VR depend on this.

[The spec](https://developer.mozilla.org/en-US/docs/Web/API/Node/insertBefore) also requires that:

> If the reference node is null, the specified node is added to the end of the list of children of the specified parent node.