### PR TITLE
Bugfix GL_EXT_frag_depth elision

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "redirect-output": "^1.0.0",
     "rimraf": "^2.6.2",
     "unescape": "^1.0.1",
-    "webgl-to-opengl": "0.0.16",
+    "webgl-to-opengl": "0.0.17",
     "window-fetch": "0.0.13",
     "window-ls": "0.0.1",
     "window-selector": "0.0.8",


### PR DESCRIPTION
Fixes https://github.com/exokitxr/exokit/issues/1405.
Ingests https://github.com/modulesio/webgl-to-opengl/pull/7.

The bug was that eliding the extension causes the shader compile to fail.