### PR TITLE
Remove core.js require from Window.js

### DIFF
--- a/src/Window.js
+++ b/src/Window.js
@@ -26,8 +26,6 @@ const {XRRigidTransform} = require('./XR.js');
 const mkdirp = require('mkdirp');
 const ws = require('ws');
 
-const core = require('./core.js');
-
 const {
   /* getUserMedia,
   MediaStream,


### PR DESCRIPTION
This significant require (`core.js`) was being required in all reality tab pages, despite being not used.