### PR TITLE
Remove dead platform/windows glob from binding.gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -18,7 +18,6 @@
                 'deps/exokit-bindings/nanosvg/src/*.cpp',
                 'deps/exokit-bindings/canvascontext/src/*.cc',
                 'deps/exokit-bindings/webglcontext/src/*.cc',
-                'deps/exokit-bindings/platform/windows/src/*.cpp',
                 'deps/exokit-bindings/webaudiocontext/src/*.cpp',
                 'deps/exokit-bindings/videocontext/src/*.cpp',
                 'deps/exokit-bindings/videocontext/src/win/*.cpp',


### PR DESCRIPTION
This path does not exist and was being ignored, causing build log spam on Windows.