### PR TITLE
Bugfix module resolution URL

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1859,7 +1859,7 @@ class HTMLScriptElement extends HTMLLoadableElement {
               url = _mapUrl(_normalizeUrl(url, baseUrl), this.ownerDocument.defaultView);
               const s = await _fetch(url);
               return new vm.SourceTextModule(s, {
-                url: baseUrl,
+                url,
               });
             });
             script.instantiate();


### PR DESCRIPTION
`vm.SourceTextModule` expects the parent module's url in the options argument -- we were passing in the base URL.

This was breaking some THREE.js examples.