### PR TITLE
Canvas2d context reuse

### DIFF
--- a/deps/exokit-bindings/canvascontext/include/canvas-context.h
+++ b/deps/exokit-bindings/canvascontext/include/canvas-context.h
@@ -167,6 +167,9 @@ public:
   static NAN_METHOD(Destroy);
   static NAN_METHOD(GetWindowHandle);
   static NAN_METHOD(SetWindowHandle);
+  static NAN_METHOD(MakeGrContext);
+  static NAN_METHOD(GetGrContext);
+  static NAN_METHOD(SetGrContext);
   static NAN_METHOD(SetTexture);
 
   static bool isImageType(Local<Value> arg);

--- a/deps/exokit-bindings/canvascontext/src/canvas-context.cc
+++ b/deps/exokit-bindings/canvascontext/src/canvas-context.cc
@@ -142,6 +142,9 @@ Local<Object> CanvasRenderingContext2D::Initialize(Isolate *isolate, Local<Value
   Nan::SetMethod(proto, "destroy", Destroy);
   Nan::SetMethod(proto, "getWindowHandle", GetWindowHandle);
   Nan::SetMethod(proto, "setWindowHandle", SetWindowHandle);
+  Nan::SetMethod(proto, "makeGrContext", MakeGrContext);
+  Nan::SetMethod(proto, "getGrContext", GetGrContext);
+  Nan::SetMethod(proto, "setGrContext", SetGrContext);
 
   Local<Function> ctorFn = Nan::GetFunction(ctor).ToLocalChecked();
   ctorFn->Set(JS_STR("ImageData"), imageDataCons);
@@ -1562,21 +1565,35 @@ NAN_METHOD(CanvasRenderingContext2D::GetWindowHandle) {
 
 NAN_METHOD(CanvasRenderingContext2D::SetWindowHandle) {
   CanvasRenderingContext2D *ctx = ObjectWrap::Unwrap<CanvasRenderingContext2D>(info.This());
-  if (info[0]->IsArray()) {
-    ctx->windowHandle = (NATIVEwindow *)arrayToPointer(Local<Array>::Cast(info[0]));
-    
-    windowsystem::SetCurrentWindowContext(ctx->windowHandle);
-    
-    // You've already created your OpenGL context and bound it.
-    // Leaving interface as null makes Skia extract pointers to OpenGL functions for the current
-    // context in a platform-specific way. Alternatively, you may create your own GrGLInterface and
-    // initialize it however you like to attach to an alternate OpenGL implementation or intercept
-    // Skia's OpenGL calls.
-    // const GrGLInterface *interface = nullptr;
-    ctx->grContext = GrContext::MakeGL(nullptr);
-  } else {
-    ctx->windowHandle = nullptr;
-  }
+  ctx->windowHandle = (NATIVEwindow *)arrayToPointer(Local<Array>::Cast(info[0]));
+  
+  // windowsystem::SetCurrentWindowContext(ctx->windowHandle);
+}
+
+NAN_METHOD(CanvasRenderingContext2D::MakeGrContext) {
+  CanvasRenderingContext2D *ctx = ObjectWrap::Unwrap<CanvasRenderingContext2D>(info.This());
+
+  // You've already created your OpenGL context and bound it.
+  // Leaving interface as null makes Skia extract pointers to OpenGL functions for the current
+  // context in a platform-specific way. Alternatively, you may create your own GrGLInterface and
+  // initialize it however you like to attach to an alternate OpenGL implementation or intercept
+  // Skia's OpenGL calls.
+  // const GrGLInterface *interface = nullptr;
+  ctx->grContext = GrContext::MakeGL(nullptr);
+  sk_sp<GrContext> *grContext = &ctx->grContext;
+  info.GetReturnValue().Set(pointerToArray(grContext));
+}
+
+NAN_METHOD(CanvasRenderingContext2D::GetGrContext) {
+  CanvasRenderingContext2D *ctx = ObjectWrap::Unwrap<CanvasRenderingContext2D>(info.This());
+  sk_sp<GrContext> *grContext = &ctx->grContext;
+  info.GetReturnValue().Set(pointerToArray(grContext));
+}
+
+NAN_METHOD(CanvasRenderingContext2D::SetGrContext) {
+  CanvasRenderingContext2D *ctx = ObjectWrap::Unwrap<CanvasRenderingContext2D>(info.This());
+  sk_sp<GrContext> *grContext = (sk_sp<GrContext> *)arrayToPointer(Local<Array>::Cast(info[0]));
+  ctx->grContext = *grContext;
 }
 
 NAN_METHOD(CanvasRenderingContext2D::SetTexture) {

--- a/deps/exokit-bindings/canvascontext/src/canvas-context.cc
+++ b/deps/exokit-bindings/canvascontext/src/canvas-context.cc
@@ -1720,4 +1720,6 @@ CanvasRenderingContext2D::CanvasRenderingContext2D() :
   clearPaint.setBlendMode(SkBlendMode::kSrc);
 }
 
-CanvasRenderingContext2D::~CanvasRenderingContext2D () {}
+CanvasRenderingContext2D::~CanvasRenderingContext2D () {
+  // XXX need to destroy the texture here
+}

--- a/deps/exokit-bindings/canvascontext/src/canvas-context.cc
+++ b/deps/exokit-bindings/canvascontext/src/canvas-context.cc
@@ -1581,12 +1581,15 @@ NAN_METHOD(CanvasRenderingContext2D::SetWindowHandle) {
 
 NAN_METHOD(CanvasRenderingContext2D::SetTexture) {
   CanvasRenderingContext2D *ctx = ObjectWrap::Unwrap<CanvasRenderingContext2D>(info.This());
-  if (info[0]->IsNumber() && info[1]->IsNumber() && info[2]->IsNumber()) {
-    GLuint tex = TO_UINT32(info[0]);
-    int width = TO_INT32(info[1]);
-    int height = TO_INT32(info[2]);
-    
-    ctx->tex = tex;
+  if (info[0]->IsNumber() && info[1]->IsNumber()) {
+    int width = TO_INT32(info[0]);
+    int height = TO_INT32(info[1]);
+
+    GLuint tex = ctx->tex;
+    if (tex == 0) {
+      glGenTextures(1, &tex);
+      ctx->tex = tex;
+    }
 
     glBindTexture(GL_TEXTURE_2D, tex);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);

--- a/deps/exokit-bindings/egl/src/egl.cc
+++ b/deps/exokit-bindings/egl/src/egl.cc
@@ -317,20 +317,6 @@ NAN_METHOD(InitWindow3D) {
   info.GetReturnValue().Set(result);
 }
 
-NAN_METHOD(InitWindow2D) {
-  NATIVEwindow *windowHandle = (NATIVEwindow *)arrayToPointer(Local<Array>::Cast(info[0]));
-  
-  SetCurrentWindowContext(windowHandle);
-
-  GLuint tex;
-  glGenTextures(1, &tex);
-
-  Local<Array> result = Nan::New<Array>(2);
-  result->Set(0, pointerToArray(windowHandle));
-  result->Set(1, JS_INT(tex));
-  info.GetReturnValue().Set(result);
-}
-
 NATIVEwindow *CreateWindowHandle(unsigned int width, unsigned int height, bool initialVisible) {
   return CreateNativeWindow(width, height, initialVisible);
 }
@@ -408,7 +394,6 @@ Local<Object> makeWindow() {
   windowsystembase::Decorate(target);
 
   Nan::SetMethod(target, "initWindow3D", egl::InitWindow3D);
-  Nan::SetMethod(target, "initWindow2D", egl::InitWindow2D);
 
   Nan::SetMethod(target, "createWindowHandle", egl::CreateWindowHandle);
   Nan::SetMethod(target, "destroyWindowHandle", egl::DestroyWindowHandle);

--- a/deps/exokit-bindings/glfw/src/glfw.cc
+++ b/deps/exokit-bindings/glfw/src/glfw.cc
@@ -1180,20 +1180,6 @@ NAN_METHOD(InitWindow3D) {
   info.GetReturnValue().Set(result);
 }
 
-NAN_METHOD(InitWindow2D) {
-  NATIVEwindow *windowHandle = (NATIVEwindow *)arrayToPointer(Local<Array>::Cast(info[0]));
-
-  SetCurrentWindowContext(windowHandle);
-
-  GLuint tex;
-  glGenTextures(1, &tex);
-
-  Local<Array> result = Nan::New<Array>(2);
-  result->Set(0, pointerToArray(windowHandle));
-  result->Set(1, JS_INT(tex));
-  info.GetReturnValue().Set(result);
-}
-
 NATIVEwindow *CreateWindowHandle(unsigned int width, unsigned int height, bool initialVisible) {
   NATIVEwindow *windowHandle;
 
@@ -1751,7 +1737,6 @@ Local<Object> makeWindow() {
   windowsystembase::Decorate(target);
 
   Nan::SetMethod(target, "initWindow3D", glfw::InitWindow3D);
-  Nan::SetMethod(target, "initWindow2D", glfw::InitWindow2D);
 
   Nan::SetMethod(target, "createWindowHandle", glfw::CreateWindowHandle);
   Nan::SetMethod(target, "destroyWindowHandle", glfw::DestroyWindowHandle);

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2526,7 +2526,12 @@ class HTMLCanvasElement extends HTMLElement {
   getContext(contextType, attrs = {}) {
     if (contextType === '2d') {
       if (this._context) {
-        this._context.destroy();
+        const windowHandle = this._context.getWindowHandle();
+        const window = this.ownerDocument.defaultView;
+        const canvas2dWindowHandle = window[symbols.canvas2dWindowHandle];
+        if (!_windowHandleEquals(windowHandle, canvas2dWindowHandle)) {
+          this._context.destroy();
+        }
         this._context = null;
       }
 

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -48,6 +48,7 @@ const _loadPromise = el => new Promise((accept, reject) => {
   el.on('load', load);
   el.on('error', error);
 });
+const _windowHandleEquals = (a, b) => a[0] === b[0] && a[1] === b[1];
 
 const EMPTY_ARRAY = [];
 

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -48,7 +48,13 @@ const _loadPromise = el => new Promise((accept, reject) => {
   el.on('load', load);
   el.on('error', error);
 });
-const _windowHandleEquals = (a, b) => a[0] === b[0] && a[1] === b[1];
+const _windowHandleEquals = (a, b) => {
+  if (a && b) {
+    return a[0] === b[0] && a[1] === b[1];
+  } else {
+    return !a && !b;
+  }
+};
 
 const EMPTY_ARRAY = [];
 

--- a/src/native-bindings.js
+++ b/src/native-bindings.js
@@ -416,21 +416,29 @@ const _onGl2DConstruct = (ctx, canvas, attrs) => {
 
   const window = canvas.ownerDocument.defaultView;
 
-  const windowHandle = (() => {
+  const windowSpec = (() => {
     if (!window[symbols.optionsSymbol].args.nogl) {
       let windowHandle = window[symbols.canvas2dWindowHandle];
+      let grContext = window[symbols.canvas2dGrContext];
       if (!windowHandle) {
         windowHandle = nativeWindow.createWindowHandle(16, 16, false);
         window[symbols.canvas2dWindowHandle] = windowHandle;
+
+        nativeWindow.setCurrentWindowContext(windowHandle);
+        grContext = ctx.makeGrContext();
+        window[symbols.canvas2dGrContext] = grContext;
       }
-      return windowHandle;
+      return [windowHandle, grContext];
     } else {
       return null;
     }
   })();
 
-  if (windowHandle) {
+  if (windowSpec) {
+    const [windowHandle, grContext] = windowSpec;
     ctx.setWindowHandle(windowHandle);
+    nativeWindow.setCurrentWindowContext(windowHandle);
+    ctx.setGrContext(grContext);
     ctx.setTexture(canvasWidth, canvasHeight);
 
     ctx.destroy = (destroy => function() {

--- a/src/native-bindings.js
+++ b/src/native-bindings.js
@@ -430,7 +430,6 @@ const _onGl2DConstruct = (ctx, canvas, attrs) => {
   })();
 
   if (windowHandle) {
-    console.log('set 2d window handle 1');
     ctx.setWindowHandle(windowHandle);
     ctx.setTexture(canvasWidth, canvasHeight);
 

--- a/src/native-bindings.js
+++ b/src/native-bindings.js
@@ -416,26 +416,24 @@ const _onGl2DConstruct = (ctx, canvas, attrs) => {
 
   const window = canvas.ownerDocument.defaultView;
 
-  const windowSpec = (() => {
+  const windowHandle = (() => {
     if (!window[symbols.optionsSymbol].args.nogl) {
-      try {
-        const windowHandle = nativeWindow.createWindowHandle(canvasWidth, canvasHeight, false);
-        return nativeWindow.initWindow2D(windowHandle);
-      } catch (err) {
-        console.warn(err.message);
-        return null;
+      let windowHandle = window[symbols.canvas2dWindowHandle];
+      if (!windowHandle) {
+        windowHandle = nativeWindow.createWindowHandle(16, 16, false);
+        window[symbols.canvas2dWindowHandle] = windowHandle;
       }
+      return windowHandle;
     } else {
       return null;
     }
   })();
 
-  if (windowSpec) {
-    const [windowHandle, tex] = windowSpec;
-
+  if (windowHandle) {
+    console.log('set 2d window handle 1');
     ctx.setWindowHandle(windowHandle);
-    ctx.setTexture(tex, canvasWidth, canvasHeight);
-    
+    ctx.setTexture(canvasWidth, canvasHeight);
+
     ctx.destroy = (destroy => function() {
       destroy.call(this);
       

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -9,6 +9,7 @@ module.exports.idSymbol = Symbol('idSymbol');
 module.exports.styleEpochSymbol = Symbol('styleEpochSymbol');
 module.exports.listenerSymbol = Symbol('listenerSymbol');
 module.exports.canvas2dWindowHandle = Symbol('canvas2dWindowHandle');
+module.exports.canvas2dGrContext = Symbol('canvas2dGrContext');
 module.exports.mrDisplaysSymbol = Symbol('mrDisplaysSymbol');
 module.exports.optionsSymbol = Symbol('optionsSymbol');
 module.exports.pointerLockElementSymbol = Symbol('pointerLockElementSymbol');

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -8,6 +8,7 @@ module.exports.htmlTagsSymbol = Symbol('htmlTagsSymbol');
 module.exports.idSymbol = Symbol('idSymbol');
 module.exports.styleEpochSymbol = Symbol('styleEpochSymbol');
 module.exports.listenerSymbol = Symbol('listenerSymbol');
+module.exports.canvas2dWindowHandle = Symbol('canvas2dWindowHandle');
 module.exports.mrDisplaysSymbol = Symbol('mrDisplaysSymbol');
 module.exports.optionsSymbol = Symbol('optionsSymbol');
 module.exports.pointerLockElementSymbol = Symbol('pointerLockElementSymbol');


### PR DESCRIPTION
Fixes https://github.com/exokitxr/exokit/issues/1334.

With this PR, windows now only create a single canvas2d Skia backing context for the lifetime of the window, and this context is not destroyed when any logical `CanvasRenderingContext2D` is destroyed.