### PR TITLE
Add missing WebGL2 methods

### DIFF
--- a/deps/exokit-bindings/webglcontext/include/webgl.h
+++ b/deps/exokit-bindings/webglcontext/include/webgl.h
@@ -236,6 +236,7 @@ public:
   static NAN_METHOD(BindFramebuffer);
   static NAN_METHOD(BindFramebufferRaw);
   static NAN_METHOD(FramebufferTexture2D);
+  static NAN_METHOD(FramebufferTextureLayer);
   static NAN_METHOD(BlitFramebuffer);
   static NAN_METHOD(InvalidateFramebuffer);
   static NAN_METHOD(InvalidateSubFramebuffer);

--- a/deps/exokit-bindings/webglcontext/include/webgl.h
+++ b/deps/exokit-bindings/webglcontext/include/webgl.h
@@ -232,6 +232,7 @@ public:
   static NAN_METHOD(CreateBuffer);
   static NAN_METHOD(BindBuffer);
   static NAN_METHOD(BindBufferBase);
+  static NAN_METHOD(BindBufferRange);
   static NAN_METHOD(CreateFramebuffer);
   static NAN_METHOD(BindFramebuffer);
   static NAN_METHOD(BindFramebufferRaw);

--- a/deps/exokit-bindings/webglcontext/include/webgl.h
+++ b/deps/exokit-bindings/webglcontext/include/webgl.h
@@ -273,6 +273,10 @@ public:
   static NAN_METHOD(VertexAttribDivisorANGLE);
   static NAN_METHOD(DrawBuffers);
   static NAN_METHOD(DrawBuffersWEBGL);
+  static NAN_METHOD(ClearBufferfv);
+  static NAN_METHOD(ClearBufferiv);
+  static NAN_METHOD(ClearBufferuiv);
+  static NAN_METHOD(ClearBufferfi);
 
   static NAN_METHOD(BlendColor);
   static NAN_METHOD(BlendEquationSeparate);

--- a/deps/exokit-bindings/webglcontext/include/webgl.h
+++ b/deps/exokit-bindings/webglcontext/include/webgl.h
@@ -206,8 +206,12 @@ public:
   static NAN_METHOD(LinkProgram);
   static NAN_METHOD(GetProgramParameter);
   static NAN_METHOD(GetUniformLocation);
+  static NAN_METHOD(GetUniformIndices);
+  static NAN_METHOD(GetActiveUniforms);
   static NAN_METHOD(GetUniformBlockIndex);
   static NAN_METHOD(UniformBlockBinding);
+  static NAN_METHOD(GetActiveUniformBlockName);
+  static NAN_METHOD(GetActiveUniformBlockParameter);
   static NAN_METHOD(ClearColor);
   static NAN_METHOD(ClearDepth);
   static NAN_METHOD(Disable);
@@ -233,8 +237,11 @@ public:
   static NAN_METHOD(BindFramebufferRaw);
   static NAN_METHOD(FramebufferTexture2D);
   static NAN_METHOD(BlitFramebuffer);
+  static NAN_METHOD(InvalidateFramebuffer);
+  static NAN_METHOD(InvalidateSubFramebuffer);
   static NAN_METHOD(BufferData);
   static NAN_METHOD(BufferSubData);
+  static NAN_METHOD(ReadBuffer);
   static NAN_METHOD(BlendEquation);
   static NAN_METHOD(BlendFunc);
   static NAN_METHOD(EnableVertexAttribArray);
@@ -315,6 +322,7 @@ public:
   static NAN_METHOD(IsSync);
 
   static NAN_METHOD(RenderbufferStorage);
+  static NAN_METHOD(RenderbufferStorageMultisample);
   static NAN_METHOD(GetShaderSource);
   static NAN_METHOD(ValidateProgram);
 
@@ -335,6 +343,7 @@ public:
   static NAN_METHOD(GetRenderbufferParameter);
   static NAN_METHOD(GetUniform);
   static NAN_METHOD(GetVertexAttrib);
+  static NAN_METHOD(GetFragDataLocation);
   static NAN_METHOD(GetSupportedExtensions);
   static NAN_METHOD(GetExtension);
   static NAN_METHOD(GetContextAttributes);

--- a/deps/exokit-bindings/webglcontext/include/webgl.h
+++ b/deps/exokit-bindings/webglcontext/include/webgl.h
@@ -243,6 +243,7 @@ public:
   static NAN_METHOD(InvalidateSubFramebuffer);
   static NAN_METHOD(BufferData);
   static NAN_METHOD(BufferSubData);
