### PR TITLE
Add WebGL2 getProgramParameter arguments support

### DIFF
--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -2660,18 +2660,25 @@ NAN_METHOD(WebGLRenderingContext::GetProgramParameter) {
   switch (pname) {
     case GL_DELETE_STATUS:
     case GL_LINK_STATUS:
-    case GL_VALIDATE_STATUS:
+    case GL_VALIDATE_STATUS: {
       glGetProgramiv(programId, pname, &value);
       info.GetReturnValue().Set(JS_BOOL(static_cast<bool>(value)));
       break;
+    }
     case GL_ATTACHED_SHADERS:
     case GL_ACTIVE_ATTRIBUTES:
     case GL_ACTIVE_UNIFORMS:
+    case GL_TRANSFORM_FEEDBACK_BUFFER_MODE:
+    case GL_TRANSFORM_FEEDBACK_VARYINGS:
+    case GL_ACTIVE_UNIFORM_BLOCKS: {
       glGetProgramiv(programId, pname, &value);
-      info.GetReturnValue().Set(JS_FLOAT(static_cast<long>(value)));
+      info.GetReturnValue().Set(JS_INT(value));
       break;
-    default:
+    }
+    default: {
       Nan::ThrowTypeError("GetProgramParameter: Invalid Enum");
+      break;
+    }
   }
 }
 


### PR DESCRIPTION
This adds support for [WebGL 2 `getProgramParameter` arguments](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/getProgramParameter):

```
gl.TRANSFORM_FEEDBACK_BUFFER_MODE: Returns a GLenum indicating the buffer mode when transform feedback is active. May be gl.SEPARATE_ATTRIBS or gl.INTERLEAVED_ATTRIBS.
gl.TRANSFORM_FEEDBACK_VARYINGS: Returns a GLint indicating the number of varying variables to capture in transform feedback mode.
gl.ACTIVE_UNIFORM_BLOCKS: Returns a GLint indicating the number of uniform blocks containing active uniforms.
```