### PR TITLE
Add WebGL 2 texStorage3D method

### DIFF
--- a/deps/exokit-bindings/webglcontext/include/webgl.h
+++ b/deps/exokit-bindings/webglcontext/include/webgl.h
@@ -316,6 +316,7 @@ public:
 
   static NAN_METHOD(TexSubImage2D);
   static NAN_METHOD(TexStorage2D);
+  static NAN_METHOD(TexStorage3D);
 
   static NAN_METHOD(ReadPixels);
   static NAN_METHOD(GetTexParameter);

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -1135,6 +1135,7 @@ std::pair<Local<Object>, Local<FunctionTemplate>> WebGLRenderingContext::Initial
 
   Nan::SetMethod(proto, "texSubImage2D", glCallWrap<TexSubImage2D>);
   Nan::SetMethod(proto, "texStorage2D", glCallWrap<TexStorage2D>);
+  Nan::SetMethod(proto, "texStorage3D", glCallWrap<TexStorage3D>);
 
   Nan::SetMethod(proto, "readPixels", glCallWrap<ReadPixels>);
   Nan::SetMethod(proto, "getTexParameter", glCallWrap<GetTexParameter>);
@@ -4424,6 +4425,18 @@ NAN_METHOD(WebGLRenderingContext::TexStorage2D) {
   GLsizei height = TO_UINT32(info[4]);
 
   glTexStorage2D(target, levels, internalFormat, width, height);
+}
+
+NAN_METHOD(WebGLRenderingContext::TexStorage3D) {
+  WebGLRenderingContext *gl = ObjectWrap::Unwrap<WebGLRenderingContext>(info.This());
+  GLenum target = TO_UINT32(info[0]);
+  GLint levels = TO_INT32(info[1]);
+  GLenum internalFormat = TO_UINT32(info[2]);
+  GLsizei width = TO_UINT32(info[3]);
+  GLsizei height = TO_UINT32(info[4]);
+  GLsizei depth = TO_UINT32(info[5]);
+
+  glTexStorage3D(target, levels, internalFormat, width, height, depth);
 }
 
 NAN_METHOD(WebGLRenderingContext::ReadPixels) {


### PR DESCRIPTION
Implements https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/texStorage3D.

Fixes https://github.com/exokitxr/exokit/issues/1271.