### PR TITLE
Pass through args in repl startup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1510,6 +1510,7 @@ const _start = () => {
     };
     let window = core.make('', {
       dataPath,
+      args,
       onnavigate: _onnavigate,
       onrequest: handleRequest,
       onhapticpulse: handleHapticPulse,


### PR DESCRIPTION
The bug here was that Exokit's repl mode (`node .`) would not take in the default arguments specification on startup, which resulted in strange effects like WebXR not being available.