### PR TITLE
Default HTMLIFrameElement child window hiddenness to d 3

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2201,7 +2201,7 @@ class HTMLIFrameElement extends HTMLSrcableElement {
                   parent,
                   top,
                   htmlString,
-                  hidden: true,
+                  hidden: this.d === 3,
                   xrOffsetBuffer: this.xrOffset._buffer,
                   onnavigate: (href) => {
                     this.readyState = null;
@@ -2316,7 +2316,7 @@ class HTMLIFrameElement extends HTMLSrcableElement {
 
   get d() {
     const d = parseInt(this.getAttribute('d') + '', 10);
-    return isFinite(d) ? d : 3;
+    return isFinite(d) ? d : null;
   }
   set d(value) {
     if (typeof value === 'number' && isFinite(value)) {


### PR DESCRIPTION
This allows the THREE.js examples page to load child GL contexts into windows (non-`d` `iframe`s).

Related: https://github.com/exokitxr/exokit/pull/1255