### PR TITLE
Add MediaStream stub methods

### DIFF
--- a/src/Window.js
+++ b/src/Window.js
@@ -617,7 +617,14 @@ const _makeRequestAnimationFrame = window => (fn, priority = 0) => {
   /* window.MediaStreamTrack = MediaStreamTrack;
   window.RTCRtpReceiver = RTCRtpReceiver;
   window.RTCRtpSender = RTCRtpSender; */
-  window.MediaStream = class MediaStream {};
+  window.MediaStream = class MediaStream {
+    getAudioTracks() {
+      return [];
+    }
+    getVideoTracks() {
+      return [];
+    }
+  };
 
   window.RTCPeerConnection = RTCPeerConnection;
   window.webkitRTCPeerConnection = RTCPeerConnection; // for feature detection


### PR DESCRIPTION
`getAudioTracks`/`getVideoTracks` was used by NAF components, causing crashing.

We have actualy [WebRTC audio support in a separate PR](https://github.com/exokitxr/exokit/pull/866).