### PR TITLE
Only use WebGL contexts for browser texture population

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2086,7 +2086,7 @@ class HTMLIFrameElement extends HTMLSrcableElement {
                 this.browser = null;
               }
 
-              const context = GlobalContext.contexts.find(context => context.canvas.ownerDocument === this.ownerDocument);
+              const context = GlobalContext.contexts.find(context => ['WebGLRenderingContext', 'WebGL2RenderingContext'].includes(context.constructor.name) && context.canvas.ownerDocument === this.ownerDocument);
               if (context) {
                 const browser = (() => {
                   const width = this.width || context.canvas.ownerDocument.defaultView.innerWidth;


### PR DESCRIPTION
Exokit's 2D browser rendering (via Electron on Desktop) hijacks the user GL context to do texture population of the browser frame data.

Unfortunately, we weren't checking for whether we were using a 2D canvas context for this, resulting in a throw from the Electron driver. This adds a check to make sure we only source the hijack from the WebGL context.