### PR TITLE
Major bugfixing in WebGL uniforms setters

### DIFF
--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -1550,12 +1550,12 @@ NAN_METHOD(WebGLRenderingContext::Uniform1fv) {
       data = getArrayData<GLfloat>(info[1], &count);
     }
     if (info[2]->IsNumber()) {
-      GLsizei srcOffset = TO_UINT32(info[3]);
+      GLsizei srcOffset = TO_UINT32(info[2]);
       data += srcOffset;
       count -= srcOffset;
     }
     if (info[3]->IsNumber()) {
-      GLsizei srcLength = TO_UINT32(info[4]);
+      GLsizei srcLength = TO_UINT32(info[3]);
       count = std::min<GLsizei>(srcLength, count);
     }
 
@@ -1583,12 +1583,13 @@ NAN_METHOD(WebGLRenderingContext::Uniform2fv) {
       count /= 2;
     }
     if (info[2]->IsNumber()) {
-      GLsizei srcOffset = TO_UINT32(info[3]);
+      GLsizei srcOffset = TO_UINT32(info[2]);
       data += srcOffset;
-      count -= srcOffset;
+      count -= srcOffset / 2;
     }
     if (info[3]->IsNumber()) {
-      GLsizei srcLength = TO_UINT32(info[4]);
+      GLsizei srcLength = TO_UINT32(info[3]);
+      srcLength /= 2;
       count = std::min<GLsizei>(srcLength, count);
     }
 
@@ -1616,12 +1617,13 @@ NAN_METHOD(WebGLRenderingContext::Uniform3fv) {
       count /= 3;
     }
     if (info[2]->IsNumber()) {
-      GLsizei srcOffset = TO_UINT32(info[3]);
+      GLsizei srcOffset = TO_UINT32(info[2]);
       data += srcOffset;
-      count -= srcOffset;
+      count -= srcOffset / 3;
     }
     if (info[3]->IsNumber()) {
-      GLsizei srcLength = TO_UINT32(info[4]);
+      GLsizei srcLength = TO_UINT32(info[3]);
+      srcLength /= 3;
       count = std::min<GLsizei>(srcLength, count);
     }
 
@@ -1649,12 +1651,13 @@ NAN_METHOD(WebGLRenderingContext::Uniform4fv) {
       count /= 4;
     }
     if (info[2]->IsNumber()) {
-      GLsizei srcOffset = TO_UINT32(info[3]);
+      GLsizei srcOffset = TO_UINT32(info[2]);
       data += srcOffset;
-      count -= srcOffset;
+      count -= srcOffset / 4;
     }
     if (info[3]->IsNumber()) {
-      GLsizei srcLength = TO_UINT32(info[4]);
+      GLsizei srcLength = TO_UINT32(info[3]);
+      srcLength /= 4;
       count = std::min<GLsizei>(srcLength, count);
     }
 
@@ -1680,12 +1683,12 @@ NAN_METHOD(WebGLRenderingContext::Uniform1iv) {
       data = getArrayData<GLint>(info[1], &count);
     }
     if (info[2]->IsNumber()) {
-      GLsizei srcOffset = TO_UINT32(info[3]);
+      GLsizei srcOffset = TO_UINT32(info[2]);
       data += srcOffset;
       count -= srcOffset;
     }
     if (info[3]->IsNumber()) {
-      GLsizei srcLength = TO_UINT32(info[4]);
+      GLsizei srcLength = TO_UINT32(info[3]);
       count = std::min<GLsizei>(srcLength, count);
     }
 
@@ -1713,12 +1716,13 @@ NAN_METHOD(WebGLRenderingContext::Uniform2iv) {
       count /= 2;
     }
     if (info[2]->IsNumber()) {
-      GLsizei srcOffset = TO_UINT32(info[3]);
+      GLsizei srcOffset = TO_UINT32(info[2]);
       data += srcOffset;
-      count -= srcOffset;
+      count -= srcOffset / 2;
     }
     if (info[3]->IsNumber()) {
-      GLsizei srcLength = TO_UINT32(info[4]);
+      GLsizei srcLength = TO_UINT32(info[3]);
+      srcLength /= 2;
       count = std::min<GLsizei>(srcLength, count);
     }
 
