### PR TITLE
Bugfix file streaming

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "rimraf": "^2.6.2",
     "unescape": "^1.0.1",
     "webgl-to-opengl": "0.0.16",
-    "window-fetch": "0.0.11",
+    "window-fetch": "0.0.12",
     "window-ls": "0.0.1",
     "window-selector": "0.0.7",
     "window-xhr": "0.0.38",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "window-fetch": "0.0.12",
     "window-ls": "0.0.1",
     "window-selector": "0.0.7",
-    "window-xhr": "0.0.38",
+    "window-xhr": "0.0.39",
     "ws": "^6.2.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
`fetch`/`XMLHttpRequest` was broken for the `file://` URL case due to incorrect `Blob` resolution instead of `stream`.

Ingests https://github.com/modulesio/window-fetch/pull/3.
Ingests https://github.com/modulesio/window-xhr/pull/10.