### PR TITLE
FakeXRDisplay manual enable/disable

### DIFF
--- a/examples/fakeXrDisplay.js
+++ b/examples/fakeXrDisplay.js
@@ -2,6 +2,7 @@
 
 window._makeFakeXrDisplay = () => {
   const fakeXrDisplay = new FakeXRDisplay();
+  fakeXrDisplay.enable();
   fakeXrDisplay.enter = async ({renderer, animate, layers}) => {
     const {domElement: canvas} = renderer;
 

--- a/src/VR.js
+++ b/src/VR.js
@@ -563,8 +563,6 @@ class FakeXRDisplay {
   constructor() {
     this.position = new THREE.Vector3();
     this.quaternion = new THREE.Quaternion();
-
-    GlobalContext.xrState.fakeVrDisplayEnabled[0] = 1;
   }
 
   pushHmdUpdate(position = this.position, quaternion = this.quaternion) {
@@ -605,10 +603,16 @@ class FakeXRDisplay {
       gamepad.connected = true;
     }
   }
-
   pushUpdate() {
     this.pushHmdUpdate();
     this.pushGamepadsUpdate();
+  }
+
+  enable() {
+    GlobalContext.xrState.fakeVrDisplayEnabled[0] = 1;
+  }
+  disable() {
+    GlobalContext.xrState.fakeVrDisplayEnabled[0] = 0;
   }
 
   get width() {


### PR DESCRIPTION
The variable `GlobalContext.xrState.fakeVrDisplayEnabled` controls whether Exokit uses the fake xr display emulation when entering XR.

This was previously set permanently on `FakeXRDisplay` construction, but it's helpful to have a way to turn on/off the fake xr display emulation. This PR breaks that flag setter out into `enable`/`display` methods and updates `realitytabs.html` to handle that case.