+  static NAN_METHOD(CopyBufferSubData);
   static NAN_METHOD(ReadBuffer);
   static NAN_METHOD(BlendEquation);
   static NAN_METHOD(BlendFunc);
@@ -349,6 +350,7 @@ public:
   static NAN_METHOD(GetRenderbufferParameter);
   static NAN_METHOD(GetUniform);
   static NAN_METHOD(GetVertexAttrib);
+  static NAN_METHOD(GetIndexedParameter);
   static NAN_METHOD(GetFragDataLocation);
   static NAN_METHOD(GetSupportedExtensions);
   static NAN_METHOD(GetExtension);

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -2125,6 +2125,10 @@ std::pair<Local<Object>, Local<FunctionTemplate>> WebGLRenderingContext::Initial
   Nan::SetMethod(proto, "vertexAttribDivisorANGLE", glCallWrap<VertexAttribDivisorANGLE>);
   Nan::SetMethod(proto, "drawBuffers", glCallWrap<DrawBuffers>);
   Nan::SetMethod(proto, "drawBuffersWEBGL", glCallWrap<DrawBuffersWEBGL>);
+  Nan::SetMethod(proto, "clearBufferfv", glCallWrap<ClearBufferfv>);
+  Nan::SetMethod(proto, "clearBufferiv", glCallWrap<ClearBufferiv>);
+  Nan::SetMethod(proto, "clearBufferuiv", glCallWrap<ClearBufferuiv>);
+  Nan::SetMethod(proto, "clearBufferfi", glCallWrap<ClearBufferfi>);
 
   Nan::SetMethod(proto, "blendColor", glCallWrap<BlendColor>);
   Nan::SetMethod(proto, "blendEquationSeparate", glCallWrap<BlendEquationSeparate>);
