### PR TITLE
Do not throw on WebSocket.close() for unopened web socket

### DIFF
--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -178,6 +178,14 @@ class Worker extends EventTarget {
 
         super(url, protocols, options);
       }
+
+      close() { // ws.close throws if not open
+        try {
+          return super.close();
+        } catch(err) {
+          console.warn(err.stack);
+        }
+      }
     }
     for (const k in Old) {
       WebSocket[k] = Old[k];


### PR DESCRIPTION
Fixes https://github.com/exokitxr/exokit/issues/1386.