### PR TITLE
Allow reality tabs presenting gl context destruction

### DIFF
--- a/src/native-bindings.js
+++ b/src/native-bindings.js
@@ -349,21 +349,15 @@ const _onGl3DConstruct = (gl, canvas, attrs) => {
     gl.destroy = (destroy => function() {
       destroy.call(this);
 
-      if (gl === GlobalContext.vrPresentState.glContext) {
-        throw new Error('destroyed vr presenting context');
-        /* bindings.nativeOpenVR.VR_Shutdown();
-
-        GlobalContext.vrPresentState.glContextId = 0;
-        GlobalContext.vrPresentState.system = null;
-        GlobalContext.vrPresentState.compositor = null; */
-      }
-
       nativeWindow.destroyWindowHandle(windowHandle);
       canvas._context = null;
-
-      canvas.ownerDocument.removeListener('domchange', ondomchange);
-
+      
       GlobalContext.contexts.splice(GlobalContext.contexts.indexOf(gl), 1);
+      
+      if (gl === GlobalContext.vrPresentState.glContext) {
+        GlobalContext.vrPresentState.glContext = null;
+      }
+      canvas.ownerDocument.removeListener('domchange', ondomchange);
 
       if (gl.id === 1) {
         process.kill(process.pid); // XXX make this a softer process.exit()


### PR DESCRIPTION
This PR unlock the (valid) case where a reality tab's context that is presenting is destroyed -- in that case we want to clear out the context and perform the usual cleanup steps.

This was previously locked down to avoid crashing due to thread retention (https://github.com/exokitxr/exokit/issues/1346).