### PR TITLE
Add some HTMLIFrameElement stub methods

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2062,6 +2062,8 @@ class HTMLIFrameElement extends HTMLSrcableElement {
     const _resetContentWindowDocument = () => {
       const contentDocument = {
         _emit() {},
+        on() {},
+        removeListener() {},
         open() {},
         write() {},
         close() {},


### PR DESCRIPTION
These were used by `MutationObserver.js` in the `iframe` listener case, causing crashing.