### PR TITLE
Support window.event

### DIFF
--- a/src/Event.js
+++ b/src/Event.js
@@ -32,6 +32,7 @@ class EventTarget extends EventEmitter {
 
   dispatchEvent(event) {
     event.target = this;
+    global.event = event;
 
     const _emit = (node, event) => {
       event.currentTarget = this;
@@ -46,7 +47,6 @@ class EventTarget extends EventEmitter {
     };
     const _recurse = (node, event) => {
       _emit(node, event);
-
       if (event.bubbles && node instanceof GlobalContext.Document) {
         _emit(node.defaultView, event);
       }
@@ -56,6 +56,8 @@ class EventTarget extends EventEmitter {
       }
     };
     _recurse(this, event);
+    
+    global.event = null;
   }
 
   _emit() { // need to call this instead of EventEmitter.prototype.emit because some frameworks override HTMLElement.prototype.emit()

--- a/src/Window.js
+++ b/src/Window.js
@@ -515,7 +515,7 @@ const _makeRequestAnimationFrame = window => (fn, priority = 0) => {
       intervals[id] = null;
     }
   })(clearInterval);
-  window.event = new Event(); // XXX this needs to track the current event
+  window.event = null;
   window.localStorage = new LocalStorage(path.join(options.dataPath, '.localStorage'));
   window.sessionStorage = new LocalStorage(path.join(options.dataPath, '.sessionStorage'));
   window.indexedDB = indexedDB;


### PR DESCRIPTION
`window.event` is supposed to track the currently processed event per the spec.

Sites in the wild depend on this behavior, so this PR enables that tracking in Exokit.