### PR TITLE
Revert FakeXRDevice framebuffer clearing in windows

### DIFF
--- a/src/Window.js
+++ b/src/Window.js
@@ -959,7 +959,7 @@ const _makeRequestAnimationFrame = window => (fn, priority = 0) => {
     }
     prevSyncs.length = 0;
   };
-  const _bindXrFramebuffer = (top, layered) => {
+  const _bindXrFramebuffer = layered => {
     if (vrPresentState.glContext) {
       nativeWindow.setCurrentWindowContext(vrPresentState.glContext.getWindowHandle());
 
@@ -972,7 +972,7 @@ const _makeRequestAnimationFrame = window => (fn, priority = 0) => {
           nativeWindow.bindVrChildFbo(vrPresentState.glContext, vrPresentState.fbo, GlobalContext.xrState.tex[0], GlobalContext.xrState.depthTex[0]);
         }
         
-        vrPresentState.glContext.setClearEnabled(top);
+        vrPresentState.glContext.setClearEnabled(false);
       } else {
         if (GlobalContext.xrState.aaEnabled[0]) {
           vrPresentState.glContext.setDefaultFramebuffer(vrPresentState.glContext.framebuffer.msFbo);
@@ -1122,7 +1122,6 @@ const _makeRequestAnimationFrame = window => (fn, priority = 0) => {
   const _makeRenderChild = window => (syncs, layered) => window.runAsync({
     method: 'tickAnimationFrame',
     syncs,
-    top: false,
     layered: layered && vrPresentState.layers.some(layer => layer.contentWindow === window),
   });
   const _collectRenders = () => windows.map(_makeRenderChild).concat([_renderLocal]);
@@ -1146,9 +1145,9 @@ const _makeRequestAnimationFrame = window => (fn, priority = 0) => {
     };
     _recurse(0);
   });
-  window.tickAnimationFrame = async ({syncs = [], top = true, layered = false}) => {
+  window.tickAnimationFrame = async ({syncs = [], layered = false}) => {
     _clearPrevSyncs();
-    _bindXrFramebuffer(top, layered);
+    _bindXrFramebuffer(layered);
     _emitXrEvents(); 
     return _render(syncs, layered);
   };

--- a/src/index.js
+++ b/src/index.js
@@ -1175,7 +1175,6 @@ const _startTopRenderLoop = () => {
   const _tickAnimationFrame = window => window.runAsync({
     method: 'tickAnimationFrame',
     syncs: topVrPresentState.hmdType !== null ? [nativeBindings.nativeWindow.getSync()] : [],
-    top: true,
     layered: true,
   })
     .catch(err => {

--- a/src/index.js
+++ b/src/index.js
@@ -1172,6 +1172,11 @@ const _startTopRenderLoop = () => {
     }
     prevSyncs.length = 0;
   };
+  const _clearXrFramebuffer = () => {
+    if (topVrPresentState.hmdType !== null) {
+      nativeBindings.nativeWindow.clearFramebuffer(xrState.aaEnabled[0] ? topVrPresentState.msFbo : topVrPresentState.fbo);
+    }
+  };
   const _tickAnimationFrame = window => window.runAsync({
     method: 'tickAnimationFrame',
     syncs: topVrPresentState.hmdType !== null ? [nativeBindings.nativeWindow.getSync()] : [],
@@ -1302,6 +1307,7 @@ const _startTopRenderLoop = () => {
     }
 
     _clearPrevSyncs();
+    _clearXrFramebuffer();
     await _tickAnimationFrames();
 
     if (args.performance) {


### PR DESCRIPTION
Reverts https://github.com/exokitxr/exokit/pull/1304.

It turns out that reality tab users have differing opinions and timing disciplines with regard to clearing the GL framebuffer. Therefore revert to the case of disallowing it, and having the engine autoclear per frame.

The recommended way to handle clear in the reality tabs case is to draw a skybox with the appropriate clearing -- this will blend correctly in all reality tab orderings due to z-buffer.