### PR TITLE
WebSocket origin header setting support

### DIFF
--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -179,7 +179,27 @@ class Worker extends EventTarget {
     }
     return XMLHttpRequest;
   })(XMLHttpRequest);
-  self.WebSocket = WebSocket;
+  self.WebSocket = (Old => {
+    class WebSocket extends Old {
+      constructor(url, protocols, options) {
+        if (typeof protocols === 'string') {
+          protocols = [protocols];
+        }
+        if (typeof protocols == 'object' && !Array.isArray(protocols) && protocols !== null) {
+          options = protocols;
+          protocols = undefined;
+        }
+        options = options || {};
+        options.origin = options.origin || (self.location.protocol + '//' + self.location.host);
+
+        super(url, protocols, options);
+      }
+    }
+    for (const k in Old) {
+      WebSocket[k] = Old[k];
+    }
+    return WebSocket;
+  })(WebSocket);
   self.FileReader = FileReader;
 
   self.performance = performance;


### PR DESCRIPTION
`WebSocket` is supposed to use an `Origin` header on its initial connection attempt, which is checked by backends -- notably `webpack-dev-server`.

Our websocket library supports setting the origin header in the options, but Exokit wasn't binding that option to implicit value in the calling window context. This PR adds a WebSocket wrapper which attaches the origin from the `window`/`self` `.location`.