### PR TITLE
WebGL getContextAttributes behavior

### DIFF
--- a/deps/exokit-bindings/webglcontext/include/webgl.h
+++ b/deps/exokit-bindings/webglcontext/include/webgl.h
@@ -355,7 +355,7 @@ public:
   static NAN_METHOD(GetFragDataLocation);
   static NAN_METHOD(GetSupportedExtensions);
   static NAN_METHOD(GetExtension);
-  static NAN_METHOD(GetContextAttributes);
+  // static NAN_METHOD(GetContextAttributes);
 
   static NAN_METHOD(CheckFramebufferStatus);
 

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -2206,7 +2206,7 @@ std::pair<Local<Object>, Local<FunctionTemplate>> WebGLRenderingContext::Initial
   Nan::SetMethod(proto, "getFragDataLocation", glCallWrap<GetFragDataLocation>);
   Nan::SetMethod(proto, "getSupportedExtensions", glCallWrap<GetSupportedExtensions>);
   Nan::SetMethod(proto, "getExtension", glCallWrap<GetExtension>);
-  Nan::SetMethod(proto, "getContextAttributes", glCallWrap<GetContextAttributes>);
+  // Nan::SetMethod(proto, "getContextAttributes", glCallWrap<GetContextAttributes>);
 
   Nan::SetMethod(proto, "checkFramebufferStatus", glCallWrap<CheckFramebufferStatus>);
 
@@ -5966,7 +5966,7 @@ NAN_METHOD(WebGLRenderingContext::GetExtension) {
   }
 }
 
-NAN_METHOD(WebGLRenderingContext::GetContextAttributes) {
+/* NAN_METHOD(WebGLRenderingContext::GetContextAttributes) {
   Local<Object> result = Object::New(Isolate::GetCurrent());
   result->Set(JS_STR("alpha"), JS_BOOL(true));
   result->Set(JS_STR("antialias"), JS_BOOL(true));
@@ -5976,7 +5976,7 @@ NAN_METHOD(WebGLRenderingContext::GetContextAttributes) {
   result->Set(JS_STR("preserveDrawingBuffer"), JS_BOOL(false));
   result->Set(JS_STR("stencil"), JS_BOOL(false));
   info.GetReturnValue().Set(result);
-}
+} */
 
 NAN_METHOD(WebGLRenderingContext::CheckFramebufferStatus) {
   GLenum target = TO_INT32(info[0]);

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -5329,6 +5329,7 @@ NAN_METHOD(WebGLRenderingContext::GetParameter) {
     case GL_MAX_VERTEX_UNIFORM_BLOCKS:
     case GL_MAX_VERTEX_UNIFORM_COMPONENTS:
     case GL_MIN_PROGRAM_TEXEL_OFFSET:
+    case GL_MAX_VIEWS_OVR:
     {
       // return an int
       GLint param;

--- a/src/native-bindings.js
+++ b/src/native-bindings.js
@@ -72,13 +72,22 @@ const _decorateGlIntercepts = gl => {
 const _onGl3DConstruct = (gl, canvas, attrs) => {
   const canvasWidth = canvas.width || innerWidth;
   const canvasHeight = canvas.height || innerHeight;
+  attrs = attrs || {};
+  attrs = {
+    alpha: !!attrs.alpha,
+    antialias: !!attrs.antialias,
+    depth: !!attrs.depth,
+    desynchronized: !!attrs.desynchronized,
+    failIfMajorPerformanceCaveat: !!attrs.failIfMajorPerformanceCaveat,
+    powerPreference: attrs.powerPreference || 'default',
+    premultipliedAlpha: !!attrs.premultipliedAlpha,
+    preserveDrawingBuffer: !!attrs.preserveDrawingBuffer,
+    stencil: !!attrs.stencil,
+  };
 
   gl.d = 3;
   gl.canvas = canvas;
-  gl.attrs = {
-    antialias: !!attrs.antialias,
-    desynchronized: !!attrs.desynchronized,
-  };
+  gl.getContextAttributes = () => attrs;
 
   const document = canvas.ownerDocument;
   const window = document.defaultView;
@@ -280,7 +289,7 @@ const _onGl3DConstruct = (gl, canvas, attrs) => {
       }
     });
     
-    const [fbo, tex, depthTex, msFbo, msTex, msDepthTex] = gl.attrs.desynchronized ? [
+    const [fbo, tex, depthTex, msFbo, msTex, msDepthTex] = attrs.desynchronized ? [
       0, 0, 0, 0, 0, 0,
     ] : nativeWindow.createRenderTarget(gl, canvasWidth, canvasHeight);
     if (msFbo) {
@@ -301,7 +310,7 @@ const _onGl3DConstruct = (gl, canvas, attrs) => {
       event: gl.framebuffer,
     });
     gl.resize = (width, height) => {
-      if (!gl.attrs.desynchronized && gl.framebuffer.type === 'canvas') {
+      if (!attrs.desynchronized && gl.framebuffer.type === 'canvas') {
         nativeWindow.setCurrentWindowContext(windowHandle);
         const [newFbo, newTex, newDepthTex, newMsFbo, newMsTex, newMsDepthTex] = nativeWindow.resizeRenderTarget(gl, width, height, fbo, tex, depthTex, msFbo, msTex, msDepthTex);
 
@@ -364,7 +373,7 @@ const _onGl3DConstruct = (gl, canvas, attrs) => {
     gl.id = Atomics.add(GlobalContext.xrState.id, 0) + 1;
     GlobalContext.contexts.push(gl);
 
-    if (gl.attrs.antialias) {
+    if (attrs.antialias) {
       GlobalContext.xrState.aaEnabled[0] = 1;
     }
   } else {


### PR DESCRIPTION
Previously we were making up the results of WebGL's `getContextAttributes` method. However, THREE.js checks for correct results here for enabling/disabling features.

Therefore, this PR makes `getContextAttributes` return the normalized attributes values that were originally passed in during context creation, as THREE.js expects.