### PR TITLE
Bugfix Element append() method

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -844,7 +844,7 @@ class Element extends Node {
 
   append() {
     for (let i = 0; i < arguments.length; i++) {
-      const content = arguments[0];
+      const content = arguments[i];
       if (typeof content === 'string') {
         this.appendChild(this.ownerDocument.createTextNode(content));
       } else {


### PR DESCRIPTION
`Element.append()` was only iterating the first element.

This method turns out to be rarely used in WebXR land, but causes broken results in components that depend on it.