### PR TITLE
Make xrState devicePixelRatio a Float32Array

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -208,7 +208,7 @@ const xrState = (() => {
   result.renderHeight = _makeTypedArray(Float32Array, 1);
   result.renderHeight[0] = 1080;
   result.metrics = _makeTypedArray(Uint32Array, 2);
-  result.devicePixelRatio = _makeTypedArray(Uint32Array, 1);
+  result.devicePixelRatio = _makeTypedArray(Float32Array, 1);
   result.depthNear = _makeTypedArray(Float32Array, 1);
   result.depthNear[0] = 0.1;
   result.depthFar = _makeTypedArray(Float32Array, 1);


### PR DESCRIPTION
It was previously a `Uint32Array`, but `devicePixelRatio` is a float value.