### PR TITLE
Bugfix Worker.js baseUrl dereference

### DIFF
--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -86,7 +86,7 @@ class Worker extends EventTarget {
         src,
         options: {
           url: src,
-          baseUrl: utils._getBaseUrl(src, GlobalContext.baseUrl),
+          baseUrl: utils._getBaseUrl(src, args.options.baseUrl),
         },
         args: args.options.args,
         xrState: args.xrState,
@@ -242,7 +242,7 @@ class Worker extends EventTarget {
   });
 })(global);
 
-const _normalizeUrl = src => utils._normalizeUrl(src, GlobalContext.baseUrl);
+const _normalizeUrl = src => utils._normalizeUrl(src, args.options.baseUrl);
 
 const SYNC_REQUEST_BUFFER_SIZE = 5 * 1024 * 1024; // TODO: we can make this unlimited with a streaming buffer + atomics loop
 function getScript(url) {

--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -281,7 +281,7 @@ function getScript(url) {
 function importScripts() {
   for (let i = 0; i < arguments.length; i++) {
     const importScriptPath = arguments[i];
-    const importScriptSource = getScript(importScriptPath);
+    const importScriptSource = getScript(importScriptPath, args.options.baseUrl);
     vm.runInThisContext(importScriptSource, global, {
       filename: /^https?:/.test(importScriptPath) ? importScriptPath : 'data-url://',
     });

--- a/src/Worker.js
+++ b/src/Worker.js
@@ -12,7 +12,7 @@ const WebSocket = require('ws/lib/websocket');
 const {FileReader} = require('./File.js');
 const GlobalContext = require('./GlobalContext');
 
-const {src, baseUrl} = args;
+const {src, options: {baseUrl}} = args;
 GlobalContext.baseUrl = baseUrl;
 
 const _normalizeUrl = src => {


### PR DESCRIPTION
This PR fixes baseUrl-relative fetches in worker contexts.

This parameter was passed under `options` here: https://github.com/exokitxr/exokit/blob/2c52eebe7842e48e3b07f86d3c83ad646ba4d7bd/src/WindowBase.js#L89