@@ -1746,12 +1750,13 @@ NAN_METHOD(WebGLRenderingContext::Uniform3iv) {
       count /= 3;
     }
     if (info[2]->IsNumber()) {
-      GLsizei srcOffset = TO_UINT32(info[3]);
+      GLsizei srcOffset = TO_UINT32(info[2]);
       data += srcOffset;
-      count -= srcOffset;
+      count -= srcOffset / 3;
     }
     if (info[3]->IsNumber()) {
-      GLsizei srcLength = TO_UINT32(info[4]);
+      GLsizei srcLength = TO_UINT32(info[3]);
+      srcLength /= 3;
       count = std::min<GLsizei>(srcLength, count);
     }
 
@@ -1779,12 +1784,13 @@ NAN_METHOD(WebGLRenderingContext::Uniform4iv) {
       count /= 4;
     }
     if (info[2]->IsNumber()) {
-      GLsizei srcOffset = TO_UINT32(info[3]);
+      GLsizei srcOffset = TO_UINT32(info[2]);
       data += srcOffset;
-      count -= srcOffset;
+      count -= srcOffset / 4;
     }
     if (info[3]->IsNumber()) {
-      GLsizei srcLength = TO_UINT32(info[4]);
+      GLsizei srcLength = TO_UINT32(info[3]);
+      srcLength /= 4;
       count = std::min<GLsizei>(srcLength, count);
     }
 
@@ -1811,12 +1817,12 @@ NAN_METHOD(WebGLRenderingContext::Uniform1uiv) {
       data = getArrayData<GLuint>(dataValue, &count);
     }
     if (info[2]->IsNumber()) {
-      GLsizei srcOffset = TO_UINT32(info[3]);
+      GLsizei srcOffset = TO_UINT32(info[2]);
       data += srcOffset;
       count -= srcOffset;
     }
     if (info[3]->IsNumber()) {
-      GLsizei srcLength = TO_UINT32(info[4]);
+      GLsizei srcLength = TO_UINT32(info[3]);
       count = std::min<GLsizei>(srcLength, count);
     }
 
@@ -1839,16 +1845,19 @@ NAN_METHOD(WebGLRenderingContext::Uniform2uiv) {
         uint32Array->Set(i, array->Get(i));
       }
       data = getArrayData<GLuint>(uint32Array, &count);
+      count /= 2;
     } else {
       data = getArrayData<GLuint>(dataValue, &count);
+      count /= 2;
     }
     if (info[2]->IsNumber()) {
-      GLsizei srcOffset = TO_UINT32(info[3]);
+      GLsizei srcOffset = TO_UINT32(info[2]);
       data += srcOffset;
-      count -= srcOffset;
+      count -= srcOffset / 2;
     }
     if (info[3]->IsNumber()) {
-      GLsizei srcLength = TO_UINT32(info[4]);
+      GLsizei srcLength = TO_UINT32(info[3]);
+      srcLength /= 2;
       count = std::min<GLsizei>(srcLength, count);
     }
 
@@ -1871,17 +1880,19 @@ NAN_METHOD(WebGLRenderingContext::Uniform3uiv) {
         uint32Array->Set(i, array->Get(i));
       }
       data = getArrayData<GLuint>(uint32Array, &count);
