### PR TITLE
Bugfix protocol-less URL detection

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -32,7 +32,7 @@ function _normalizeUrl(src, baseUrl) {
   if (/^\/\//.test(src)) {
     src = new URL(baseUrl).protocol + src;
   }
-  if (!/^[a-z]+:/.test(src)) {
+  if (!/^(?:\/|[a-z]+:)/.test(src)) {
     src = baseUrl + (!/\/$/.test(baseUrl) ? '/' : '') + src;
   }
   if (!/^(?:https?|data|blob):/.test(src)) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -32,9 +32,9 @@ function _normalizeUrl(src, baseUrl) {
   if (/^\/\//.test(src)) {
     src = new URL(baseUrl).protocol + src;
   }
-  if (!/^(?:\/|[a-z]+:)/.test(src)) {
+  /* if (!/^(?:\/|[a-z]+:)/.test(src)) {
     src = baseUrl + (!/\/$/.test(baseUrl) ? '/' : '') + src;
-  }
+  } */
   if (!/^(?:https?|data|blob):/.test(src)) {
     return new URL(src, baseUrl).href
       .replace(/^(file:\/\/)\/([a-z]:.*)$/i, '$1$2');


### PR DESCRIPTION
Follow-up to https://github.com/exokitxr/exokit/pull/1393; fixes CryptoVoxels loading, among others.

The bug was that absolute paths were being auto-prefixed with `baseUrl`, which is not correct. We regex test for this case.