### PR TITLE
Bugfix realitytab redirects

### DIFF
--- a/examples/realitytabs.html
+++ b/examples/realitytabs.html
@@ -592,11 +592,11 @@ const _openUrl = (u, position = new THREE.Vector3(), orientation = new THREE.Qua
     }
   }
 
-  const _drawOk = () => {
-    console.log('reality tab load ok: ' + u);
+  const _drawOk = (src) => {
+    console.log('reality tab load ok: ' + src);
   };
-  const _drawFail = () => {
-    console.log('reality tab load error: ' + u);
+  const _drawFail = (src) => {
+    console.log('reality tab load error: ' + src);
   };
 
   const iframe = document.createElement('iframe');
@@ -617,11 +617,11 @@ const _openUrl = (u, position = new THREE.Vector3(), orientation = new THREE.Qua
       }
     })();
     if (contentDocument) {
-      _drawOk();
+      _drawOk(iframe.src);
 
       // scene.background = null;
     } else {
-      _drawFail();
+      _drawFail(iframe.src || u);
 
       _closeTab(tab);
 

--- a/examples/realitytabs.html
+++ b/examples/realitytabs.html
@@ -592,11 +592,11 @@ const _openUrl = (u, position = new THREE.Vector3(), orientation = new THREE.Qua
     }
   }
 
-  const _drawOk = (src) => {
-    console.log('reality tab load ok: ' + src);
+  const _drawOk = () => {
+    console.log('reality tab load ok: ' + u);
   };
-  const _drawFail = (src) => {
-    console.log('reality tab load error: ' + src);
+  const _drawFail = () => {
+    console.log('reality tab load error: ' + u);
   };
 
   const iframe = document.createElement('iframe');
@@ -617,11 +617,11 @@ const _openUrl = (u, position = new THREE.Vector3(), orientation = new THREE.Qua
       }
     })();
     if (contentDocument) {
-      _drawOk(iframe.src);
+      _drawOk();
 
       // scene.background = null;
     } else {
-      _drawFail(iframe.src || u);
+      _drawFail();
 
       _closeTab(tab);
 

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -309,7 +309,7 @@ Node.DOCUMENT_TYPE_NODE = 10;
 Node.DOCUMENT_FRAGMENT_NODE = 11;
 module.exports.Node = Node;
 
-const _setAttributeRaw = (el, prop, value) => {
+const _setAttributeRaw = (el, prop, value, notify = true) => {
   if (prop === 'length') {
     el.attrs.length = value;
   } else {
@@ -320,11 +320,11 @@ const _setAttributeRaw = (el, prop, value) => {
         value,
       };
       el.attrs.push(attr);
-      el._emit('attribute', prop, value, null);
+      notify && el._emit('attribute', prop, value, null);
     } else {
       const oldValue = attr.value;
       attr.value = value;
-      el._emit('attribute', prop, value, oldValue);
+      notify && el._emit('attribute', prop, value, oldValue);
     }
   }
 };
@@ -2199,7 +2199,9 @@ class HTMLIFrameElement extends HTMLSrcableElement {
                 const parentWindow = this.ownerDocument.defaultView;
                 const options = parentWindow[symbols.optionsSymbol];
 
-                url = _normalizeUrl(url, options.baseUrl);
+                url = _normalizeUrl(res.url, options.baseUrl);
+                // passively update .src with the final url (which can differ in case of redirects)
+                _setAttributeRaw(this, 'src', url, false);
                 const parent = {};
                 const top = parentWindow === parentWindow.top ? parent : {};
                 this.contentWindow = _makeWindow({

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -309,7 +309,7 @@ Node.DOCUMENT_TYPE_NODE = 10;
 Node.DOCUMENT_FRAGMENT_NODE = 11;
 module.exports.Node = Node;
 
-const _setAttributeRaw = (el, prop, value, notify = true) => {
+const _setAttributeRaw = (el, prop, value) => {
   if (prop === 'length') {
     el.attrs.length = value;
   } else {
@@ -320,11 +320,11 @@ const _setAttributeRaw = (el, prop, value, notify = true) => {
         value,
       };
       el.attrs.push(attr);
-      notify && el._emit('attribute', prop, value, null);
+      el._emit('attribute', prop, value, null);
     } else {
       const oldValue = attr.value;
       attr.value = value;
-      notify && el._emit('attribute', prop, value, oldValue);
+      el._emit('attribute', prop, value, oldValue);
     }
   }
 };
@@ -2200,8 +2200,6 @@ class HTMLIFrameElement extends HTMLSrcableElement {
                 const options = parentWindow[symbols.optionsSymbol];
 
                 url = _normalizeUrl(res.url, options.baseUrl);
-                // passively update .src with the final url (which can differ in case of redirects)
-                _setAttributeRaw(this, 'src', url, false);
                 const parent = {};
                 const top = parentWindow === parentWindow.top ? parent : {};
                 this.contentWindow = _makeWindow({


### PR DESCRIPTION
proposed fix for #1168 that enables redirected reality tab URLs to load correctly.

```sh
$ node . -t https://aframe.io/a-painter
THREE.WebGLRenderer 105
no xr devices
loaded root in 2D
reality tab load ok: https://aframe.io/a-painter/
A-Frame Version: 0.7.0 (Date 2018-02-05, Commit #39daf67)
...
```