+      count /= 3;
     } else {
       data = getArrayData<GLuint>(dataValue, &count);
+      count /= 3;
     }
     if (info[2]->IsNumber()) {
-
-      GLsizei srcOffset = TO_UINT32(info[3]);
+      GLsizei srcOffset = TO_UINT32(info[2]);
       data += srcOffset;
-      count -= srcOffset;
+      count -= srcOffset / 3;
     }
     if (info[3]->IsNumber()) {
-      GLsizei srcLength = TO_UINT32(info[4]);
+      GLsizei srcLength = TO_UINT32(info[3]);
+      srcLength /= 3;
       count = std::min<GLsizei>(srcLength, count);
     }
 
@@ -1904,16 +1915,19 @@ NAN_METHOD(WebGLRenderingContext::Uniform4uiv) {
         uint32Array->Set(i, array->Get(i));
       }
       data = getArrayData<GLuint>(uint32Array, &count);
+      count /= 4;
     } else {
       data = getArrayData<GLuint>(dataValue, &count);
+      count /= 4;
     }
     if (info[2]->IsNumber()) {
-      GLsizei srcOffset = TO_UINT32(info[3]);
+      GLsizei srcOffset = TO_UINT32(info[2]);
       data += srcOffset;
-      count -= srcOffset;
+      count -= srcOffset / 4;
     }
     if (info[3]->IsNumber()) {
-      GLsizei srcLength = TO_UINT32(info[4]);
+      GLsizei srcLength = TO_UINT32(info[3]);
+      srcLength /= 4;
       count = std::min<GLsizei>(srcLength, count);
     }
 
@@ -1936,27 +1950,23 @@ NAN_METHOD(WebGLRenderingContext::UniformMatrix2fv) {
         float32Array->Set(i, array->Get(i));
       }
       data = getArrayData<GLfloat>(float32Array, &count);
+      count /= 2*2;
     } else {
       data = getArrayData<GLfloat>(info[2], &count);
+      count /= 2*2;
     }
     if (info[3]->IsNumber()) {
       GLsizei srcOffset = TO_UINT32(info[3]);
       data += srcOffset;
-      count -= srcOffset;
+      count -= srcOffset / (2*2);
     }
     if (info[4]->IsNumber()) {
       GLsizei srcLength = TO_UINT32(info[4]);
+      srcLength /= 2*2;
       count = std::min<GLsizei>(srcLength, count);
     }
 
-    if (count < 4) {
-      Nan::ThrowError("Not enough data for UniformMatrix2fv");
-    } else {
-      count /= 4;
-      glUniformMatrix2fv(location, count, transpose, data);
-
-      // info.GetReturnValue().Set(Nan::Undefined());
-    }
+    glUniformMatrix2fv(location, count, transpose, data);
   }
 }
 
@@ -1975,25 +1985,23 @@ NAN_METHOD(WebGLRenderingContext::UniformMatrix3fv) {
         float32Array->Set(i, array->Get(i));
       }
       data = getArrayData<GLfloat>(float32Array, &count);
+      count /= 3*3;
     } else {
       data = getArrayData<GLfloat>(info[2], &count);
+      count /= 3*3;
     }
     if (info[3]->IsNumber()) {
       GLsizei srcOffset = TO_UINT32(info[3]);
       data += srcOffset;
-      count -= srcOffset;
+      count -= srcOffset / (3*3);
     }
     if (info[4]->IsNumber()) {
       GLsizei srcLength = TO_UINT32(info[4]);
+      srcLength /= 3*3;
       count = std::min<GLsizei>(srcLength, count);
     }
 
-    if (count < 9) {
-      Nan::ThrowError("Not enough data for UniformMatrix3fv");
-    } else {
-      count /= 9;
-      glUniformMatrix3fv(location, count, transpose, data);
-    }
+    glUniformMatrix3fv(location, count, transpose, data);
   }
 }
 
@@ -2012,25 +2020,23 @@ NAN_METHOD(WebGLRenderingContext::UniformMatrix4fv) {
         float32Array->Set(i, array->Get(i));
       }
       data = getArrayData<GLfloat>(float32Array, &count);
