### PR TITLE
Bugfix XRView viewMatrix binding

### DIFF
--- a/src/XR.js
+++ b/src/XR.js
@@ -447,12 +447,13 @@ class XRView {
     this.eye = eye;
     this.transform = new XRRigidTransform(eye);
     this.projectionMatrix = eye === 'left' ? GlobalContext.xrState.leftProjectionMatrix : GlobalContext.xrState.rightProjectionMatrix;
-    this.viewMatrix = this.transform.inverse.matrix; // non-standard
 
     this._viewport = new XRViewport(eye);
     this._realViewMatrix = this.transform.inverse.matrix;
     this._localViewMatrix = Float32Array.from([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
     this.transform.inverse.matrix = this._localViewMatrix;
+
+    this.viewMatrix = this.transform.inverse.matrix; // non-standard
   }
 }
 module.exports.XRView = XRView;


### PR DESCRIPTION
The WebXR samples were not using the properly offset view matrices.

This means in the reality tabs case, the placement of the reality tab would not factor in to the view in the XR sub-world space.

This PR fixes that bug by correctly binding the view matrix inverse to the managed transformed version. Side note: saves a full `Float32 * 16` bytes!