### PR TITLE
Clean up IVRSystem referencing

### DIFF
--- a/deps/openvr/src/openvr-bindings.cpp
+++ b/deps/openvr/src/openvr-bindings.cpp
@@ -191,8 +191,12 @@ NAN_METHOD(VR_GetInitToken)
 }
 
 NAN_METHOD(GetGlobalSystem) {
-  auto result = IVRSystem::NewInstance(vrSystem);
-  info.GetReturnValue().Set(result);
+  if (vrSystem != nullptr) {
+    auto result = IVRSystem::NewInstance(vrSystem);
+    info.GetReturnValue().Set(result);
+  } else {
+    info.GetReturnValue().Set(Nan::Null());
+  }
 }
 
 Local<Object> makeOpenVR() {

--- a/deps/openvr/src/openvr-bindings.cpp
+++ b/deps/openvr/src/openvr-bindings.cpp
@@ -10,7 +10,7 @@
 
 using namespace v8;
 
-vr::IVRSystem *vrSystem;
+vr::IVRSystem *vrSystem = nullptr;
 
 //=============================================================================
 // inline IVRSystem *VR_Init( EVRInitError *peError, EVRApplicationType eApplicationType );

--- a/src/VR.js
+++ b/src/VR.js
@@ -738,7 +738,7 @@ function getGamepads() {
     let hmdType = getHMDType();
     if (hmdType === 'openvr') {
       const vrSystem = nativeOpenVR.GetGlobalSystem();
-      if (/^Knuckles/.test(vrSystem.GetModelName(0) || vrSystem.GetModelName(1))) {
+      if (vrSystem && /^Knuckles/.test(vrSystem.GetModelName(0) || vrSystem.GetModelName(1))) {
         hmdType = 'index';
       }
     }

--- a/src/XR.js
+++ b/src/XR.js
@@ -205,9 +205,9 @@ class XRSession extends EventTarget {
   set baseLayer(baseLayer) {
     this.renderState.update({baseLayer});
   }
-  end() {
+  async end() {
+    await this.onexitpresent();
     this.emit('end');
-    return Promise.resolve();
   }
   update() {
     const inputSources = this.getInputSources();


### PR DESCRIPTION
In Exokit's Valve Index support we needed to read the OpenVR system reference from the window thread. However, this can happen before the system is initialized, resulting in a wild read.

This PR detects that case and guards it with a null check.