+      count /= 4*4;
     } else {
       data = getArrayData<GLfloat>(info[2], &count);
+      count /= 4*4;
     }
     if (info[3]->IsNumber()) {
       GLsizei srcOffset = TO_UINT32(info[3]);
       data += srcOffset;
-      count -= srcOffset;
+      count -= srcOffset / (4*4);
     }
     if (info[4]->IsNumber()) {
       GLsizei srcLength = TO_UINT32(info[4]);
+      srcLength /= 4*4;
       count = std::min<GLsizei>(srcLength, count);
     }
 
-    if (count < 16) {
-      Nan::ThrowError("Not enough data for UniformMatrix4fv");
-    } else {
-      count /= 16;
-      glUniformMatrix4fv(location, count, transpose, data);
-    }
+    glUniformMatrix4fv(location, count, transpose, data);
   }
 }
 
@@ -2050,25 +2056,23 @@ NAN_METHOD(WebGLRenderingContext::UniformMatrix3x2fv) {
         float32Array->Set(i, array->Get(i));
       }
       data = getArrayData<GLfloat>(float32Array, &count);
+      count /= 3*2;
     } else {
       data = getArrayData<GLfloat>(dataValue, &count);
+      count /= 3*2;
     }
     if (info[3]->IsNumber()) {
       GLsizei srcOffset = TO_UINT32(info[3]);
       data += srcOffset;
-      count -= srcOffset;
+      count -= srcOffset / (3*2);
     }
     if (info[4]->IsNumber()) {
       GLsizei srcLength = TO_UINT32(info[4]);
+      srcLength /= 3*2;
       count = std::min<GLsizei>(srcLength, count);
     }
 
-    if (count < 6) {
-      Nan::ThrowError("Not enough data for UniformMatrix3x2fv");
-    } else {
-      count /= 6;
-      glUniformMatrix3x2fv(location, count, transpose, data);
-    }
+    glUniformMatrix3x2fv(location, count, transpose, data);
   }
 }
 
@@ -2088,25 +2092,23 @@ NAN_METHOD(WebGLRenderingContext::UniformMatrix4x2fv) {
         float32Array->Set(i, array->Get(i));
       }
       data = getArrayData<GLfloat>(float32Array, &count);
+      count /= 4*2;
     } else {
       data = getArrayData<GLfloat>(dataValue, &count);
+      count /= 4*2;
     }
     if (info[3]->IsNumber()) {
       GLsizei srcOffset = TO_UINT32(info[3]);
       data += srcOffset;
-      count -= srcOffset;
+      count -= srcOffset / (4*2);
     }
     if (info[4]->IsNumber()) {
       GLsizei srcLength = TO_UINT32(info[4]);
+      srcLength /= 4*2;
       count = std::min<GLsizei>(srcLength, count);
     }
 
-    if (count < 8) {
-      Nan::ThrowError("Not enough data for UniformMatrix4x2fv");
-    } else {
-      count /= 8;
-      glUniformMatrix4x2fv(location, count, transpose, data);
-    }
+    glUniformMatrix4x2fv(location, count, transpose, data);
   }
 }
 
@@ -2126,25 +2128,23 @@ NAN_METHOD(WebGLRenderingContext::UniformMatrix2x3fv) {
         float32Array->Set(i, array->Get(i));
       }
       data = getArrayData<GLfloat>(float32Array, &count);
+      count /= 2*3;
     } else {
       data = getArrayData<GLfloat>(dataValue, &count);
+      count /= 2*3;
     }
     if (info[3]->IsNumber()) {
       GLsizei srcOffset = TO_UINT32(info[3]);
       data += srcOffset;
-      count -= srcOffset;
+      count -= srcOffset / (2*3);
     }
     if (info[4]->IsNumber()) {
       GLsizei srcLength = TO_UINT32(info[4]);
+      srcLength /= 2*3;
       count = std::min<GLsizei>(srcLength, count);
     }
 
