### PR TITLE
WebGL instanceof inheritance

### DIFF
--- a/src/native-bindings.js
+++ b/src/native-bindings.js
@@ -394,11 +394,12 @@ bindings.nativeGl = (nativeGl => {
   return WebGLRenderingContext;
 })(bindings.nativeGl);
 bindings.nativeGl2 = (nativeGl2 => {
-  function WebGL2RenderingContext(canvas, attrs) {
-    const gl = new nativeGl2();
-    _decorateGlIntercepts(gl);
-    _onGl3DConstruct(gl, canvas, attrs);
-    return gl;
+  class WebGL2RenderingContext extends nativeGl2 {
+    constructor(canvas, attrs) {
+      super();
+      _decorateGlIntercepts(this);
+      _onGl3DConstruct(this, canvas, attrs);
+    }
   }
   for (const k in nativeGl2) {
     WebGL2RenderingContext[k] = nativeGl2[k];

--- a/src/native-bindings.js
+++ b/src/native-bindings.js
@@ -381,11 +381,12 @@ const _onGl3DConstruct = (gl, canvas, attrs) => {
   }
 };
 bindings.nativeGl = (nativeGl => {
-  function WebGLRenderingContext(canvas, attrs) {
-    const gl = new nativeGl();
-    _decorateGlIntercepts(gl);
-    _onGl3DConstruct(gl, canvas, attrs);
-    return gl;
+  class WebGLRenderingContext extends nativeGl {
+    constructor(canvas, attrs) {
+      super();
+      _decorateGlIntercepts(this);
+      _onGl3DConstruct(this, canvas, attrs);
+    }
   }
   for (const k in nativeGl) {
     WebGLRenderingContext[k] = nativeGl[k];


### PR DESCRIPTION
The way that Exokit creates WebGL contexts, the resulting `gl` object was not actually an instance of the `WebGLRenderingContext` class -- same for `WebGL2RenderingContext`.

This PR cleans that up by refactoring the native binding to use class inheritance, making `instanceof` checks pass as expected.