### PR TITLE
Sync contextless 2d iframes

### DIFF
--- a/deps/exokit-bindings/egl/src/egl.cc
+++ b/deps/exokit-bindings/egl/src/egl.cc
@@ -119,6 +119,14 @@ NAN_METHOD(HasCurrentWindowContext) {
   info.GetReturnValue().Set(JS_BOOL(currentWindow != nullptr));
 }
 
+NAN_METHOD(GetCurrentWindowContext) {
+  if (currentWindow != nullptr) {
+    info.GetReturnValue().Set(pointerToArray(currentWindow));
+  } else {
+    info.GetReturnValue().Set(Nan::Null());
+  }
+}
+
 NAN_METHOD(SetCurrentWindowContext) {
   NATIVEwindow *window = (NATIVEwindow *)arrayToPointer(Local<Array>::Cast(info[0]));
   SetCurrentWindowContext(window);
@@ -427,6 +435,7 @@ Local<Object> makeWindow() {
   Nan::SetMethod(target, "blitTopFrameBuffer", egl::BlitTopFrameBuffer);
   Nan::SetMethod(target, "blitChildFrameBuffer", egl::BlitChildFrameBuffer);
   Nan::SetMethod(target, "hasCurrentWindowContext", egl::HasCurrentWindowContext);
+  Nan::SetMethod(target, "getCurrentWindowContext", egl::GetCurrentWindowContext);
   Nan::SetMethod(target, "setCurrentWindowContext", egl::SetCurrentWindowContext);
 
   return scope.Escape(target);

--- a/deps/exokit-bindings/egl/src/egl.cc
+++ b/deps/exokit-bindings/egl/src/egl.cc
@@ -115,6 +115,10 @@ void SetCurrentWindowContext(NATIVEwindow *window) {
   }
 } */
 
+NAN_METHOD(HasCurrentWindowContext) {
+  info.GetReturnValue().Set(JS_BOOL(currentWindow != nullptr));
+}
+
 NAN_METHOD(SetCurrentWindowContext) {
   NATIVEwindow *window = (NATIVEwindow *)arrayToPointer(Local<Array>::Cast(info[0]));
   SetCurrentWindowContext(window);
@@ -422,6 +426,7 @@ Local<Object> makeWindow() {
   Nan::SetMethod(target, "setClipboard", egl::SetClipboard);
   Nan::SetMethod(target, "blitTopFrameBuffer", egl::BlitTopFrameBuffer);
   Nan::SetMethod(target, "blitChildFrameBuffer", egl::BlitChildFrameBuffer);
+  Nan::SetMethod(target, "hasCurrentWindowContext", egl::HasCurrentWindowContext);
   Nan::SetMethod(target, "setCurrentWindowContext", egl::SetCurrentWindowContext);
 
   return scope.Escape(target);

--- a/deps/exokit-bindings/glfw/src/glfw.cc
+++ b/deps/exokit-bindings/glfw/src/glfw.cc
@@ -946,6 +946,14 @@ NAN_METHOD(HasCurrentWindowContext) {
   info.GetReturnValue().Set(JS_BOOL(currentWindow != nullptr));
 }
 
+NAN_METHOD(GetCurrentWindowContext) {
+  if (currentWindow != nullptr) {
+    info.GetReturnValue().Set(pointerToArray(currentWindow));
+  } else {
+    info.GetReturnValue().Set(Nan::Null());
+  }
+}
+
 NAN_METHOD(SetCurrentWindowContext) {
   NATIVEwindow *window = (NATIVEwindow *)arrayToPointer(Local<Array>::Cast(info[0]));
   SetCurrentWindowContext(window);
@@ -1763,6 +1771,7 @@ Local<Object> makeWindow() {
   Nan::SetMethod(target, "blitTopFrameBuffer", glfw::BlitTopFrameBuffer);
   Nan::SetMethod(target, "blitChildFrameBuffer", glfw::BlitChildFrameBuffer);
   Nan::SetMethod(target, "hasCurrentWindowContext", glfw::HasCurrentWindowContext);
+  Nan::SetMethod(target, "getCurrentWindowContext", glfw::GetCurrentWindowContext);
   Nan::SetMethod(target, "setCurrentWindowContext", glfw::SetCurrentWindowContext);
 #ifdef MAIN_THREAD_POLLING
   Nan::SetMethod(target, "pollEvents", glfw::PollEvents);

--- a/deps/exokit-bindings/glfw/src/glfw.cc
+++ b/deps/exokit-bindings/glfw/src/glfw.cc
@@ -942,6 +942,10 @@ void ReadPixels(WebGLRenderingContext *gl, unsigned int fbo, int x, int y, int w
   }
 }
 
+NAN_METHOD(HasCurrentWindowContext) {
+  info.GetReturnValue().Set(JS_BOOL(currentWindow != nullptr));
+}
+
 NAN_METHOD(SetCurrentWindowContext) {
   NATIVEwindow *window = (NATIVEwindow *)arrayToPointer(Local<Array>::Cast(info[0]));
   SetCurrentWindowContext(window);
@@ -1758,6 +1762,7 @@ Local<Object> makeWindow() {
   Nan::SetMethod(target, "setClipboard", glfw::SetClipboard);
   Nan::SetMethod(target, "blitTopFrameBuffer", glfw::BlitTopFrameBuffer);
   Nan::SetMethod(target, "blitChildFrameBuffer", glfw::BlitChildFrameBuffer);
+  Nan::SetMethod(target, "hasCurrentWindowContext", glfw::HasCurrentWindowContext);
   Nan::SetMethod(target, "setCurrentWindowContext", glfw::SetCurrentWindowContext);
 #ifdef MAIN_THREAD_POLLING
   Nan::SetMethod(target, "pollEvents", glfw::PollEvents);


### PR DESCRIPTION
Fixes https://github.com/exokitxr/exokit/issues/1328.

This fixes the case seen in the THREE.js examples, where there is a 2d parent iframe (not a reality tab, not handled by Exokit) is parent to a 3d-rendering iframe.

Previously the 2d contextless iframe would attempt to consume the 3D `GLsync` despite not having a context. This PR handles that case by forwarding the unhandlable sync object to the next iframe in the render chaing (or failing that, `index.js`), preventing the GL error.