### PR TITLE
Clear XR framebuffer in Window context

### DIFF
--- a/src/Window.js
+++ b/src/Window.js
@@ -959,7 +959,7 @@ const _makeRequestAnimationFrame = window => (fn, priority = 0) => {
     }
     prevSyncs.length = 0;
   };
-  const _bindXrFramebuffer = layered => {
+  const _bindXrFramebuffer = (top, layered) => {
     if (vrPresentState.glContext) {
       nativeWindow.setCurrentWindowContext(vrPresentState.glContext.getWindowHandle());
 
@@ -972,7 +972,7 @@ const _makeRequestAnimationFrame = window => (fn, priority = 0) => {
           nativeWindow.bindVrChildFbo(vrPresentState.glContext, vrPresentState.fbo, GlobalContext.xrState.tex[0], GlobalContext.xrState.depthTex[0]);
         }
         
-        vrPresentState.glContext.setClearEnabled(false);
+        vrPresentState.glContext.setClearEnabled(top);
       } else {
         if (GlobalContext.xrState.aaEnabled[0]) {
           vrPresentState.glContext.setDefaultFramebuffer(vrPresentState.glContext.framebuffer.msFbo);
@@ -1122,6 +1122,7 @@ const _makeRequestAnimationFrame = window => (fn, priority = 0) => {
   const _makeRenderChild = window => (syncs, layered) => window.runAsync({
     method: 'tickAnimationFrame',
     syncs,
+    top: false,
     layered: layered && vrPresentState.layers.some(layer => layer.contentWindow === window),
   });
   const _collectRenders = () => windows.map(_makeRenderChild).concat([_renderLocal]);
@@ -1145,9 +1146,9 @@ const _makeRequestAnimationFrame = window => (fn, priority = 0) => {
     };
     _recurse(0);
   });
-  window.tickAnimationFrame = async ({syncs = [], layered = false}) => {
+  window.tickAnimationFrame = async ({syncs = [], top = true, layered = false}) => {
     _clearPrevSyncs();
-    _bindXrFramebuffer(layered);
+    _bindXrFramebuffer(top, layered);
     _emitXrEvents(); 
     return _render(syncs, layered);
   };

--- a/src/index.js
+++ b/src/index.js
@@ -1175,6 +1175,7 @@ const _startTopRenderLoop = () => {
   const _tickAnimationFrame = window => window.runAsync({
     method: 'tickAnimationFrame',
     syncs: topVrPresentState.hmdType !== null ? [nativeBindings.nativeWindow.getSync()] : [],
+    top: true,
     layered: true,
   })
     .catch(err => {

--- a/src/index.js
+++ b/src/index.js
@@ -1172,11 +1172,6 @@ const _startTopRenderLoop = () => {
     }
     prevSyncs.length = 0;
   };
-  const _clearXrFramebuffer = () => {
-    if (topVrPresentState.hmdType !== null) {
-      nativeBindings.nativeWindow.clearFramebuffer(xrState.aaEnabled[0] ? topVrPresentState.msFbo : topVrPresentState.fbo);
-    }
-  };
   const _tickAnimationFrame = window => window.runAsync({
     method: 'tickAnimationFrame',
     syncs: topVrPresentState.hmdType !== null ? [nativeBindings.nativeWindow.getSync()] : [],
@@ -1307,7 +1302,6 @@ const _startTopRenderLoop = () => {
     }
 
     _clearPrevSyncs();
-    _clearXrFramebuffer();
     await _tickAnimationFrames();
 
     if (args.performance) {


### PR DESCRIPTION
For reality tabs multi-site composition, Exokit needs to exercise some control over clearing the framebuffer, or else reality tabs would stomp over each other's frames.

We've been doing this at the top index.js renderloop and eliding the clear in the window contexts, but this presents the problem that the intended clear setting of the top level reality tab does not apply -- specifically the depth/stencil/color clear settings.

This PR moves the clear to the top level XR reality tab window instead of `index.js`, so that top level tab is now in charge of the clear setting, fixing some THREE.js corner cases.