### PR TITLE
MutationObserver bugfixes

### DIFF
--- a/src/Document.js
+++ b/src/Document.js
@@ -172,6 +172,7 @@ function initDocument (document, window) {
       }
 
       body.childNodes = bodyChildNodes;
+      body._emit('children', Array.from(bodyChildNodes), [], null, null);
 
       try {
         await GlobalContext._runHtml(document.body, window);

--- a/src/MutationObserver.js
+++ b/src/MutationObserver.js
@@ -4,8 +4,7 @@ const {process} = global;
 const emptyNodeList = new NodeList();
 
 class MutationRecord {
-  constructor(type, target, addedNodes, removedNodes, previousSibling, nextSibling,
-              attributeName, attributeNamespace, oldValue) {
+  constructor(type, target, addedNodes, removedNodes, previousSibling, nextSibling, attributeName, attributeNamespace, oldValue) {
     this.type = type;
     this.target = target;
     this.addedNodes = addedNodes;

--- a/src/MutationObserver.js
+++ b/src/MutationObserver.js
@@ -25,7 +25,7 @@ class MutationObserver {
 
     this.queue = [];
     this.bindings = new Map();
-    this.callbacks = new WeakMap();
+    this.listeners = new WeakMap();
   }
 
   observe(el, options) {
@@ -91,7 +91,7 @@ class MutationObserver {
           el.on('value', _value);
         }
 
-        this.callbacks.set(el, [_attribute, _children, _value]);
+        this.listeners.set(el, [_attribute, _children, _value]);
       }
     };
 
@@ -104,13 +104,13 @@ class MutationObserver {
 
   unbind(el, options) {
     const _unbind = el => {
-      const callbacks = this.callbacks.get(el);
-      if (callbacks) {
+      const listeners = this.listeners.get(el);
+      if (listeners) {
         const [
           _attribute,
           _children,
           _value,
-        ] = callbacks;
+        ] = listeners;
         if (_attribute) {
           el.removeListener('attribute', _attribute);
         }
@@ -120,7 +120,7 @@ class MutationObserver {
         if (_value) {
           el.removeListener('value', _value);
         }
-        this.callbacks.delete(el);
+        this.listeners.delete(el);
       }
     };
 


### PR DESCRIPTION
This fixes several bugs in the MutationObserver that were causing wonky booting of DOM-heavy apps, particularly A-Frame.

- Respect `.observe` options, especially `childList`
- Allow multiple `MutationObserver` `.observe`
- Support `MutationObserver` on `document`