### PR TITLE
Bugfix selector quoting

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "webgl-to-opengl": "0.0.16",
     "window-fetch": "0.0.13",
     "window-ls": "0.0.1",
-    "window-selector": "0.0.7",
+    "window-selector": "0.0.8",
     "window-xhr": "0.0.40",
     "ws": "^6.2.0"
   },


### PR DESCRIPTION
Ingests https://github.com/modulesio/window-selector/pull/5.

Fixes https://github.com/exokitxr/exokit/issues/453.

Allows Unity exports to work in Exokit:

![Capture 31](https://user-images.githubusercontent.com/6926057/60847947-a0784d00-a1b2-11e9-93c1-29e1f4d5880e.PNG)
