### PR TITLE
Bump window-xhr version

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "window-fetch": "0.0.13",
     "window-ls": "0.0.1",
     "window-selector": "0.0.8",
-    "window-xhr": "0.0.40",
+    "window-xhr": "0.0.41",
     "ws": "^6.2.0"
   },
   "optionalDependencies": {

--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -162,23 +162,7 @@ class Worker extends EventTarget {
   self.Headers = Headers;
   self.Blob = Blob;
   self.FormData = FormData;
-  self.XMLHttpRequest = (Old => {
-    class XMLHttpRequest extends Old {
-      get response() {
-        if (this.responseType === 'blob') {
-          return new Blob(super.response, {
-            type: this.getResponseHeader('content-type') || 'application/octet-stream',
-          });
-        } else {
-          return super.response;
-        }
-      }
-    }
-    for (const k in Old) {
-      XMLHttpRequest[k] = Old[k];
-    }
-    return XMLHttpRequest;
-  })(XMLHttpRequest);
+  self.XMLHttpRequest = XMLHttpRequest;
   self.WebSocket = WebSocket;
   self.FileReader = FileReader;
 


### PR DESCRIPTION
Ingests https://github.com/modulesio/window-xhr/pull/11.

Makes `window-xhr` (correctly) handle the `.responseType === 'blob'` case.

This previously was not working, since `window-xhr` sets a local interceptor on `this`, which takes precedence over the class interceptor we were using in `WindowBase.js`.