-    if (count < 6) {
-      Nan::ThrowError("Not enough data for UniformMatrix2x3fv");
-    } else {
-      count /= 6;
-      glUniformMatrix2x3fv(location, count, transpose, data);
-    }
+    glUniformMatrix2x3fv(location, count, transpose, data);
   }
 }
 
@@ -2164,25 +2164,23 @@ NAN_METHOD(WebGLRenderingContext::UniformMatrix4x3fv) {
         float32Array->Set(i, array->Get(i));
       }
       data = getArrayData<GLfloat>(float32Array, &count);
+      count /= 4*3;
     } else {
       data = getArrayData<GLfloat>(dataValue, &count);
+      count /= 4*3;
     }
     if (info[3]->IsNumber()) {
       GLsizei srcOffset = TO_UINT32(info[3]);
       data += srcOffset;
-      count -= srcOffset;
+      count -= srcOffset / (4*3);
     }
     if (info[4]->IsNumber()) {
       GLsizei srcLength = TO_UINT32(info[4]);
+      srcLength /= 4*3;
       count = std::min<GLsizei>(srcLength, count);
     }
 
-    if (count < 12) {
-      Nan::ThrowError("Not enough data for UniformMatrix4x3fv");
-    } else {
-      count /= 12;
-      glUniformMatrix4x3fv(location, count, transpose, data);
-    }
+    glUniformMatrix4x3fv(location, count, transpose, data);
   }
 }
 
@@ -2202,25 +2200,23 @@ NAN_METHOD(WebGLRenderingContext::UniformMatrix2x4fv) {
         float32Array->Set(i, array->Get(i));
       }
       data = getArrayData<GLfloat>(float32Array, &count);
+      count /= 2*4;
     } else {
       data = getArrayData<GLfloat>(dataValue, &count);
+      count /= 2*4;
     }
     if (info[3]->IsNumber()) {
       GLsizei srcOffset = TO_UINT32(info[3]);
       data += srcOffset;
-      count -= srcOffset;
+      count -= srcOffset / (2*4);
     }
     if (info[4]->IsNumber()) {
       GLsizei srcLength = TO_UINT32(info[4]);
+      srcLength /= 2*4;
       count = std::min<GLsizei>(srcLength, count);
     }
 
-    if (count < 8) {
-      Nan::ThrowError("Not enough data for UniformMatrix2x4fv");
-    } else {
-      count /= 8;
-      glUniformMatrix2x4fv(location, count, transpose, data);
-    }
+    glUniformMatrix2x4fv(location, count, transpose, data);
   }
 }
 
@@ -2240,25 +2236,23 @@ NAN_METHOD(WebGLRenderingContext::UniformMatrix3x4fv) {
         float32Array->Set(i, array->Get(i));
       }
       data = getArrayData<GLfloat>(float32Array, &count);
+      count /= 3*4;
     } else {
       data = getArrayData<GLfloat>(dataValue, &count);
+      count /= 3*4;
     }
     if (info[3]->IsNumber()) {
       GLsizei srcOffset = TO_UINT32(info[3]);
       data += srcOffset;
-      count -= srcOffset;
+      count -= srcOffset / (3*4);
     }
     if (info[4]->IsNumber()) {
       GLsizei srcLength = TO_UINT32(info[4]);
+      srcLength /= 3*4;
       count = std::min<GLsizei>(srcLength, count);
     }
 
-    if (count < 12) {
-      Nan::ThrowError("Not enough data for UniformMatrix3x4fv");
-    } else {
-      count /= 12;
-      glUniformMatrix3x4fv(location, count, transpose, data);
-    }
+    glUniformMatrix3x4fv(location, count, transpose, data);
   }
 }
 


### PR DESCRIPTION
The WebGL2 uniform setters code was highly broken for various corner cases.

Bugs include:

- Looking at the wrong arguments index
- Improper division of array length
- Incorrect array offsetting

This PR does a broad cleanup of these functions.