@@ -4454,6 +4458,90 @@ NAN_METHOD(WebGLRenderingContext::DrawBuffersWEBGL) {
   glDrawBuffers(numBuffers, buffers);
 
   // info.GetReturnValue().Set(Nan::Undefined());
+}
+
+NAN_METHOD(WebGLRenderingContext::ClearBufferfv) {
+  GLenum buffer = TO_UINT32(info[0]);
+  GLint drawBuffer = TO_INT32(info[1]);
+  Local<Value> valuesValue = info[3];
+  GLint srcOffset = info[4]->IsNumber() ? TO_INT32(info[1]) : 0;
+
+  if (valuesValue->IsArray()) {
+    Local<Array> valuesArray = Local<Array>::Cast(valuesValue);
+    size_t length = std::max<size_t>(valuesArray->Length() - srcOffset, 0);
+    if (length > 0) {
+      std::vector<GLfloat> values(length);
+      for (size_t i = 0; i < length; i++) {
+        values[i] = TO_FLOAT(valuesArray->Get(i + srcOffset));
+      }
+      glClearBufferfv(buffer, drawBuffer, values.data());
+    }
+  } else if (valuesValue->IsFloat32Array()) {
+    Local<Float32Array> valuesFloat32Array = Local<Float32Array>::Cast(valuesValue);
+    GLfloat *values = (GLfloat *)((char *)valuesFloat32Array->Buffer()->GetContents().Data() + valuesFloat32Array->ByteOffset());
+    glClearBufferfv(buffer, drawBuffer, values);
+  } else {
+    Nan::ThrowError("ClearBufferfv: Invalid arguments");
+  }
+}
+
+NAN_METHOD(WebGLRenderingContext::ClearBufferiv) {
+  GLenum buffer = TO_UINT32(info[0]);
+  GLint drawBuffer = TO_INT32(info[1]);
+  Local<Value> valuesValue = info[3];
+  GLint srcOffset = info[4]->IsNumber() ? TO_INT32(info[1]) : 0;
+
+  if (valuesValue->IsArray()) {
+    Local<Array> valuesArray = Local<Array>::Cast(valuesValue);
+    size_t length = std::max<size_t>(valuesArray->Length() - srcOffset, 0);
+    if (length > 0) {
+      std::vector<GLint> values(length);
+      for (size_t i = 0; i < length; i++) {
+        values[i] = TO_INT32(valuesArray->Get(i + srcOffset));
+      }
+      glClearBufferiv(buffer, drawBuffer, values.data());
+    }
+  } else if (valuesValue->IsInt32Array()) {
+    Local<Int32Array> valuesInt32Array = Local<Int32Array>::Cast(valuesValue);
+    GLint *values = (GLint *)((char *)valuesInt32Array->Buffer()->GetContents().Data() + valuesInt32Array->ByteOffset());
+    glClearBufferiv(buffer, drawBuffer, values);
+  } else {
+    Nan::ThrowError("ClearBufferiv: Invalid arguments");
+  }
+}
+
+NAN_METHOD(WebGLRenderingContext::ClearBufferuiv) {
+  GLenum buffer = TO_UINT32(info[0]);
+  GLint drawBuffer = TO_INT32(info[1]);
+  Local<Value> valuesValue = info[3];
+  GLint srcOffset = info[4]->IsNumber() ? TO_INT32(info[1]) : 0;
+
+  if (valuesValue->IsArray()) {
+    Local<Array> valuesArray = Local<Array>::Cast(valuesValue);
+    size_t length = std::max<size_t>(valuesArray->Length() - srcOffset, 0);
+    if (length > 0) {
+      std::vector<GLuint> values(length);
+      for (size_t i = 0; i < length; i++) {
+        values[i] = TO_UINT32(valuesArray->Get(i + srcOffset));
+      }
+      glClearBufferuiv(buffer, drawBuffer, values.data());
+    }
+  } else if (valuesValue->IsUint32Array()) {
+    Local<Uint32Array> valuesUint32Array = Local<Uint32Array>::Cast(valuesValue);
+    GLuint *values = (GLuint *)((char *)valuesUint32Array->Buffer()->GetContents().Data() + valuesUint32Array->ByteOffset());
+    glClearBufferuiv(buffer, drawBuffer, values);
+  } else {
+    Nan::ThrowError("ClearBufferiv: Invalid arguments");
+  }
+}
+
+NAN_METHOD(WebGLRenderingContext::ClearBufferfi) {
+  GLenum buffer = TO_UINT32(info[0]);
+  GLint drawBuffer = TO_INT32(info[1]);
+  GLfloat depth = TO_FLOAT(info[2]);
+  GLint stencil = TO_INT32(info[3]);
+
+  glClearBufferfi(buffer, drawBuffer, depth, stencil);
 }
 
 NAN_METHOD(WebGLRenderingContext::BlendColor) {

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -2091,6 +2091,7 @@ std::pair<Local<Object>, Local<FunctionTemplate>> WebGLRenderingContext::Initial
   Nan::SetMethod(proto, "createBuffer", glCallWrap<CreateBuffer>);
   Nan::SetMethod(proto, "bindBuffer", glCallWrap<BindBuffer>);
   Nan::SetMethod(proto, "bindBufferBase", glCallWrap<BindBufferBase>);
+  Nan::SetMethod(proto, "bindBufferRange", glCallWrap<BindBufferRange>);
   Nan::SetMethod(proto, "bufferData", glCallWrap<BufferData>);
   Nan::SetMethod(proto, "bufferSubData", glCallWrap<BufferSubData>);
   Nan::SetMethod(proto, "readBuffer", glCallWrap<ReadBuffer>);
@@ -3920,6 +3921,16 @@ NAN_METHOD(WebGLRenderingContext::BindBufferBase) {
   GLuint buffer = info[2]->IsObject() ? TO_UINT32(JS_OBJ(info[2])->Get(JS_STR("id"))) : 0;
 
   glBindBufferBase(target, index, buffer);
+}
+
+NAN_METHOD(WebGLRenderingContext::BindBufferRange) {
+  GLenum target = TO_UINT32(info[0]);
+  GLuint index = TO_UINT32(info[1]);
+  GLuint buffer = info[2]->IsObject() ? TO_UINT32(JS_OBJ(info[2])->Get(JS_STR("id"))) : 0;
+  GLintptr offset = TO_UINT32(info[3]);
+  GLsizei size = TO_UINT32(info[4]);
+
+  glBindBufferRange(target, index, buffer, offset, size);
 }
 
 NAN_METHOD(WebGLRenderingContext::CreateFramebuffer) {

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -2084,6 +2084,7 @@ std::pair<Local<Object>, Local<FunctionTemplate>> WebGLRenderingContext::Initial
   Nan::SetMethod(proto, "bindFramebuffer", glCallWrap<BindFramebuffer>);
   Nan::SetMethod(proto, "bindFramebufferRaw", glCallWrap<BindFramebufferRaw>);
   Nan::SetMethod(proto, "framebufferTexture2D", glCallWrap<FramebufferTexture2D>);
+  Nan::SetMethod(proto, "framebufferTextureLayer", glCallWrap<FramebufferTextureLayer>);
   Nan::SetMethod(proto, "blitFramebuffer", glCallWrap<BlitFramebuffer>);
   Nan::SetMethod(proto, "invalidateFramebuffer", glCallWrap<InvalidateFramebuffer>);
   Nan::SetMethod(proto, "invalidateSubFramebuffer", glCallWrap<InvalidateSubFramebuffer>);
@@ -3963,6 +3964,18 @@ NAN_METHOD(WebGLRenderingContext::FramebufferTexture2D) {
   GLint level = TO_INT32(info[4]);
 
   glFramebufferTexture2D(target, attachment, textarget, texture, level);
+
+  // info.GetReturnValue().Set(Nan::Undefined());
+}
+
+NAN_METHOD(WebGLRenderingContext::FramebufferTextureLayer) {
+  GLenum target = TO_UINT32(info[0]);
+  GLenum attachment = TO_INT32(info[1]);
+  GLuint texture = info[2]->IsObject() ? TO_UINT32(JS_OBJ(info[2])->Get(JS_STR("id"))) : 0;
+  GLint level = TO_INT32(info[3]);
+  GLint layer = TO_INT32(info[4]);
+
+  glFramebufferTextureLayer(target, attachment, texture, level, layer);
 
   // info.GetReturnValue().Set(Nan::Undefined());
 }

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -5029,9 +5029,9 @@ NAN_METHOD(WebGLRenderingContext::RenderbufferStorage) {
 }
 
 NAN_METHOD(WebGLRenderingContext::RenderbufferStorageMultisample) {
-  GLenum target = TO_INT32(info[0]);
+  GLenum target = TO_UINT32(info[0]);
   GLsizei samples = TO_UINT32(info[1]);
-  GLenum internalformat = TO_INT32(info[2]);
+  GLenum internalformat = TO_UINT32(info[2]);
   GLsizei width = TO_UINT32(info[3]);
   GLsizei height = TO_UINT32(info[4]);
 

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -2094,6 +2094,7 @@ std::pair<Local<Object>, Local<FunctionTemplate>> WebGLRenderingContext::Initial
   Nan::SetMethod(proto, "bindBufferRange", glCallWrap<BindBufferRange>);
   Nan::SetMethod(proto, "bufferData", glCallWrap<BufferData>);
   Nan::SetMethod(proto, "bufferSubData", glCallWrap<BufferSubData>);
+  Nan::SetMethod(proto, "copyBufferSubData", glCallWrap<CopyBufferSubData>);
   Nan::SetMethod(proto, "readBuffer", glCallWrap<ReadBuffer>);
   Nan::SetMethod(proto, "enable", glCallWrap<Enable>);
   Nan::SetMethod(proto, "blendEquation", glCallWrap<BlendEquation>);
@@ -4122,6 +4123,16 @@ NAN_METHOD(WebGLRenderingContext::BufferSubData) {
   }
 
   glBufferSubData(target, dstOffset, size, data);
+}
+
+NAN_METHOD(WebGLRenderingContext::CopyBufferSubData) {
+  GLenum readTarget = TO_UINT32(info[0]);
+  GLenum writeTarget = TO_UINT32(info[1]);
+  GLintptr readOffset = TO_INT32(info[2]);
+  GLintptr writeOffset = TO_INT32(info[3]);
+  GLsizei size = TO_INT32(info[4]);
+
+  glCopyBufferSubData(readTarget, writeTarget, readOffset, writeOffset, size);
 }
 
 NAN_METHOD(WebGLRenderingContext::ReadBuffer) {


### PR DESCRIPTION
Adds:

- `getUniformIndices`
- `getActiveUniforms`
- `getActiveUniformBlockName`
- `getActiveUniformBlockParameter`
- `invalidateFramebuffer`
- `invalidateSubFramebuffer`
- `readBuffer`
- `renderbufferStorageMultisample`
- `getFragDataLocation`

Fixes https://github.com/exokitxr/exokit/issues/1278.
Fixes https://github.com/exokitxr/exokit/issues/1279.
Fixes https://github.com/exokitxr/exokit/issues/1280.

Based off of https://github.com/exokitxr/exokit/pull/1276.