### PR TITLE
Normalize blob url format

### DIFF
--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -59,7 +59,7 @@ consoleStream._writev = (chunks, callback) => {
 global.console = new Console(consoleStream);
 
 URL.createObjectURL = blob => {
-  const url = 'blob:' + GlobalContext.xrState.blobId[0]++;
+  const url = 'blob:' + global.location.protocol + '//' + global.location.host + '/' + GlobalContext.xrState.blobId[0]++;
   nativeCache.set(url, blob.buffer);
   return url;
 };


### PR DESCRIPTION
Some loaders do not like our `blob:[0-9]+` URL format.

This PR makes the format more like browsers (e.g.)

```
blob:https?://localhost:8000/[0-9]+
```