### PR TITLE
WebGL 2 null checks

### DIFF
--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -5590,7 +5590,7 @@ NAN_METHOD(WebGL2RenderingContext::IsSampler) {
 
 NAN_METHOD(WebGL2RenderingContext::BindSampler) {
   GLuint unit = TO_UINT32(info[0]);
-  GLuint sampler = TO_UINT32(JS_OBJ(info[1])->Get(JS_STR("id")));
+  GLuint sampler = info[0]->IsObject() ? TO_UINT32(JS_OBJ(info[1])->Get(JS_STR("id"))) : 0;
 
   glBindSampler(unit, sampler);
 }

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -3328,7 +3328,7 @@ NAN_METHOD(WebGLRenderingContext::BindBuffer) {
 NAN_METHOD(WebGLRenderingContext::BindBufferBase) {
   GLenum target = TO_UINT32(info[0]);
   GLuint index = TO_UINT32(info[1]);
-  GLuint buffer = TO_UINT32(JS_OBJ(info[2])->Get(JS_STR("id")));
+  GLuint buffer = info[2]->IsObject() ? TO_UINT32(JS_OBJ(info[2])->Get(JS_STR("id"))) : 0;
 
   glBindBufferBase(target, index, buffer);
 }

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -5590,7 +5590,7 @@ NAN_METHOD(WebGL2RenderingContext::IsSampler) {
 
 NAN_METHOD(WebGL2RenderingContext::BindSampler) {
   GLuint unit = TO_UINT32(info[0]);
-  GLuint sampler = info[0]->IsObject() ? TO_UINT32(JS_OBJ(info[1])->Get(JS_STR("id"))) : 0;
+  GLuint sampler = info[1]->IsObject() ? TO_UINT32(JS_OBJ(info[1])->Get(JS_STR("id"))) : 0;
 
   glBindSampler(unit, sampler);
 }


### PR DESCRIPTION
`WebGL2RenderingContext` `bindBufferBase` and `bindSampler` were missing null checks, causing a crash when provided. Their nullity is allowed by the spec.