### PR TITLE
FakeXRDisplay Gamepad update

### DIFF
--- a/src/VR.js
+++ b/src/VR.js
@@ -566,7 +566,7 @@ class FakeXRDisplay {
     GlobalContext.xrState.fakeVrDisplayEnabled[0] = 1;
   }
 
-  pushUpdate() {
+  pushUpdate({updateGamepads = true} = {}) {
     // update hmd
     this.position.toArray(GlobalContext.xrState.position);
     this.quaternion.toArray(GlobalContext.xrState.orientation);
@@ -584,24 +584,26 @@ class FakeXRDisplay {
     if (!globalGamepads) {
       globalGamepads = _makeGlobalGamepads();
     }
-    for (let i = 0; i < globalGamepads.main.length; i++) {
-      const gamepad = globalGamepads.main[i];
-      localVector.copy(this.position)
-        .add(
-          localVector2.set(-0.3 + i*0.6, -0.3, -0.35)
-            .applyQuaternion(this.quaternion)
-        ).toArray(gamepad.pose.position);
-      this.quaternion.toArray(gamepad.pose.orientation); // XXX updates xrState
+    if (updateGamepads) {
+      for (let i = 0; i < globalGamepads.main.length; i++) {
+        const gamepad = globalGamepads.main[i];
+        localVector.copy(this.position)
+          .add(
+            localVector2.set(-0.3 + i*0.6, -0.3, -0.35)
+              .applyQuaternion(this.quaternion)
+          ).toArray(gamepad.pose.position);
+        this.quaternion.toArray(gamepad.pose.orientation); // XXX updates xrState
 
-      localMatrix2
-        .compose(
-          localVector.fromArray(gamepad.pose.position),
-          localQuaternion.fromArray(gamepad.pose.orientation),
-          localVector2.set(1, 1, 1)
-        )
-        .toArray(gamepad.pose._localPointerMatrix);
+        localMatrix2
+          .compose(
+            localVector.fromArray(gamepad.pose.position),
+            localQuaternion.fromArray(gamepad.pose.orientation),
+            localVector2.set(1, 1, 1)
+          )
+          .toArray(gamepad.pose._localPointerMatrix);
 
-      gamepad.connected = true;
+        gamepad.connected = true;
+      }
     }
   }
 

--- a/src/VR.js
+++ b/src/VR.js
@@ -566,8 +566,7 @@ class FakeXRDisplay {
     GlobalContext.xrState.fakeVrDisplayEnabled[0] = 1;
   }
 
-  pushUpdate({updateGamepads = true} = {}) {
-    // update hmd
+  pushHmdUpdate(position = this.position, quaternion = this.quaternion) {
     this.position.toArray(GlobalContext.xrState.position);
     this.quaternion.toArray(GlobalContext.xrState.orientation);
 
@@ -579,8 +578,8 @@ class FakeXRDisplay {
       .getInverse(localMatrix)
       .toArray(GlobalContext.xrState.leftViewMatrix);
     GlobalContext.xrState.rightViewMatrix.set(GlobalContext.xrState.leftViewMatrix);
-
-    // update gamepads
+  }
+  pushGamepadsUpdate(position = this.position, quaternion = this.quaternion) {
     if (!globalGamepads) {
       globalGamepads = _makeGlobalGamepads();
     }
@@ -605,6 +604,11 @@ class FakeXRDisplay {
         gamepad.connected = true;
       }
     }
+  }
+
+  pushUpdate() {
+    this.pushHmdUpdate(this.position, this.quaternion);
+    this.pushGamepadsUpdate(this.position, this.quaternion);
   }
 
   get width() {

--- a/src/VR.js
+++ b/src/VR.js
@@ -583,26 +583,25 @@ class FakeXRDisplay {
     if (!globalGamepads) {
       globalGamepads = _makeGlobalGamepads();
     }
-    if (updateGamepads) {
-      for (let i = 0; i < globalGamepads.main.length; i++) {
-        const gamepad = globalGamepads.main[i];
-        localVector.copy(this.position)
-          .add(
-            localVector2.set(-0.3 + i*0.6, -0.3, -0.35)
-              .applyQuaternion(this.quaternion)
-          ).toArray(gamepad.pose.position);
-        this.quaternion.toArray(gamepad.pose.orientation); // XXX updates xrState
 
-        localMatrix2
-          .compose(
-            localVector.fromArray(gamepad.pose.position),
-            localQuaternion.fromArray(gamepad.pose.orientation),
-            localVector2.set(1, 1, 1)
-          )
-          .toArray(gamepad.pose._localPointerMatrix);
+    for (let i = 0; i < globalGamepads.main.length; i++) {
+      const gamepad = globalGamepads.main[i];
+      localVector.copy(this.position)
+        .add(
+          localVector2.set(-0.3 + i*0.6, -0.3, -0.35)
+            .applyQuaternion(this.quaternion)
+        ).toArray(gamepad.pose.position);
+      this.quaternion.toArray(gamepad.pose.orientation); // XXX updates xrState
 
-        gamepad.connected = true;
-      }
+      localMatrix2
+        .compose(
+          localVector.fromArray(gamepad.pose.position),
+          localQuaternion.fromArray(gamepad.pose.orientation),
+          localVector2.set(1, 1, 1)
+        )
+        .toArray(gamepad.pose._localPointerMatrix);
+
+      gamepad.connected = true;
     }
   }
 

--- a/src/VR.js
+++ b/src/VR.js
@@ -606,8 +606,8 @@ class FakeXRDisplay {
   }
 
   pushUpdate() {
-    this.pushHmdUpdate(this.position, this.quaternion);
-    this.pushGamepadsUpdate(this.position, this.quaternion);
+    this.pushHmdUpdate();
+    this.pushGamepadsUpdate();
   }
 
   get width() {


### PR DESCRIPTION
Exokit's XR device emulation generally assumes total ownership of the controllers.

However, in developing the frontend we raised the use case of being able to mouseover to control the controllers, which means updating the Gamepad objects to be something other than head-locked.

This PR breaks up the update code into hmd and gamepads cases so they can be controller independently by the driver.