### PR TITLE
Valve Index Gamepad naming 

### DIFF
--- a/deps/openvr/include/ivrcompositor.h
+++ b/deps/openvr/include/ivrcompositor.h
@@ -31,7 +31,7 @@ public:
 class IVRCompositor : public Nan::ObjectWrap
 {
 public:
-  static NAN_MODULE_INIT(Init);
+  static void Init(Nan::Persistent<v8::Function> &constructor);
 
   // Static factory construction method for other node addons to use.
   static v8::Local<v8::Object> NewInstance(vr::IVRCompositor *compositor);
@@ -50,7 +50,10 @@ private:
   /// Create a singleton reference to a constructor function.
   static inline Nan::Persistent<v8::Function>& constructor()
   {
-    static Nan::Persistent<v8::Function> the_constructor;
+    static thread_local Nan::Persistent<v8::Function> the_constructor;
+    if (the_constructor.IsEmpty()) {
+      Init(the_constructor);
+    }
     return the_constructor;
   }
 

--- a/deps/openvr/include/ivrsystem.h
+++ b/deps/openvr/include/ivrsystem.h
@@ -14,7 +14,7 @@ class IVRSystem;
 class IVRSystem : public Nan::ObjectWrap
 {
 public:
-  static NAN_MODULE_INIT(Init);
+  static void Init(Nan::Persistent<v8::Function> &constructor);
 
   // Static factory construction method for other node addons to use.
   static v8::Local<v8::Object> NewInstance(vr::IVRSystem *system);
@@ -127,7 +127,10 @@ private:
   /// Create a singleton reference to a constructor function.
   static inline Nan::Persistent<v8::Function>& constructor()
   {
-    static Nan::Persistent<v8::Function> the_constructor;
+    static thread_local Nan::Persistent<v8::Function> the_constructor;
+    if (the_constructor.IsEmpty()) {
+      Init(the_constructor);
+    }
     return the_constructor;
   }
 

--- a/deps/openvr/include/ivrsystem.h
+++ b/deps/openvr/include/ivrsystem.h
@@ -122,6 +122,8 @@ private:
   /// virtual void AcknowledgeQuit_UserPrompt() = 0;
   static NAN_METHOD(AcknowledgeQuit_UserPrompt);
 
+  static NAN_METHOD(GetModelName);
+
   /// Create a singleton reference to a constructor function.
   static inline Nan::Persistent<v8::Function>& constructor()
   {

--- a/deps/openvr/src/ivrcompositor.cpp
+++ b/deps/openvr/src/ivrcompositor.cpp
@@ -43,8 +43,7 @@ VRPoseRes::VRPoseRes(Local<Function> cb) : cb(cb) {}
 VRPoseRes::~VRPoseRes() {}
 
 //=============================================================================
-NAN_MODULE_INIT(IVRCompositor::Init)
-{
+void IVRCompositor::Init(Nan::Persistent<v8::Function> &constructor) {
   // Create a function template that is called in JS to create this wrapper.
   Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
 
@@ -60,7 +59,7 @@ NAN_MODULE_INIT(IVRCompositor::Init)
   Nan::SetPrototypeMethod(tpl, "Submit", Submit);
 
   // Set a static constructor function to reference the `New` function template.
-  constructor().Reset(Nan::GetFunction(tpl).ToLocalChecked());
+  constructor.Reset(Nan::GetFunction(tpl).ToLocalChecked());
 
   uv_sem_init(&vr::reqSem, 0);
   uv_loop_t *loop = windowsystembase::GetEventLoop();

--- a/deps/openvr/src/ivrsystem.cpp
+++ b/deps/openvr/src/ivrsystem.cpp
@@ -946,7 +946,7 @@ NAN_METHOD(IVRSystem::GetModelName)
 
   char buf[4096];
   vr::TrackedPropertyError error;
-  uint32_t size = vr::GetStringTrackedDeviceProperty(deviceClass, vr::ETrackedDeviceProperty::Prop_ModelNumber_String, buf, sizeof(buf), &error);
+  uint32_t size = obj->self_->GetStringTrackedDeviceProperty(deviceClass, vr::ETrackedDeviceProperty::Prop_ModelNumber_String, buf, sizeof(buf), &error);
   Local<String> modelName = Nan::New<String>(buf, size).ToLocalChecked();
   info.GetReturnValue().Set(modelName);
 }

--- a/deps/openvr/src/ivrsystem.cpp
+++ b/deps/openvr/src/ivrsystem.cpp
@@ -13,8 +13,7 @@ using TrackedDevicePoseArray = std::array<vr::TrackedDevicePose_t, vr::k_unMaxTr
 using TrackedDeviceIndexArray = std::array<vr::TrackedDeviceIndex_t, vr::k_unMaxTrackedDeviceCount>;
 
 //=============================================================================
-NAN_MODULE_INIT(IVRSystem::Init)
-{
+void IVRSystem::Init(Nan::Persistent<v8::Function> &constructor) {
   // Create a function template that is called in JS to create this wrapper.
   Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
 
@@ -80,8 +79,10 @@ NAN_MODULE_INIT(IVRSystem::Init)
   Nan::SetPrototypeMethod(tpl, "AcknowledgeQuit_Exiting", AcknowledgeQuit_Exiting);
   Nan::SetPrototypeMethod(tpl, "AcknowledgeQuit_UserPrompt", AcknowledgeQuit_UserPrompt);
 
+  Nan::SetPrototypeMethod(tpl, "GetModelName", GetModelName);
+
   // Set a static constructor function to reference the `New` function template.
-  constructor().Reset(Nan::GetFunction(tpl).ToLocalChecked());
+  constructor.Reset(Nan::GetFunction(tpl).ToLocalChecked());
 }
 
 //=============================================================================

--- a/deps/openvr/src/ivrsystem.cpp
+++ b/deps/openvr/src/ivrsystem.cpp
@@ -946,7 +946,6 @@ NAN_METHOD(IVRSystem::GetModelName)
 
   char buf[4096];
   vr::TrackedPropertyError error;
-  GetTrackedDeviceIndexForControllerRole(index + 1);
   uint32_t size = GetStringTrackedDeviceProperty(deviceClass, vr::ETrackedDeviceProperty::Prop_ModelNumber_String, buf, sizeof(buf), &error);
   Local<String> modelName = Nan::New<String>(buf, size)->ToLocalChecked();
   info.GetReturnValue().Set(modelName);

--- a/deps/openvr/src/ivrsystem.cpp
+++ b/deps/openvr/src/ivrsystem.cpp
@@ -946,8 +946,8 @@ NAN_METHOD(IVRSystem::GetModelName)
 
   char buf[4096];
   vr::TrackedPropertyError error;
-  uint32_t size = GetStringTrackedDeviceProperty(deviceClass, vr::ETrackedDeviceProperty::Prop_ModelNumber_String, buf, sizeof(buf), &error);
-  Local<String> modelName = Nan::New<String>(buf, size)->ToLocalChecked();
+  uint32_t size = vr::GetStringTrackedDeviceProperty(deviceClass, vr::ETrackedDeviceProperty::Prop_ModelNumber_String, buf, sizeof(buf), &error);
+  Local<String> modelName = Nan::New<String>(buf, size).ToLocalChecked();
   info.GetReturnValue().Set(modelName);
 }
 

--- a/deps/openvr/src/ivrsystem.cpp
+++ b/deps/openvr/src/ivrsystem.cpp
@@ -5,6 +5,8 @@
 #include <node.h>
 #include <openvr.h>
 
+#include <defines.h>
+
 using namespace v8;
 
 using TrackedDevicePoseArray = std::array<vr::TrackedDevicePose_t, vr::k_unMaxTrackedDeviceCount>;
@@ -927,3 +929,26 @@ NAN_METHOD(IVRSystem::AcknowledgeQuit_UserPrompt)
 
   obj->self_->AcknowledgeQuit_UserPrompt();
 }
+
+NAN_METHOD(IVRSystem::GetModelName)
+{
+  IVRSystem* obj = ObjectWrap::Unwrap<IVRSystem>(info.Holder());
+
+  if (info.Length() != 1)
+  {
+    Nan::ThrowError("Wrong number of arguments.");
+    return;
+  }
+
+  uint32_t hand = TO_UINT32(info[0]);
+  vr::ETrackedControllerRole role = static_cast<vr::ETrackedControllerRole>(hand + 1);
+  vr::TrackedDeviceIndex_t deviceClass = obj->self_->GetTrackedDeviceIndexForControllerRole(role);
+
+  char buf[4096];
+  vr::TrackedPropertyError error;
+  GetTrackedDeviceIndexForControllerRole(index + 1);
+  uint32_t size = GetStringTrackedDeviceProperty(deviceClass, vr::ETrackedDeviceProperty::Prop_ModelNumber_String, buf, sizeof(buf), &error);
+  Local<String> modelName = Nan::New<String>(buf, size)->ToLocalChecked();
+  info.GetReturnValue().Set(modelName);
+}
+

--- a/deps/openvr/src/openvr-bindings.cpp
+++ b/deps/openvr/src/openvr-bindings.cpp
@@ -10,6 +10,8 @@
 
 using namespace v8;
 
+vr::IVRSystem *vrSystem;
+
 //=============================================================================
 // inline IVRSystem *VR_Init( EVRInitError *peError, EVRApplicationType eApplicationType );
 NAN_METHOD(VR_Init)
@@ -37,13 +39,13 @@ NAN_METHOD(VR_Init)
 
   // Perform the actual wrapped call.
   vr::EVRInitError error;
-  vr::IVRSystem *system = vr::VR_Init(
+  vrSystem = vr::VR_Init(
     &error,
     static_cast<vr::EVRApplicationType>(applicationType)
   );
 
   // If the VR system failed to initialize, immediately raise a node exception.
-  if (system == nullptr)
+  if (vrSystem == nullptr)
   {
     Local<Value> err = Exception::Error(String::NewFromUtf8(Isolate::GetCurrent(), vr::VR_GetVRInitErrorAsEnglishDescription(error)));
     Local<Object>::Cast(err)->Set(String::NewFromUtf8(Isolate::GetCurrent(), "code"), Number::New(Isolate::GetCurrent(), error));
@@ -52,7 +54,7 @@ NAN_METHOD(VR_Init)
   }
 
   // Wrap the resulting system in the correct wrapper and return it.
-  auto result = IVRSystem::NewInstance(system);
+  auto result = IVRSystem::NewInstance(vrSystem);
   info.GetReturnValue().Set(result);
 }
 

--- a/deps/openvr/src/openvr-bindings.cpp
+++ b/deps/openvr/src/openvr-bindings.cpp
@@ -171,19 +171,8 @@ NAN_METHOD(VR_GetInitToken)
   info.GetReturnValue().Set(Nan::New<Number>(result));
 }
 
-NAN_METHOD(GetContext)
-{
-  Local<Object> result = Object::New(Isolate::GetCurrent());
-
-  v8::Local<v8::Object> system = v8::Object::New(v8::Isolate::GetCurrent());
-  IVRSystem::Init(system);
-  result->Set(Nan::New("system").ToLocalChecked(), system);
-
-  v8::Local<v8::Object> compositor = v8::Object::New(v8::Isolate::GetCurrent());
-  compositor->Set(Nan::New("NewCompositor").ToLocalChecked(), Nan::GetFunction(Nan::New<v8::FunctionTemplate>(NewCompositor)).ToLocalChecked());
-  IVRCompositor::Init(compositor);
-  result->Set(Nan::New("compositor").ToLocalChecked(), compositor);
-
+NAN_METHOD(GetGlobalSystem) {
+  auto result = IVRSystem::NewInstance(vrSystem);
   info.GetReturnValue().Set(result);
 }
 
@@ -200,7 +189,8 @@ Local<Object> makeOpenVR() {
   exports->Set(Nan::New("VR_GetVRInitErrorAsSymbol").ToLocalChecked(), Nan::GetFunction(Nan::New<v8::FunctionTemplate>(VR_GetVRInitErrorAsSymbol)).ToLocalChecked());
   exports->Set(Nan::New("VR_GetVRInitErrorAsEnglishDescription").ToLocalChecked(), Nan::GetFunction(Nan::New<v8::FunctionTemplate>(VR_GetVRInitErrorAsEnglishDescription)).ToLocalChecked());
   exports->Set(Nan::New("VR_GetInitToken").ToLocalChecked(), Nan::GetFunction(Nan::New<v8::FunctionTemplate>(VR_GetInitToken)).ToLocalChecked());
-  exports->Set(Nan::New("getContext").ToLocalChecked(), Nan::GetFunction(Nan::New<v8::FunctionTemplate>(GetContext)).ToLocalChecked());
+  exports->Set(Nan::New("NewCompositor").ToLocalChecked(), Nan::GetFunction(Nan::New<v8::FunctionTemplate>(NewCompositor)).ToLocalChecked());
+  exports->Set(Nan::New("GetGlobalSystem").ToLocalChecked(), Nan::GetFunction(Nan::New<v8::FunctionTemplate>(GetGlobalSystem)).ToLocalChecked());
 
   return scope.Escape(exports);
 }

--- a/src/VR.js
+++ b/src/VR.js
@@ -727,11 +727,10 @@ function getGamepads() {
     if (!globalGamepads) {
       globalGamepads = _makeGlobalGamepads();
     }
+    const gamepads = globalGamepads.main.slice();
 
     globalGamepads.main[0].id = getControllerID(hmdType, 'left');
     globalGamepads.main[1].id = getControllerID(hmdType, 'right');
-
-    const gamepads = globalGamepads.main.slice();
 
     if (hmdType === 'openvr') {
       for (let i = 0; i < globalGamepads.tracker.length; i++) {

--- a/src/VR.js
+++ b/src/VR.js
@@ -708,6 +708,8 @@ const controllerIDs = {
   fake: 'OpenVR Gamepad',
   openvr: 'OpenVR Gamepad',
   openvrTracker: 'OpenVR Tracker',
+  indexLeft: 'Valve Index (Left)',
+  indexRight: 'Valve Index (Right)',
   oculusLeft: 'Oculus Touch (Left)',
   oculusRight: 'Oculus Touch (Right)',
   // oculusMobile: 'Oculus Go',
@@ -726,8 +728,9 @@ function getGamepads() {
     let hmdType = getHMDType();
     if (hmdType === 'openvr') {
       const vrSystem = nativeOpenVR.GetGlobalSystem();
-      const model = vrSystem.GetModelName();
-      console.log('got model name'); // XXX
+      if (/^Knuckles/.test(vrSystem.GetModelName(0) || vrSystem.GetModelName(1))) {
+        hmdType = 'index';
+      }
     }
 
     if (!globalGamepads) {

--- a/src/VR.js
+++ b/src/VR.js
@@ -723,7 +723,13 @@ function getControllerID(hmdType, hand) {
 }
 function getGamepads() {
   if (GlobalContext.xrState.isPresenting[0]) {
-    const hmdType = getHMDType();
+    let hmdType = getHMDType();
+    if (hmdType === 'openvr') {
+      const vrSystem = nativeOpenVR.GetGlobalSystem();
+      const model = vrSystem.GetModelName();
+      console.log('got model name'); // XXX
+    }
+
     if (!globalGamepads) {
       globalGamepads = _makeGlobalGamepads();
     }

--- a/src/index.js
+++ b/src/index.js
@@ -443,12 +443,10 @@ const _waitHandleRequest = ({type, keypath}) => {
       xrState.renderWidth[0] = halfWidth;
       xrState.renderHeight[0] = height;
     } else if (hmdType === 'openvr') {
-      const vrContext = nativeBindings.nativeOpenVR.getContext();
       const system = nativeBindings.nativeOpenVR.VR_Init(nativeBindings.nativeOpenVR.EVRApplicationType.Scene);
-      const compositor = vrContext.compositor.NewCompositor();
+      const compositor = nativeBindings.nativeOpenVR.NewCompositor();
       // const lmContext = topVrPresentState.lmContext || (nativeLm && new nativeLm());
 
-      topVrPresentState.vrContext = vrContext;
       topVrPresentState.vrSystem = system;
       topVrPresentState.vrCompositor = compositor;
 


### PR DESCRIPTION
Exokit currently calls any gamepad coming from OpenVR as [`OpenVR Gamepad`](https://github.com/exokitxr/exokit/blob/568fdb45186f2877466424bbbd5b8c93ebf8fdb7/src/VR.js#L708). The problem is that sites cannot use this to distinguish the various gamepads for displaying a rendering model.

This PR adds a mapping system for distinguishing OpenVR controller models on the gamepad `.id`, as we already do for other headset cases.