### PR TITLE
Bump window-xhr version

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "window-fetch": "0.0.13",
     "window-ls": "0.0.1",
     "window-selector": "0.0.8",
-    "window-xhr": "0.0.41",
+    "window-xhr": "0.0.42",
     "ws": "^6.2.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Ingests https://github.com/modulesio/window-xhr/pull/12.

This fixes clients that defer reading `XMLHttpRequest` `.response` to a timeout or a promise -- previously they would get `null`.