### PR TITLE
Quest/Android build Debian Buster incompat

### DIFF
--- a/android.Dockerfile
+++ b/android.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM debian:stretch
 
 RUN apt-get update -y && \
   apt-get install -y \


### PR DESCRIPTION
Debian 10 (Buster) was recently released, causing the Dockerfile for `debian:latest` to be updated, which causes Java to update.

Unfortunately `android-sdk` only supports old Java versions, causing build failures:

```
[91mException in thread "main" [0m[91mjava.lang.NoClassDefFoundError: javax/xml/bind/annotation/XmlSchema
[0m[91m	at com.android.repository.api.SchemaModule$SchemaModuleVersion.<init>(SchemaModule.java:156)
[0m[91m	at com.android.repository.api.SchemaModule.<init>(SchemaModule.java:75)
	at com.android.sdklib.repository.AndroidSdkHandler.<clinit>(AndroidSdkHandler.java:81)[0m[91m
	at com.android.sdklib.tool.sdkmanager.SdkManagerCli.main(SdkManagerCli.java:73)
[0m[91m	at com.android.sdklib.tool.sdkmanager.SdkManagerCli.main(SdkManagerCli.java:48)
[0m[91mCaused by: java.lang.ClassNotFoundException: javax.xml.bind.annotation.XmlSchema
[0m[91m	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:583)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
[0m[91m	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
```

This PR fixes that by downgrading to old Debian Stretch until `android-sdk` can work with a modern Java.